### PR TITLE
Allow constructing a point from any object with x/y/z members.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ target_include_directories(simfil
 
 target_compile_features(simfil
   PUBLIC
-    cxx_std_17)
+    cxx_std_20)
 
 target_link_libraries(simfil
   PUBLIC

--- a/include/simfil/model/point.h
+++ b/include/simfil/model/point.h
@@ -9,10 +9,39 @@ namespace simfil
 namespace geo
 {
 
+/**
+ * Concept which is used to construct points
+ * from arbitrary other compatible structures.
+ */
+template <typename T, typename Precision>
+concept HasXY = requires(T t) {
+    { t.x } -> std::convertible_to<Precision>;
+    { t.y } -> std::convertible_to<Precision>;
+};
+
+/** Minimal 3D point structure. */
 template <class Precision = double>
 struct Point
 {
     Precision x = 0, y = 0, z = 0;
+
+    /** Define trivial constructors */
+    Point() = default;
+    Point(Point const&) = default;
+    Point(Precision const& x, Precision const& y, Precision const& z = .0) : x(x), y(y), z(z) {}
+
+    /**
+     * Allow constructing a point from any class which has .x and .y members.
+     * If the other class has a z member, it will be applied as well.
+     */
+    template <typename T>
+    requires HasXY<T, Precision>
+    Point(T const& other) : x(other.x), y(other.y)  // NOLINT: Allow implicit conversion
+    {
+        if constexpr (requires { {other.z} -> std::convertible_to<Precision>; }) {
+            z = other.z;
+        }
+    }
 
     auto operator==(const Point& o) const -> bool
     {

--- a/src/ext-geo.cpp
+++ b/src/ext-geo.cpp
@@ -227,7 +227,7 @@ auto BBox::toString() const -> std::string
 auto Polygon::bbox() const -> BBox
 {
     if (polys.empty())
-        return {{0, 0}, {0}};
+        return {{0, 0}, {0, 0}};
 
     return polys[0].bbox();
 }

--- a/test/ext-geo.cpp
+++ b/test/ext-geo.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Point", "[geo.point]") {
 }
 
 TEST_CASE("BBox", "[geo.bbox]") {
-    REQUIRE(BBox{0, 1, 2, 3} == BBox{0, 1, 2, 3});
+    REQUIRE(BBox{{0, 1}, {2, 3}} == BBox{{0, 1}, {2, 3}});
 }
 
 TEST_CASE("LineString", "[geo.linestring]") {


### PR DESCRIPTION
Interfacing with simfil points is a bit cumbersome, as there are no useful constructors defined. This PR bumps simfils C++ requirement to 20, and uses concepts to define a constructor which can take any object with x/y(/z) members, such as a glm vector.