### PR TITLE
deps/bitsery: Use lower-case only in FetchContent to fix silently failing fetching of bitsery.

### DIFF
--- a/deps.cmake
+++ b/deps.cmake
@@ -21,13 +21,13 @@ FetchContent_Declare(fmt
   GIT_SHALLOW    ON
   FIND_PACKAGE_ARGS)
 
-FetchContent_Declare(Bitsery
+FetchContent_Declare(bitsery
   GIT_REPOSITORY "https://github.com/fraillt/bitsery.git"
   GIT_TAG        "v5.2.3"
   GIT_SHALLOW    ON
   FIND_PACKAGE_ARGS)
 
-FetchContent_MakeAvailable(sfl fmt Bitsery)
+FetchContent_MakeAvailable(sfl fmt bitsery)
 
 if (SIMFIL_WITH_MODEL_JSON)
   FetchContent_Declare(nlohmann_json


### PR DESCRIPTION
At least when using emscripten based cross-compilation for erdblick, the `bitsery` dependency was not fetched properly. There was not source/build dir in the `_deps` dir. Not sure if it was hidden somewhere else but at the end this caused a linker error, because of the non-present bitsery library. This PR just changes to all-lower-case. I think it is somehow related to the way cmake populates variables when using FetchContent, but I don't know for sure. Nevertheless, I guess this should not have any negative side-effect but makes the cross-compilation work.