### PR TITLE
Use current source dir, not root for module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,13 @@ include(FetchContent)
 
 project(simfil)
 
-if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  option(WITH_COVERAGE "Enable gcovr coverage" YES)
-else()
-  set(WITH_COVERAGE NO)
-endif()
-
 find_program(GCOVR_BIN gcovr)
 if (WITH_COVERAGE AND NOT GCOVR_BIN)
   set(WITH_COVERAGE NO)
   message(WARNING "Could not find gcovr binary. Disabling coverage report!")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cmake-modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake-modules")
 
 # Do not build tests, if bundled
 set(MAIN_PROJECT OFF)
@@ -26,9 +20,16 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   option(WITH_REPL     "Build simfil repl" YES)
   option(WITH_EXAMPLES "Build examples" YES)
+
+  if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option(WITH_COVERAGE "Enable gcovr coverage" YES)
+  else()
+    set(WITH_COVERAGE NO)
+  endif()
 else()
   set(WITH_REPL NO)
   set(WITH_EXAMPLES NO)
+  set(WITH_COVERAGE NO)
 endif()
 
 if (NOT TARGET sfl)


### PR DESCRIPTION
This bug breaks compilation as subproject.

Also do not enable coverage if not the main project.