### PR TITLE
Critical bugfix for ModelPool::Resolve of geometry view vertices.

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -779,7 +779,7 @@ struct VertexNode final : public MandatoryModelPoolNodeBase
 
 protected:
     VertexNode() = default;
-    VertexNode(ModelNode const& baseNode, Geometry::Data const& geomData);
+    VertexNode(ModelNode const& baseNode, Geometry::Data const* geomData);
 
     geo::Point<double> point_;
 };
@@ -788,7 +788,7 @@ template <typename LambdaType, class ModelType>
 bool Geometry::forEachPoint(LambdaType const& callback) const {
     VertexBufferNode vertexBufferNode{geomData_, model_, {ModelType::PointBuffers, addr_.index()}};
     for (auto i = 0; i < vertexBufferNode.size(); ++i) {
-        VertexNode vertex{*vertexBufferNode.at(i), *vertexBufferNode.geomData_};
+        VertexNode vertex{*vertexBufferNode.at(i), vertexBufferNode.geomData_};
         if (!callback(vertex.point_))
             return false;
     }

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -239,7 +239,7 @@ void ModelPool::resolve(ModelNode const& n, ResolveFn const& cb) const
     }
     case Points: {
         auto& val = get(impl_->columns_.geom_);
-        cb(VertexNode(n, val));
+        cb(VertexNode(n, &val));
         break;
     }
     case PointBuffers: {


### PR DESCRIPTION
There was an oversight in my GeometryView implementation regarding ModelPool::resolve for vertices when not accessed through their VertexBuffer container.