### PR TITLE
Fix crash when calling select() with variable index.

### DIFF
--- a/src/function.cpp
+++ b/src/function.cpp
@@ -509,7 +509,7 @@ auto SelectFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, co
         .ok();
 
     if (!ok)
-        res(ctx, Value::undef());
+        return res(ctx, Value::undef());
 
     auto iidx = idx.as<ValueType::Int>();
     auto icnt = cnt.as<ValueType::Int>();

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -303,6 +303,7 @@ TEST_CASE("Model Functions", "[yaml.mode-functions]") {
         REQUIRE_RESULT("split('hello.this.is.a.test.', '.', false)", "hello|this|is|a|test");
     }
     SECTION("Test select(... )") {
+        REQUIRE_RESULT("select(split('a.b.c.d', '.'), a)", "b");
         REQUIRE_RESULT("select(split('a.b.c.d', '.'), 0)", "a");
         REQUIRE_RESULT("select(split('a.b.c.d', '.'), 1, 2)", "b|c");
         REQUIRE_RESULT("select(split('a.b.c.d', '.'), 1, 0)", "b|c|d");


### PR DESCRIPTION
There was a missing return, which lead to a crash when using a non-constant expression for the select index argument.