### PR TITLE
Additional Geometry APIs

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -618,6 +618,9 @@ struct GeometryCollection : public MandatoryModelPoolNodeBase
     /** Adds a new Geometry to the collection and returns a reference. */
     shared_model_ptr<Geometry> newGeometry(Geometry::GeomType type, size_t initialCapacity=4);
 
+    /** Append an existing Geometry to the collection. */
+    void addGeometry(shared_model_ptr<Geometry> const& geom);
+
     /** Iterate over all Geometries in the collection.
      * @param callback Function which is called for each contained geometry.
      *  Must return true to continue iteration, false to abort iteration.

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -558,6 +558,12 @@ struct Geometry final : public MandatoryModelPoolNodeBase
     /** Get the type of the geometry. */
     [[nodiscard]] GeomType geomType() const;
 
+    /** Get the number of points in the geometry buffer. */
+    [[nodiscard]] size_t numPoints() const;
+
+    /** Get a point at an index. */
+    [[nodiscard]] geo::Point<double> pointAt(size_t index) const;
+
     /** Iterate over all Points in the geometry.
      * @param callback Function which is called for each contained point.
      *  Must return true to continue iteration, false to abort iteration.
@@ -620,6 +626,9 @@ struct GeometryCollection : public MandatoryModelPoolNodeBase
 
     /** Append an existing Geometry to the collection. */
     void addGeometry(shared_model_ptr<Geometry> const& geom);
+
+    /** Get the number of contained geometries. */
+    [[nodiscard]] size_t numGeometries() const;
 
     /** Iterate over all Geometries in the collection.
      * @param callback Function which is called for each contained geometry.

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -400,6 +400,12 @@ std::optional<ModelNode::Ptr> GeometryCollection::singleGeom() const
     return {};
 }
 
+void GeometryCollection::addGeometry(const shared_model_ptr<Geometry>& geom)
+{
+    auto arrayPtr = ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Arrays, addr_.index()});
+    model().resolveArray(arrayPtr)->append(ModelNode::Ptr(geom));
+}
+
 /** ModelNode impls. for Geometry */
 
 Geometry::Geometry(Data& data, ModelConstPtr pool_, ModelNodeAddress a)

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -406,6 +406,11 @@ void GeometryCollection::addGeometry(const shared_model_ptr<Geometry>& geom)
     model().resolveArray(arrayPtr)->append(ModelNode::Ptr(geom));
 }
 
+size_t GeometryCollection::numGeometries() const
+{
+    return model().arrayMemberStorage().size((ArrayIndex)addr().index());
+}
+
 /** ModelNode impls. for Geometry */
 
 Geometry::Geometry(Data& data, ModelConstPtr pool_, ModelNodeAddress a)
@@ -474,6 +479,19 @@ bool Geometry::iterate(const IterCallback& cb) const
     if (!cb(*at(0))) return false;
     if (!cb(*at(1))) return false;
     return true;
+}
+
+size_t Geometry::numPoints() const
+{
+    VertexBufferNode vertexBufferNode{geomData_, model_, {ModelPool::PointBuffers, addr_.index()}};
+    return vertexBufferNode.size();
+}
+
+geo::Point<double> Geometry::pointAt(size_t index) const
+{
+    VertexBufferNode vertexBufferNode{geomData_, model_, {ModelPool::PointBuffers, addr_.index()}};
+    VertexNode vertex{*vertexBufferNode.at((int64_t)index), geomData_};
+    return vertex.point_;
 }
 
 /** ModelNode impls. for VertexBufferNode */

--- a/test/ext-geo.cpp
+++ b/test/ext-geo.cpp
@@ -69,22 +69,31 @@ TEST_CASE("GeometryCollection", "[geom.collection]") {
         auto geometry_collection = model_pool->newGeometryCollection();
         auto point_geom = geometry_collection->newGeometry(Geometry::GeomType::Points);
         point_geom->append({.0, .0, .0});
-        point_geom->append({.1, .1, .1});
+        point_geom->append({.25, .25, .25});
+        point_geom->append({.5, .5, .5});
+        point_geom->append({1., 1., 1.});
 
         REQUIRE(point_geom->type() == ValueType::Object);
         REQUIRE(point_geom->geomType() == Geometry::GeomType::Points);
+        REQUIRE(point_geom->numPoints() == 4);
+        REQUIRE(point_geom->pointAt(0).x == .0);
+        REQUIRE(point_geom->pointAt(1).x == .25);
+        REQUIRE(point_geom->pointAt(2).x == .5);
+        REQUIRE(point_geom->pointAt(3).x == 1.);
+        REQUIRE(geometry_collection->numGeometries() == 1);
 
         // Since the collection only contains one geometry,
         // it hides itself and directly presents the nested geometry,
         // conforming to GeoJSON (a collection must have >1 geometries).
         REQUIRE(geometry_collection->size() == 2); // 'type' and 'geometry' fields
         REQUIRE(geometry_collection->at(1)->type() == ValueType::Array); // 'geometry' field
-        REQUIRE(geometry_collection->at(1)->size() == 2); // two points
+        REQUIRE(geometry_collection->at(1)->size() == 4); // four points
 
         // Add nested geometry again two more times, now the view changes.
         geometry_collection->addGeometry(point_geom);
         geometry_collection->addGeometry(point_geom);
 
+        REQUIRE(geometry_collection->numGeometries() == 3);
         REQUIRE(geometry_collection->at(1)->size() == 3); // Three geometries
     }
 }

--- a/test/ext-geo.cpp
+++ b/test/ext-geo.cpp
@@ -74,9 +74,18 @@ TEST_CASE("GeometryCollection", "[geom.collection]") {
         REQUIRE(point_geom->type() == ValueType::Object);
         REQUIRE(point_geom->geomType() == Geometry::GeomType::Points);
 
-        REQUIRE(geometry_collection->size() == 2); // 'type' and 'geometries' fields
-        REQUIRE(geometry_collection->at(1)->type() == ValueType::Array); // 'geometries' field
-        REQUIRE(geometry_collection->at(1)->size() == 2); // one geometry in the collection, directly resolves to single nested geometry
+        // Since the collection only contains one geometry,
+        // it hides itself and directly presents the nested geometry,
+        // conforming to GeoJSON (a collection must have >1 geometries).
+        REQUIRE(geometry_collection->size() == 2); // 'type' and 'geometry' fields
+        REQUIRE(geometry_collection->at(1)->type() == ValueType::Array); // 'geometry' field
+        REQUIRE(geometry_collection->at(1)->size() == 2); // two points
+
+        // Add nested geometry again two more times, now the view changes.
+        geometry_collection->addGeometry(point_geom);
+        geometry_collection->addGeometry(point_geom);
+
+        REQUIRE(geometry_collection->at(1)->size() == 3); // Three geometries
     }
 }
 


### PR DESCRIPTION
There were some gaps the Geometry/GeometryCollection APIs:
* `GeometryCollection::addGeometry`: Add an existing geometry to a collection.
* `GeometryCollection::numGeometries`: Get count of geometries in a collection.
* `Geometry::numPoints`: Get count of points in a geometry.
* `Geometry::pointAt`: Access a geometry point at some index.