### PR TITLE
Add GCOVR Coverage Reports

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,15 +32,15 @@ jobs:
       working-directory: build/test
       run: |
         ctest --verbose
-    - name: Test Coverage
+    - name: Run Test Coverage
       working-directory: build
       run: |
-        cmake --build . --target coverage && tar cf coverage.tar coverage
+        cmake --build . --target coverage
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Test Coverage
-        path: build/test/coverage.tar
+        path: build/coverage
   build-windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,14 +16,14 @@ jobs:
         submodules: true
     - name: Install dependencies
       run: |
-        sudo apt-get install gcovr
+        sudo apt-get install gcovr ninja-build
     - name: Setup
       run: |
         mkdir build
     - name: Configure
       working-directory: build
       run: |
-        cmake ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=YES -GNinja ..
     - name: Build
       working-directory: build
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Setup
@@ -71,7 +71,7 @@ jobs:
     name: MacOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Setup

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,6 +14,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Install dependencies
+      run: |
+        sudo apt-get install gcovr
     - name: Setup
       run: |
         mkdir build
@@ -29,6 +32,15 @@ jobs:
       working-directory: build/test
       run: |
         ctest --verbose
+    - name: Test Coverage
+      working-directory: build
+      run: |
+        cmake --build . --target coverage && tar cf coverage.tar coverage
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Test Coverage
+        path: build/test/coverage.tar
   build-windows:
     name: Windows
     runs-on: windows-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake/cmake-modules"]
+	path = cmake/cmake-modules
+	url = https://github.com/bilke/cmake-modules.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 
 project(simfil)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   option(WITH_COVERAGE "Enable gcovr coverage" YES)
 else()
   set(WITH_COVERAGE NO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ else()
   set(WITH_COVERAGE NO)
 endif()
 
+find_program(GCOVR_BIN gcovr)
+if (WITH_COVERAGE AND NOT GCOVR_BIN)
+  set(WITH_COVERAGE NO)
+  message(WARNING "Could not find gcovr binary. Disabling coverage report!")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cmake-modules")
 
 # Do not build tests, if bundled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@ include(FetchContent)
 
 project(simfil)
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+  option(WITH_COVERAGE "Enable gcovr coverage" YES)
+else()
+  set(WITH_COVERAGE NO)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cmake-modules")
+
 # Do not build tests, if bundled
 set(MAIN_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -33,6 +41,10 @@ endif()
 
 if (NOT DEFINED SIMFIL_WITH_MODEL_JSON)
   set(SIMFIL_WITH_MODEL_JSON YES)
+endif()
+
+if (WITH_COVERAGE)
+  include(CodeCoverage)
 endif()
 
 add_library(simfil STATIC
@@ -105,10 +117,22 @@ if (SIMFIL_WITH_MODEL_JSON)
       nlohmann_json::nlohmann_json)
 endif()
 
+if (WITH_COVERAGE)
+  append_coverage_compiler_flags_to_target(simfil)
+endif()
+
 add_library(simfil::simfil ALIAS simfil)
 
 add_subdirectory(repl)
 
 if (MAIN_PROJECT)
   add_subdirectory(test)
+
+  if (WITH_COVERAGE)
+    setup_target_for_coverage_gcovr_html(
+      NAME coverage
+      EXECUTABLE test.simfil
+      BASE_DIRECTORY "${CMAKE_SOURCE_DIR}/src"
+      EXCLUDE "*catch2*")
+  endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17) # Required for catch2
 if (NOT TARGET Catch2)
   FetchContent_Declare(Catch2
     GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-    GIT_TAG        "v3.1.0"
+    GIT_TAG        "v3.3.2"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(Catch2)
   list(APPEND CMAKE_MODULE_PATH "${CATCH2_SOURCE_DIR}/contrib")


### PR DESCRIPTION
This adds gcov coverage reports to the build.

On a machine with GCC or Clang, `cmake --build . --target coverage` creates a coverage report using `gcov` & `gcovr`.