### PR TITLE
Do not allow zero Geometry capacity

### DIFF
--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -341,6 +341,7 @@ shared_model_ptr<GeometryCollection> ModelPool::newGeometryCollection(size_t ini
 
 shared_model_ptr<Geometry> ModelPool::newGeometry(Geometry::GeomType geomType, size_t initialCapacity)
 {
+    initialCapacity = std::max((size_t)1, initialCapacity);
     impl_->columns_.geom_.emplace_back(Geometry::Data{geomType, -(ArrayIndex)initialCapacity, {.0, .0, .0}});
     return Geometry(
         impl_->columns_.geom_.back(),

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -421,9 +421,13 @@ FieldId Geometry::keyAt(int64_t i) const {
 }
 
 void Geometry::append(geo::Point<double> const& p) {
+    // Before the geometry is assigned with a vertex array,
+    // a negative array handle denotes the desired initial
+    // capacity, +1, because there is always the additional
+    // offset point.
     if (geomData_.vertexArray_ < 0) {
         auto initialCapacity = abs(geomData_.vertexArray_);
-        geomData_.vertexArray_ = storage_->new_array(initialCapacity);
+        geomData_.vertexArray_ = storage_->new_array(initialCapacity-1);
         geomData_.offset_ = p;
         return;
     }


### PR DESCRIPTION
Before the geometry is assigned with a vertex array, a negative array handle denotes the desired initial capacity, +1, because there is always the additional offset point. So there can not (and must never be) an initial capacity of zero.
