### PR TITLE
Add ModelPool::setFieldNames

### DIFF
--- a/include/simfil/model/fields.h
+++ b/include/simfil/model/fields.h
@@ -42,6 +42,9 @@ struct Fields
     /// Default constructor initializes strings for static Ids
     Fields();
 
+    /// Copy constructor
+    Fields(Fields const&);
+
     /// Virtual destructor to allow polymorphism
     virtual ~Fields() = default;
 

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -153,6 +153,17 @@ public:
     /// Access the field name storage
     std::shared_ptr<Fields> fieldNames() const;
 
+     /// Instruct the model to switch to its own field dict copy.
+     /// This can be necessary, if you make changes to this dict,
+     /// which are not supposed to have any side effects for other layers.
+     /// Returns the new copy of the dictionary.
+    std::shared_ptr<simfil::Fields> takeFieldsDictOwnership();
+
+    /// Change the fields dict of this model to a different one.
+    /// Note: This will potentially create new field entries in the newDict,
+    /// for field names which were not there before.
+    virtual void transcode(std::shared_ptr<simfil::Fields> const& newDict);
+
     /// Serialization
     virtual void write(std::ostream& outputStream);
     virtual void read(std::istream& inputStream);

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -153,16 +153,10 @@ public:
     /// Access the field name storage
     std::shared_ptr<Fields> fieldNames() const;
 
-     /// Instruct the model to switch to its own field dict copy.
-     /// This can be necessary, if you make changes to this dict,
-     /// which are not supposed to have any side effects for other layers.
-     /// Returns the new copy of the dictionary.
-    std::shared_ptr<simfil::Fields> takeFieldsDictOwnership();
-
     /// Change the fields dict of this model to a different one.
     /// Note: This will potentially create new field entries in the newDict,
     /// for field names which were not there before.
-    virtual void transcode(std::shared_ptr<simfil::Fields> const& newDict);
+    virtual void setFieldNames(std::shared_ptr<simfil::Fields> const& newDict);
 
     /// Serialization
     virtual void write(std::ostream& outputStream);
@@ -177,9 +171,6 @@ protected:
     Object::Storage& objectMemberStorage();
     Array::Storage& arrayMemberStorage();
     Geometry::Storage& vertexBufferStorage();
-
-    /// Allows a derived ModelPool to set the field name storage dictionary
-    void setFieldNames(std::shared_ptr<Fields> fieldNames);
 };
 
 }

--- a/src/model/fields.cpp
+++ b/src/model/fields.cpp
@@ -10,8 +10,6 @@
 namespace simfil
 {
 
-/** String Pool implementation */
-
 Fields::Fields() {
     addStaticKey(Empty, "");
     addStaticKey(Lon, "lon");
@@ -24,6 +22,16 @@ Fields::Fields() {
     addStaticKey(Type, "type");
     addStaticKey(Coordinates, "coordinates");
     addStaticKey(Elevation, "elevation");
+}
+
+Fields::Fields(const Fields& other) :
+    idForString_(other.idForString_),
+    stringForId_(other.stringForId_),
+    nextId_(other.nextId_),
+    byteSize_(other.byteSize_.load()),
+    cacheHits_(other.cacheHits_.load()),
+    cacheMisses_(other.cacheMisses_.load())
+{
 }
 
 FieldId Fields::emplace(std::string_view const& str)

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -428,4 +428,22 @@ void ModelPool::read(std::istream& inputStream) {
     }
 }
 
+std::shared_ptr<simfil::Fields> ModelPool::takeFieldsDictOwnership()
+{
+    impl_->fieldNames_ = std::make_shared<Fields>(*impl_->fieldNames_);
+    return impl_->fieldNames_;
+}
+
+void ModelPool::transcode(std::shared_ptr<simfil::Fields> const& newDict)
+{
+    // Translate object field IDs to the new dictionary.
+    for (auto memberArray : impl_->columns_.objectMemberArrays_) {
+        for (auto& member : memberArray) {
+            if (auto resolvedName = impl_->fieldNames_->resolve(member.name_))
+                member.name_ = newDict->emplace(*resolvedName);
+        }
+    }
+    impl_->fieldNames_ = newDict;
+}
+
 }  // namespace simfil

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -471,3 +471,20 @@ TEST_CASE("Object/Array Extend", "[model.extend]") {
         REQUIRE(Value(testArrayA->at(3)->value()).as<ValueType::Int>() == 55ll);
     }
 }
+
+TEST_CASE("Transcode Model", "[model.transcode]")
+{
+    auto pool = std::make_shared<ModelPool>();
+    auto oldFieldDict = pool->fieldNames();
+    auto newFieldDict = pool->takeFieldsDictOwnership();
+    REQUIRE(oldFieldDict != newFieldDict);
+
+    auto obj = pool->newObject();
+    obj->addField("hello", "world");
+
+    oldFieldDict->emplace("gobbledigook");
+    pool->transcode(oldFieldDict);
+    REQUIRE_NOTHROW(pool->validate());
+    REQUIRE(pool->fieldNames() == oldFieldDict);
+    REQUIRE(oldFieldDict->size() != newFieldDict->size());
+}

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -472,19 +472,21 @@ TEST_CASE("Object/Array Extend", "[model.extend]") {
     }
 }
 
-TEST_CASE("Transcode Model", "[model.transcode]")
+TEST_CASE("Switch Model Fields Dict", "[model.setfieldnames]")
 {
     auto pool = std::make_shared<ModelPool>();
     auto oldFieldDict = pool->fieldNames();
-    auto newFieldDict = pool->takeFieldsDictOwnership();
-    REQUIRE(oldFieldDict != newFieldDict);
+    auto newFieldDict = std::make_shared<simfil::Fields>(*oldFieldDict);
+    pool->setFieldNames(newFieldDict);
+    REQUIRE(pool->fieldNames() == newFieldDict);
 
     auto obj = pool->newObject();
     obj->addField("hello", "world");
 
     oldFieldDict->emplace("gobbledigook");
-    pool->transcode(oldFieldDict);
-    REQUIRE_NOTHROW(pool->validate());
+    pool->setFieldNames(oldFieldDict);
+
     REQUIRE(pool->fieldNames() == oldFieldDict);
+    REQUIRE_NOTHROW(pool->validate());
     REQUIRE(oldFieldDict->size() != newFieldDict->size());
 }


### PR DESCRIPTION
Motivation: Allow two features which are encoded with different field dicts to be evaluated under one OverlayNode, which combines the two feature nodes which come from different models.