### PR TITLE
Allow values in paths / Rework null handling

### DIFF
--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -510,6 +510,8 @@ public:
         return left_->eval(ctx, val, [this, &res](auto ctx, auto v) {
             if (v.isa(ValueType::Undef))
                 return res(ctx, std::move(v));
+            if (v.isa(ValueType::Null) && !v.node)
+                return res(ctx, std::move(v));
 
             return right_->eval(ctx, v, [this, &res](auto ctx, auto vv) {
                 return res(ctx, std::move(vv));

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -47,7 +47,6 @@ enum Precedence {
     PATH        = 12, // a.b
     SUBEXPR     = 11, // a{b}
     SUBSCRIPT   = 10, // a[b]
-    //METHOD      = 10, // a:b()
     POST_UNARY  = 9,  // a?, a exists, a...
     UNARY       = 8,  // not, -, ~
     CAST        = 7,  // a as b
@@ -1221,40 +1220,6 @@ class WordParser : public PrefixParselet
     }
 };
 
-#if 0 /* Disabled */
-class MethodCallParser : public InfixParselet
-{
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
-    {
-        if (!p.match(Token::WORD))
-            throw std::runtime_error("Operator ':' expected function identifier; got "s + p.current().toString());
-
-        auto word = std::get<std::string>(p.current().value);
-        p.consume();
-
-        auto arguments = std::vector<ExprPtr>();
-        arguments.push_back(std::move(left));
-
-        /* For method calls with 1 argument, parentheses are optional! */
-        if (p.match(Token::LPAREN)) {
-            p.consume();
-
-            auto addArgs = p.parseList(Token::RPAREN);
-            arguments.insert(arguments.end(),
-                             std::make_move_iterator(addArgs.begin()),
-                             std::make_move_iterator(addArgs.end()));
-        }
-
-        return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
-    }
-
-    auto precedence() const -> int override
-    {
-        return Precedence::METHOD;
-    }
-};
-#endif
-
 /**
  * Parser for parsing '.' separated paths.
  *
@@ -1336,7 +1301,6 @@ auto compile(Environment& env, std::string_view sv, bool any) -> ExprPtr
     /* Ident/Function */
     p.prefixParsers[Token::WORD] = std::make_unique<WordParser>();
     p.prefixParsers[Token::SELF] = std::make_unique<WordParser>();
-    // p.infixParsers[Token::COLON] = std::make_unique<MethodCallParser>();
 
     /* Wildcards */
     p.prefixParsers[Token::WILDCARD] = std::make_unique<WordParser>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,9 @@ if (NOT TARGET Catch2)
 endif()
 
 add_executable(test.simfil
-  simfil.cpp
   token.cpp
+  simfil.cpp
+  complex.cpp
   ext-geo.cpp)
 
 target_link_libraries(test.simfil

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "simfil/simfil.h"
+#include "simfil/model/json.h"
+
+using namespace simfil;
+
+static const auto invoice = json::parse(R"json(
+{
+"account": {
+  "name": "Demo",
+  "order": [
+    {
+      "id": "order1",
+      "product": [
+        {
+          "name": "Thing",
+          "id": "abc",
+          "price": 34.45,
+          "quantity": 2
+        },
+        {
+          "name": "Another Thing",
+          "id": "xyz",
+          "price": 21.67,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "order12",
+      "product": [
+        {
+          "name": "Thing",
+          "id": "abc",
+          "price": 34.45,
+          "quantity": 4
+        },
+        {
+          "name": "Something Expensive",
+          "id": "xyz",
+          "price": 107.99,
+          "quantity": 1
+        }
+      ]
+    }
+  ]
+}
+}
+)json");
+
+static auto joined_result(const ModelNode* model, std::string_view query)
+{
+    Environment env;
+    auto ast = compile(env, query, false);
+    INFO("AST: " << ast->toString());
+
+    auto res = eval(env, *ast, model);
+
+    std::string vals;
+    for (const auto& vv : res) {
+        if (!vals.empty())
+            vals.push_back('|');
+        vals += vv.toString();
+    }
+    return vals;
+}
+
+#define REQUIRE_RESULT(model, query, result) \
+    REQUIRE(joined_result(model.get(), query) == result)
+
+TEST_CASE("Invoice", "[yaml.complex.invoice-sum]") {
+    REQUIRE_RESULT(invoice, "account.order.*.product.*.(price * quantity)",
+                            "68.900000|21.670000|137.800000|107.990000");
+    REQUIRE_RESULT(invoice, "sum(account.order.*.product.*.(price * quantity))",
+                            "336.360000");
+    REQUIRE_RESULT(invoice, "sum(**.(price * quantity))",
+                            "336.360000");
+}

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -75,6 +75,8 @@ TEST_CASE("Invoice", "[yaml.complex.invoice-sum]") {
                             "68.900000|21.670000|137.800000|107.990000");
     REQUIRE_RESULT(invoice, "sum(account.order.*.product.*.(price * quantity))",
                             "336.360000");
+    REQUIRE_RESULT(invoice, "**.(price * quantity)",
+                            "68.900000|21.670000|137.800000|107.990000");
     REQUIRE_RESULT(invoice, "sum(**.(price * quantity))",
                             "336.360000");
 }

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -41,12 +41,22 @@ TEST_CASE("OperatorConst", "[ast.operator]") {
     REQUIRE_AST("a+2", "(+ a 2)");
     REQUIRE_AST("2+a", "(+ 2 a)");
     REQUIRE_AST("a+b", "(+ a b)");
+    REQUIRE_AST("1+null", "null");
+    REQUIRE_AST("null+1", "null");
+    REQUIRE_AST("1*null", "null");
+    REQUIRE_AST("null*1", "null");
+    REQUIRE_AST("1-null", "null");
+    REQUIRE_AST("null-1", "null");
+    REQUIRE_AST("1/null", "null");
+    REQUIRE_AST("null/1", "null");
 
     /* Division by zero */
     CHECK_THROWS(getASTString("1/0"));
-    CHECK_THROWS(getASTString("1/null"));
     CHECK_THROWS(getASTString("1%0"));
-    CHECK_THROWS(getASTString("1%null"));
+
+    /* String */
+    REQUIRE_AST("'a'+null", "null");
+    REQUIRE_AST("null+'a'", "null");
 
     /* Comparison */
     REQUIRE_AST("1==1", "true");
@@ -226,8 +236,10 @@ TEST_CASE("Path Wildcard", "[yaml.path-wildcard]") {
     REQUIRE_RESULT("sub.**", "null|sub a|sub b|null|sub sub a|sub sub b");
     /*                        ^- sub           ^- sub.sub */
 
-    REQUIRE_RESULT("sub.* + sub.*", "sub asub a|sub asub b|sub a|sub bsub a|sub bsub b|sub b|sub a|sub b|0");
-    /*                                                                         null + '...' -^-----^     ^- null + null */
+    REQUIRE_RESULT("sub.* + sub.*", "sub asub a|sub asub b|null|sub bsub a|sub bsub b|null|null|null|null");
+    /*                                                     ^---------- null + '...' --^----^----^    ^- null + null */
+    REQUIRE_RESULT("(sub.* + sub.*)._", "sub asub a|sub asub b|sub bsub a|sub bsub b"); /* . filters null */
+    REQUIRE_RESULT("sub.*.{_} + sub.*.{_}", "sub asub a|sub asub b|sub bsub a|sub bsub b"); /* {_} filters null */
     REQUIRE_RESULT("count(*)", "2");
     REQUIRE_RESULT("count(**)", "27");
     REQUIRE_RESULT("count(** exists)", "47"); /* root + 46 */

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -331,44 +331,25 @@ TEST_CASE("Value Expansion", "[yaml.value-expansion]") {
     }
 
     SECTION("Compare value to lists") {
-        /*
-        BENCHMARK("10") {
-            REQUIRE_RESULT("each(range(1,10)... == 1)", "false");
-        };
-        BENCHMARK("100") {
-            REQUIRE_RESULT("each(range(1,100)... == 1)", "false");
-        };
-        BENCHMARK("1000") {
-            REQUIRE_RESULT("each(range(1,1000)... == 1)", "false");
-        };
-        BENCHMARK("10000") {
-            REQUIRE_RESULT("each(range(1,10000)... == 1)", "false");
-        };
-        */
-    }
-    SECTION("Compare two lists") {
-        /*
-        BENCHMARK("2 x 3") {
-            REQUIRE_RESULT("each(range(1,3)... == range(1,3)...)", "false");
-        };
-        BENCHMARK("2 x 10") {
-            REQUIRE_RESULT("each(range(1,10)... == range(1,10)...)", "false");
-        };
-        BENCHMARK("2 x 25") {
-            REQUIRE_RESULT("each(range(1,25)... == range(1,25)...)", "false");
-        };
-        */
+        REQUIRE_RESULT("each(range(1,10)... == 1)", "false");
+        REQUIRE_RESULT("each(range(1,100)... == 1)", "false");
+        REQUIRE_RESULT("each(range(1,1000)... == 1)", "false");
+        REQUIRE_RESULT("each(range(1,10000)... == 1)", "false");
     }
 }
 
 TEST_CASE("GeoJSON", "[geojson.geo]") {
     SECTION("Construct Geometry") {
+        REQUIRE_RESULT("typeof geo()",                       "null");
         REQUIRE_RESULT("typeof geo(_)",                      "null");
         REQUIRE_RESULT("typeof geo(geoPoint)",               "point");
         REQUIRE_RESULT("typeof geo(geoPoint.geometry)",      "point");
+        REQUIRE_RESULT("typeof geoPoint.geo()",              "point");
         REQUIRE_RESULT("typeof geo(geoLineString)",          "linestring");
         REQUIRE_RESULT("typeof geo(geoLineString.geometry)", "linestring");
+        REQUIRE_RESULT("typeof geoLineString.geo()",         "linestring");
         REQUIRE_RESULT("typeof geo(geoPolygon)",             "polygon");
         REQUIRE_RESULT("typeof geo(geoPolygon.geometry)",    "polygon");
+        REQUIRE_RESULT("typeof geoPolygon.geo()",            "polygon");
     }
 }


### PR DESCRIPTION
Allow values in paths.
As long as the left side of a path evaluates to non-null or is a node, evaluate the right side.
`(1).(2) => 2`
`null.(1) => null`
`a.(1) => 1 if a exists, null otherwise`
This allows returning results of multiple sub-nodes like in JSONata:
`**.(Price * Quantity) => ...` (here, `(...)` is a value)

See `test/complex.cpp` for examples.
Try out the changes to decide if the new behavior makes sense.

## Changes
- The `.` operator filters out `null` values which do not belong to a node
- All arithmetic operators return `null` as soon as one of their arguments is `null`.
- Remove method call code (`:...`)
- Make geo(...) use `_` by default.