### PR TITLE
Case-Insensitive syntax

### DIFF
--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -52,7 +52,7 @@ public:
     /**
      * Query function by name.
      */
-    auto findFunction(const std::string&) const -> const Function*;
+    auto findFunction(std::string) const -> const Function*;
 
 public:
     std::unique_ptr<std::mutex> warnMtx;
@@ -61,6 +61,7 @@ public:
     std::unique_ptr<std::mutex> traceMtx;
     std::map<std::string, Trace> traces;
 
+    /* lower-case function ident -> function */
     std::map<std::string, const Function*> functions;
 
     Debug* debug = nullptr;

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -5,6 +5,11 @@ structured data built for use with GeoJSON.
 
 ## Language Basics
 
+### Syntax
+
+The syntax of simfil is case-insensitive. This means that `any(...)`, `ANY(...)` and `Any(...)` all compile
+to the same function.
+
 ### Paths
 
 To traverse the document and evaluate nested nodes, simfil provides the

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -154,7 +154,7 @@ The following types can be target types for a cast:
 | `a ^ b`             | Bitwise XOR.                                                                                            |
 | `a < b` / `a <= b`  | Less than / less than or equal to.                                                                      |
 | `a > b` / `a >= b`  | Greater than / greater than or equal to.                                                                |
-| `a == b` / `a != b` | Equal to / not equal to.                                                                                |
+| `a == b` / `a != b` | Equal to / not equal to. `a = b` is an alias for `a == b`.                                              |
 | `a =~ b` / `a !~ b` | `a` matches regular expression `b` / `a` does not match regular expression `b`. Returns `a` or `false`  |
 | `a or b`            | Logical or, returning the first non-false argument (like JavaScript).                                   |
 | `a and b`           | Logical and, returning the first false argument (like JavaScript).                                      |
@@ -173,7 +173,7 @@ The following types can be target types for a cast:
 | `+`, `-`                               | 5          |
 | `<<`, `>>`, `&`, `\|`, `^`             | 4          |
 | `<`, `<=`, `>`, `>=`                   | 3          |
-| `==`, `!=`, `=~`, `!~`                 | 2          |
+| `==`/`=`, `!=`, `=~`, `!~`             | 2          |
 | `and`, `or`                            | 1          |
 
 ## Functions

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -44,7 +44,7 @@ auto Environment::trace(const std::string& name, std::function<void(Trace&)> fn)
     fn(traces[name]);
 }
 
-auto Environment::findFunction(const std::string& name) const -> const Function*
+auto Environment::findFunction(std::string name) const -> const Function*
 {
     if (auto iter = functions.find(name); iter != functions.end())
         return iter->second;

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -1234,6 +1234,11 @@ class WordParser : public PrefixParselet
         if (p.match(Token::LPAREN)) {
             p.consume();
 
+            /* Downcase function name */
+            std::transform(word.begin(), word.end(), word.begin(), [](auto c) {
+                return tolower(c);
+            });
+
             auto arguments = p.parseList(Token::RPAREN);
             return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
         }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -13,6 +13,20 @@
 #include <optional>
 #include <cstring>
 #include <unordered_map>
+#include <algorithm>
+
+namespace
+{
+
+std::string downcase(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), [](auto c) {
+        return tolower(c);
+    });
+    return s;
+}
+
+}
 
 namespace simfil
 {
@@ -170,16 +184,17 @@ void skipWhitespace(Scanner& s)
 std::optional<Token> scanWord(Scanner& s)
 {
     static const std::unordered_map<std::string, Token::Type> keyword_tab = {
-        {"_",     Token::SELF},
-        {"and",   Token::OP_AND},
-        {"or",    Token::OP_OR},
-        {"not",   Token::OP_NOT},
-        {"exists",Token::OP_EXISTS},
-        {"typeof",Token::OP_TYPEOF},
-        {"true",  Token::C_TRUE},
-        {"false", Token::C_FALSE},
-        {"null",  Token::C_NULL},
-        {"as",    Token::OP_CAST},
+        /* lowercase-op-name | token-type */
+        {"_",                  Token::SELF},
+        {"and",                Token::OP_AND},
+        {"or",                 Token::OP_OR},
+        {"not",                Token::OP_NOT},
+        {"exists",             Token::OP_EXISTS},
+        {"typeof",             Token::OP_TYPEOF},
+        {"true",               Token::C_TRUE},
+        {"false",              Token::C_FALSE},
+        {"null",               Token::C_NULL},
+        {"as",                 Token::OP_CAST},
     };
 
     const auto isWordStart = [](auto c) {
@@ -198,7 +213,7 @@ std::optional<Token> scanWord(Scanner& s)
             text.push_back(s.pop());
         } while (s && (isalnum(s.at(0)) || s.at(0) == '_' || s.at(0) == '\\'));
 
-        if (auto iter = keyword_tab.find(text); iter != keyword_tab.end())
+        if (auto iter = keyword_tab.find(downcase(text)); iter != keyword_tab.end())
             return Token(iter->second, begin, s.pos());
 
         return Token(Token::WORD, text, begin, s.pos());

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -366,6 +366,7 @@ std::optional<Token> scanSyntax(Scanner& s)
         {">", Token::OP_GT},
         {"==",Token::OP_EQ},
         {"!=",Token::OP_NOT_EQ},
+        {"=", Token::OP_EQ}, /* Alias for == */
     };
 
     auto begin = s.pos();

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -170,6 +170,10 @@ TEST_CASE("UtilityFns", "[ast.functions]") {
 
     REQUIRE_AST("trace(a.b)",         "(trace (. a b))");
     REQUIRE_AST("trace('test', a.b)", "(trace \"test\" (. a b))");
+
+    /* Test case-insensitivity */
+    REQUIRE_AST("TRACE(1)",      "(trace 1)");
+    REQUIRE_AST("Trace(1)",      "(trace 1)");
 }
 
 static const char* doc = R"json(

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -108,6 +108,14 @@ TEST_CASE("Tokenize symbols", "[token.symbol]") {
     REQUIRE(getFirstType("typeof") == Token::Type::OP_TYPEOF);
 }
 
+TEST_CASE("Tokenize symbols", "[token.icase]") {
+    /* Test operator (and) for case insensitivity */
+    REQUIRE(getFirstType("and")     == Token::Type::OP_AND);
+    REQUIRE(getFirstType("AND")     == Token::Type::OP_AND);
+    REQUIRE(getFirstType("And")     == Token::Type::OP_AND);
+    REQUIRE(getFirstType("AnD")     == Token::Type::OP_AND);
+}
+
 TEST_CASE("Tokenize mixed", "[token.mixed]") {
     auto tokens = tokenize("1+.0 and true or 'test'");
     REQUIRE(tokens.size() == 7 + 1 /*EOF*/);

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -101,6 +101,7 @@ TEST_CASE("Tokenize symbols", "[token.symbol]") {
     REQUIRE(getFirstType("+")      == Token::Type::OP_ADD);
     REQUIRE(getFirstType("=~")     == Token::Type::OP_MATCH);
     REQUIRE(getFirstType("==")     == Token::Type::OP_EQ);
+    REQUIRE(getFirstType("=")      == Token::Type::OP_EQ);
     REQUIRE(getFirstType("<")      == Token::Type::OP_LT);
     REQUIRE(getFirstType("< <")    == Token::Type::OP_LT);
     REQUIRE(getFirstType("<<")     == Token::Type::OP_LSHIFT);


### PR DESCRIPTION
Implements #7.

* Adds operator `=` as an alias for `==`
* Case-Insensitive operators (`and`, `or`, …)
* Case-Insensitive functions