### PR TITLE
Allow Array Inheritance

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -405,7 +405,7 @@ SmallValueNode<bool>::SmallValueNode(ModelConstPtr, ModelNodeAddress);
 
 /** Model Node for an array. */
 
-struct Array final : public MandatoryModelPoolNodeBase
+struct Array : public MandatoryModelPoolNodeBase
 {
     template<typename> friend struct shared_model_ptr;
     friend class ModelPool;

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -101,7 +101,7 @@ struct shared_model_ptr
     inline T* operator-> () {return &data_;}
     inline T const& operator* () const {return data_;}
     inline T const* operator-> () const {return &data_;}
-    inline operator bool () const {return data_.addr_.value_ != 0;}  // NOLINT
+    inline operator bool () const {return data_.addr_;}  // NOLINT (allow implicit bool cast)
 
 private:
     T data_;
@@ -145,6 +145,10 @@ struct ModelNodeAddress
 
     [[nodiscard]] int16_t int16() const {
         return static_cast<int16_t>((value_ >> 8) & 0xffff);
+    }
+
+    [[nodiscard]] operator bool() const {  // NOLINT (allow implicit bool cast)
+        return value_ != 0;
     }
 
     template<typename S>
@@ -670,7 +674,7 @@ protected:
             else {
                 s.value4b(detail_.view_.offset_);
                 s.value4b(detail_.view_.size_);
-                s.value4b(detail_.view_.baseGeometry_.value_);
+                s.object(detail_.view_.baseGeometry_);
             }
         }
     };
@@ -729,7 +733,7 @@ struct GeometryCollection : public MandatoryModelPoolNodeBase
     }
 
 protected:
-    std::optional<ModelNode::Ptr> singleGeom() const;
+    ModelNode::Ptr singleGeom() const;
 
     using Storage = Array::Storage;
 

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -402,13 +402,13 @@ shared_model_ptr<Geometry> GeometryCollection::newGeometry(Geometry::GeomType ty
 bool GeometryCollection::iterate(const IterCallback& cb) const
 {
     if (auto singleGeomEntry = singleGeom())
-        return (*singleGeomEntry)->iterate(cb);
+        return singleGeomEntry->iterate(cb);
     if (!cb(*at(0))) return false;
     if (!cb(*at(1))) return false;
     return true;
 }
 
-std::optional<ModelNode::Ptr> GeometryCollection::singleGeom() const
+ModelNode::Ptr GeometryCollection::singleGeom() const
 {
     if (model().arrayMemberStorage().size((ArrayIndex)addr_.index()) == 1) {
         auto arrayPtr = ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Arrays, addr_.index()});

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -364,7 +364,7 @@ ValueType GeometryCollection::type() const {
 
 ModelNode::Ptr GeometryCollection::at(int64_t i) const {
     if (auto singleGeomEntry = singleGeom())
-        return (*singleGeomEntry)->at(i);
+        return singleGeomEntry->at(i);
     if (i == 0) return ValueNode(GeometryCollectionStr, model_);
     if (i == 1) return ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Arrays, addr_.index()});
     throw std::out_of_range("geom collection: Out of range.");
@@ -372,13 +372,13 @@ ModelNode::Ptr GeometryCollection::at(int64_t i) const {
 
 uint32_t GeometryCollection::size() const {
     if (auto singleGeomEntry = singleGeom())
-        return (*singleGeomEntry)->size();
+        return singleGeomEntry->size();
     return 2;
 }
 
 ModelNode::Ptr GeometryCollection::get(const FieldId& f) const {
     if (auto singleGeomEntry = singleGeom())
-        return (*singleGeomEntry)->get(f);
+        return singleGeomEntry->get(f);
     if (f == Fields::Type) return at(0);
     if (f == Fields::Geometries) return at(1);
     return {};
@@ -386,7 +386,7 @@ ModelNode::Ptr GeometryCollection::get(const FieldId& f) const {
 
 FieldId GeometryCollection::keyAt(int64_t i) const {
     if (auto singleGeomEntry = singleGeom())
-        return (*singleGeomEntry)->keyAt(i);
+        return singleGeomEntry->keyAt(i);
     if (i == 0) return Fields::Type;
     if (i == 1) return Fields::Geometries;
     throw std::out_of_range("geom collection: Out of range.");


### PR DESCRIPTION
Small changes for overall usability improvements:

* I need a derived array model node type, so the final specifier was removed (there was no performance impact).
* There are some checks in mapget for ModelNodeAdress::value_ != 0, so I just gave it a bool operator.