### PR TITLE
Fix test when compiling with MSVC+Ninja

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,13 @@ target_link_libraries(test.simfil
     simfil
     Catch2::Catch2WithMain)
 
+if (MSVC)
+  # Ensure that tests work when compiled with Ninja on Windows.
+  # The test.simfil.exe must be deployed side-by-side with simfil.dll.
+  set_target_properties(test.simfil PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:simfil>)
+endif()
+
 include(Catch)
 include(CTest)
 catch_discover_tests(test.simfil)


### PR DESCRIPTION
Ensure that the test.simfil output directory matches the library output directory when compiling with MSVC. Otherwise, test.simfil.exe cannot find simfil.dll.