### PR TITLE
Fix Environment struct predeclaration.

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -21,7 +21,7 @@ class Value;
 class ModelPool;
 class Model;
 struct ModelNode;
-class Environment;
+struct Environment;
 class Expr;
 
 std::vector<Value> eval(Environment& env, const Expr& ast, const ModelNode& node);


### PR DESCRIPTION
Fix Environment struct predeclaration.

Just to get rid of the annoying warning.