### PR TITLE
Conan Fixups Part III

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![](https://img.shields.io/badge/Coverage-HTML-orange)](https://htmlpreview.github.io/?https://gist.githubusercontent.com/johannes-wolf/61e57af50757b03e0c7cd119ec2d2f4b/raw/ed28c457ebc09ce8ddddc9cec6668e130d59b64c/coverage.html)
 [![](https://gist.githubusercontent.com/johannes-wolf/61e57af50757b03e0c7cd119ec2d2f4b/raw/0ae49c7509dea18b4c110b8bf416f2715a214933/badge.svg)](https://github.com/Klebert-Engineering/simfil)
+[![Conan Center](https://img.shields.io/conan/v/simfil)](https://conan.io/center/recipes/simfil)
 
 `simfil` is a C++ 17 library and a language for querying structured map feature data. The library provides an efficient in-memory storage pool for map data, optimized for the `simfil` query language, along with a query interpreter to query the actual data.
 
@@ -110,6 +111,19 @@ For an example of how to add new types to `simfil`, see [ext-geo.h](include/simf
 
 ## Using the Library
 ### Conan Package
+#### Using Conan
+Simfil is published on [conan.io](https://conan.io/center/recipes/simfil). All you have to do is to add it to your
+conanfile:
+
+``` conan
+[requires]
+simfil/0.1.1
+
+[generators]
+CMakeDeps
+CMakeToolchain
+```
+
 #### Using Conan Editable Mode
 You can link the local simfil source directory as a [Conan 2 editable mode package ](https://docs.conan.io/2/tutorial/developing_packages/editable_packages.html) via `conan editable add <simfil-dir>`. Note that you have to pass
 `--build=editable` to your `conan install` invocation, otherwise the CMake build fails with errors about not finding the library.

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,8 +16,8 @@ class SimfilRecipe(ConanFile):
     version = "dev"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Klebert-Engineering/simfil"
-    license = "BSD 3-Clause"
-    topics = ["query language"]
+    license = "BSD-3-Clause"
+    topics = ["query-language", "json", "data-model"]
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
@@ -37,12 +37,15 @@ class SimfilRecipe(ConanFile):
     def validate(self):
         check_min_cppstd(self, "20")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>3.19 <4]")
+
     def requirements(self):
         self.requires("sfl/[~1]", transitive_headers=True)
-        self.requires("fmt/[~10]", transitive_headers=True)
+        self.requires("fmt/10.0.0", transitive_headers=True)
         self.requires("bitsery/[~5]", transitive_headers=True)
         if self.options.with_json:
-            self.requires("nlohmann_json/[~3]")
+            self.requires("nlohmann_json/[~3]", transitive_headers=True)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -50,6 +53,10 @@ class SimfilRecipe(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -75,4 +82,3 @@ class SimfilRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["simfil"]
-        self.cpp_info.set_property("cmake_target_name", "simfil::simfil")

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,11 +38,11 @@ class SimfilRecipe(ConanFile):
         check_min_cppstd(self, "20")
 
     def requirements(self):
-        self.requires("sfl/1.2.4", transitive_headers=True)
-        self.requires("fmt/10.0.0", transitive_headers=True)
-        self.requires("bitsery/5.2.3", transitive_headers=True)
+        self.requires("sfl/[~1]", transitive_headers=True)
+        self.requires("fmt/[~10]", transitive_headers=True)
+        self.requires("bitsery/[~5]", transitive_headers=True)
         if self.options.with_json:
-            self.requires("nlohmann_json/3.11.2")
+            self.requires("nlohmann_json/[~3]")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,7 +39,7 @@ class SimfilRecipe(ConanFile):
 
     def requirements(self):
         self.requires("sfl/1.2.4", transitive_headers=True)
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("fmt/10.0.0", transitive_headers=True)
         self.requires("bitsery/5.2.3", transitive_headers=True)
         if self.options.with_json:
             self.requires("nlohmann_json/3.11.2")

--- a/deps.cmake
+++ b/deps.cmake
@@ -15,7 +15,7 @@ else()
 
   FetchContent_Declare(fmt
     GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-    GIT_TAG        "10.2.1"
+    GIT_TAG        "10.0.0"
     GIT_SHALLOW    ON)
 
   FetchContent_Declare(bitsery

--- a/deps.cmake
+++ b/deps.cmake
@@ -8,37 +8,47 @@ if (SIMFIL_CONAN)
     find_package(nlohmann_json REQUIRED)
   endif()
 else()
-  FetchContent_Declare(sfl
-    GIT_REPOSITORY "https://github.com/slavenf/sfl-library.git"
-    GIT_TAG        "master"
-    GIT_SHALLOW    ON)
+  if (NOT TARGET sfl::sfl)
+    FetchContent_Declare(sfl
+      GIT_REPOSITORY "https://github.com/slavenf/sfl-library.git"
+      GIT_TAG        "master"
+      GIT_SHALLOW    ON)
+  endif()
 
-  FetchContent_Declare(fmt
-    GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-    GIT_TAG        "10.0.0"
-    GIT_SHALLOW    ON)
+  if (NOT TARGET fmt::fmt)
+    FetchContent_Declare(fmt
+      GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
+      GIT_TAG        "10.0.0"
+      GIT_SHALLOW    ON)
+  endif()
 
-  FetchContent_Declare(bitsery
-    GIT_REPOSITORY "https://github.com/fraillt/bitsery.git"
-    GIT_TAG        "v5.2.3"
-    GIT_SHALLOW    ON)
+  if (NOT TARGET bitsery::bitsery)
+    FetchContent_Declare(bitsery
+      GIT_REPOSITORY "https://github.com/fraillt/bitsery.git"
+      GIT_TAG        "v5.2.3"
+      GIT_SHALLOW    ON)
+  endif()
 
   FetchContent_MakeAvailable(sfl fmt bitsery)
 
   if (SIMFIL_WITH_MODEL_JSON)
-    FetchContent_Declare(nlohmann_json
-      GIT_REPOSITORY "https://github.com/nlohmann/json.git"
-      GIT_TAG        "v3.11.2"
-      GIT_SHALLOW    ON)
-    FetchContent_MakeAvailable(nlohmann_json)
+    if (NOT TARGET nlohmann_json::nlohmann_json)
+      FetchContent_Declare(nlohmann_json
+        GIT_REPOSITORY "https://github.com/nlohmann/json.git"
+        GIT_TAG        "v3.11.2"
+        GIT_SHALLOW    ON)
+      FetchContent_MakeAvailable(nlohmann_json)
+    endif()
   endif()
 endif()
 
 if (SIMFIL_WITH_TESTS)
-  FetchContent_Declare(catch2
-    GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-    GIT_TAG        "v3.5.2"
-    GIT_SHALLOW    ON
-    FIND_PACKAGE_ARGS)
-  FetchContent_MakeAvailable(catch2)
+  if (NOT TARGET Catch2::Catch2WithMain)
+    FetchContent_Declare(catch2
+      GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+      GIT_TAG        "v3.5.2"
+      GIT_SHALLOW    ON
+      FIND_PACKAGE_ARGS)
+    FetchContent_MakeAvailable(catch2)
+  endif()
 endif()

--- a/deps.cmake
+++ b/deps.cmake
@@ -7,35 +7,31 @@ if (SIMFIL_CONAN)
   if (SIMFIL_WITH_MODEL_JSON)
     find_package(nlohmann_json REQUIRED)
   endif()
-endif()
+else()
+  FetchContent_Declare(sfl
+    GIT_REPOSITORY "https://github.com/slavenf/sfl-library.git"
+    GIT_TAG        "master"
+    GIT_SHALLOW    ON)
 
-FetchContent_Declare(sfl
-  GIT_REPOSITORY "https://github.com/slavenf/sfl-library.git"
-  GIT_TAG        "master"
-  GIT_SHALLOW    ON
-  FIND_PACKAGE_ARGS)
+  FetchContent_Declare(fmt
+    GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
+    GIT_TAG        "10.2.1"
+    GIT_SHALLOW    ON)
 
-FetchContent_Declare(fmt
-  GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-  GIT_TAG        "10.2.1"
-  GIT_SHALLOW    ON
-  FIND_PACKAGE_ARGS)
+  FetchContent_Declare(bitsery
+    GIT_REPOSITORY "https://github.com/fraillt/bitsery.git"
+    GIT_TAG        "v5.2.3"
+    GIT_SHALLOW    ON)
 
-FetchContent_Declare(bitsery
-  GIT_REPOSITORY "https://github.com/fraillt/bitsery.git"
-  GIT_TAG        "v5.2.3"
-  GIT_SHALLOW    ON
-  FIND_PACKAGE_ARGS)
+  FetchContent_MakeAvailable(sfl fmt bitsery)
 
-FetchContent_MakeAvailable(sfl fmt bitsery)
-
-if (SIMFIL_WITH_MODEL_JSON)
-  FetchContent_Declare(nlohmann_json
-    GIT_REPOSITORY "https://github.com/nlohmann/json.git"
-    GIT_TAG        "v3.11.2"
-    GIT_SHALLOW    ON
-    FIND_PACKAGE_ARGS)
-  FetchContent_MakeAvailable(nlohmann_json)
+  if (SIMFIL_WITH_MODEL_JSON)
+    FetchContent_Declare(nlohmann_json
+      GIT_REPOSITORY "https://github.com/nlohmann/json.git"
+      GIT_TAG        "v3.11.2"
+      GIT_SHALLOW    ON)
+    FetchContent_MakeAvailable(nlohmann_json)
+  endif()
 endif()
 
 if (SIMFIL_WITH_TESTS)


### PR DESCRIPTION
This PR:
- Guards all `FetchContent` calls, so that they do not get called if `SIMFIL_CONAN` is set
- Removes all the `FIND_PACKAGE_ARGS` arguments
- Downgrades `fmt` to `10.0.0` because of compat. with `spdlog` in mapget – I guess it would be best to not have `fmt` in the `simfil` public-headers, though
- Add guards for each target (TODO: check case of the target names!)