### PR TITLE
Support GeometryView

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: true
     - name: Install dependencies
       run: |
-        sudo apt-get install gcovr ninja-build valgrind
+        sudo apt-get update && sudo apt-get install gcovr ninja-build valgrind
     - name: Setup
       run: |
         mkdir build

--- a/include/simfil/model/arena.h
+++ b/include/simfil/model/arena.h
@@ -367,7 +367,7 @@ private:
         data_.resize(offset + newCapacity);
         if (head.capacity == 0) {
             head.offset = (SizeType_)offset;
-            head.capacity = newCapacity;
+            head.capacity = static_cast<SizeType_>(newCapacity);
             return head;
         }
         auto newIndex = static_cast<ArrayIndex>(continuations_.size());

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -138,6 +138,11 @@ public:
     /// Geometry(-Collection) factories
     shared_model_ptr<GeometryCollection> newGeometryCollection(size_t initialCapacity = 1);
     shared_model_ptr<Geometry> newGeometry(Geometry::GeomType geomType, size_t initialCapacity = 1);
+    shared_model_ptr<Geometry> newGeometryView(
+        Geometry::GeomType geomType,
+        uint32_t offset,
+        uint32_t size,
+        shared_model_ptr<Geometry> const& base);
 
     /// Node-type-specific resolve-functions
     shared_model_ptr<Object> resolveObject(ModelNode::Ptr const& n) const;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -342,7 +342,20 @@ shared_model_ptr<GeometryCollection> ModelPool::newGeometryCollection(size_t ini
 shared_model_ptr<Geometry> ModelPool::newGeometry(Geometry::GeomType geomType, size_t initialCapacity)
 {
     initialCapacity = std::max((size_t)1, initialCapacity);
-    impl_->columns_.geom_.emplace_back(Geometry::Data{geomType, -(ArrayIndex)initialCapacity, {.0, .0, .0}});
+    impl_->columns_.geom_.emplace_back(geomType, initialCapacity);
+    return Geometry(
+        &impl_->columns_.geom_.back(),
+        shared_from_this(),
+        {Geometries, (uint32_t)impl_->columns_.geom_.size()-1});
+}
+
+shared_model_ptr<Geometry> ModelPool::newGeometryView(
+    Geometry::GeomType geomType,
+    uint32_t offset,
+    uint32_t size,
+    const shared_model_ptr<Geometry>& base)
+{
+    impl_->columns_.geom_.emplace_back(geomType, offset, size, base->addr_);
     return Geometry(
         &impl_->columns_.geom_.back(),
         shared_from_this(),


### PR DESCRIPTION
This PR adds support for having Geometry nodes which are views into other geometries. This is required to simplify NDS.Live lane boundary decoding, where multiple boundary ranges share a single polyline.