### PR TITLE
Prevent string views from being remembered in trace result

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -190,7 +190,7 @@ auto VertexNode::get(int64_t idx) const -> const ModelNode*
 
 auto VertexNode::children() const -> std::vector<const ModelNode*> { return {{&lon, &lat}}; }
 
-auto VertexNode::keys() const -> std::vector<std::string_view> { return {{"lon"s, "lat"s}}; }
+auto VertexNode::keys() const -> std::vector<std::string_view> { return {{"lon", "lat"}}; }
 
 auto VertexNode::size() const -> int64_t { return 2; }
 


### PR DESCRIPTION
Without this change, a query like `trace(keys(**))` will store string views in the result environment, but the environment might outlive the model.