### PR TITLE
Optimize sub and index expr

### DIFF
--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -849,7 +849,7 @@ public:
 
     auto toString() const -> std::string override
     {
-        return "(and "s + left_->toString() + " "s + right_->toString() + ")"s;
+        return "(or "s + left_->toString() + " "s + right_->toString() + ")"s;
     }
 
     ExprPtr left_, right_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ if (NOT TARGET Catch2)
     GIT_TAG        "v3.1.0"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(Catch2)
+  list(APPEND CMAKE_MODULE_PATH "${CATCH2_SOURCE_DIR}/contrib")
 endif()
 
 add_executable(test.simfil
@@ -19,4 +20,6 @@ target_link_libraries(test.simfil
     simfil
     Catch2::Catch2WithMain)
 
-add_test(NAME test.simfil COMMAND test.simfil)
+include(Catch)
+include(CTest)
+catch_discover_tests(test.simfil)


### PR DESCRIPTION
- Fix operator `or` string representation
- Use Catch2 CMake integration
- Allow optimization of sub- and subscript-expressions