### PR TITLE
Fix write lock for fields dict access.

### DIFF
--- a/src/model/fields.cpp
+++ b/src/model/fields.cpp
@@ -151,7 +151,7 @@ void Fields::write(std::ostream& outputStream, FieldId offset) const  // NOLINT
 
 void Fields::read(std::istream& inputStream)
 {
-    std::shared_lock stringStoreWriteAccess_(stringStoreMutex_);
+    std::unique_lock stringStoreWriteAccess_(stringStoreMutex_);
     bitsery::Deserializer<bitsery::InputStreamAdapter> s(inputStream);
 
     // Determine how many fields are to be received


### PR DESCRIPTION
Pretty simple bug and fix, otherwise concurrent field dict updates lead to access violations.