### PR TITLE
Support addField and append directly with derived ModelNode types.

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -411,6 +411,11 @@ struct Array final : public MandatoryModelPoolNodeBase
     [[nodiscard]] uint32_t size() const override;
     bool iterate(IterCallback const& cb) const override;  // NOLINT (allow discard)
 
+    template<class ModelNodeType>
+    Array& append(shared_model_ptr<ModelNodeType> const& value) {
+        return append(static_cast<ModelNode::Ptr>(value));
+    }
+
     Array& append(bool value);
     Array& append(uint16_t value);
     Array& append(int16_t value);
@@ -441,6 +446,11 @@ struct Object : public MandatoryModelPoolNodeBase
     [[nodiscard]] ModelNode::Ptr get(const FieldId &) const override;
     [[nodiscard]] FieldId keyAt(int64_t) const override;
     bool iterate(IterCallback const& cb) const override;  // NOLINT (allow discard)
+
+    template<class ModelNodeType>
+    Object& addField(std::string_view const& name, shared_model_ptr<ModelNodeType> const& value) {
+        return addField(name, static_cast<ModelNode::Ptr>(value));
+    }
 
     Object& addBool(std::string_view const& name, bool value);
     Object& addField(std::string_view const& name, uint16_t value);

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -378,7 +378,7 @@ FieldId GeometryCollection::keyAt(int64_t i) const {
 shared_model_ptr<Geometry> GeometryCollection::newGeometry(Geometry::GeomType type, size_t initialCapacity) {
     auto result = model().newGeometry(type, initialCapacity);
     auto arrayPtr = ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Arrays, addr_.index()});
-    model().resolveArray(arrayPtr)->append(ModelNode::Ptr(result));
+    model().resolveArray(arrayPtr)->append(result);
     return result;
 }
 

--- a/test/ext-geo.cpp
+++ b/test/ext-geo.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Spatial Operators", "[spatial.ops]") {
     point_geom->append({2., 3., 0.});
     model_pool->addRoot(shared_model_ptr<ModelNode>(model_pool->newObject()->addField(
         "geometry",
-        ModelNode::Ptr(point_geom))));
+        point_geom)));
     Environment env(model_pool->fieldNames());
 
     SECTION("Point Within BBox") {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -390,7 +390,7 @@ TEST_CASE("Model Pool Validation", "[model.validation]") {
     REQUIRE_NOTHROW(pool->validate());
 
     // An empty object should also be valid
-    pool->newObject()->addField("good", ModelNode::Ptr(pool->newObject()));
+    pool->newObject()->addField("good", pool->newObject());
     REQUIRE_NOTHROW(pool->validate());
 }
 


### PR DESCRIPTION
Fixes #48 

We were always explicitely casting from `shared_model_ptr<Derived>` to `shared_model_ptr<ModelNode>`. This is now not necessary anymore when calling `Object::addField` or `Array::append`.