### PR TITLE
Allow setting a custom exception handler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(simfil ${LIBRARY_TYPE}
   src/simfil.cpp
   src/value.cpp
   src/overlay.cpp
+  src/exception-handler.cpp
   src/model/model.cpp
   src/model/nodes.cpp
   src/model/fields.cpp)
@@ -73,6 +74,7 @@ target_sources(simfil PUBLIC
       include/simfil/value.h
       include/simfil/transient.h
       include/simfil/simfil.h
+      include/simfil/exception-handler.h
 
       include/simfil/model/arena.h
       include/simfil/model/fields.h

--- a/include/simfil/exception-handler.h
+++ b/include/simfil/exception-handler.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <functional>
+#include <exception>
+#include <string>
+#include <typeinfo>
+
+namespace simfil
+{
+
+/**
+ * Define the error handler callback type. The first argument
+ * is the name of the exception class, the second argument is
+ * exception.what(), or an empty string if what() does not exist.
+ */
+using CustomThrowHandlerType = std::function<void(const std::string&, const std::string&)>;
+
+/**
+ * Singleton class to store a custom exception handling callback.
+ */
+class ThrowHandler
+{
+public:
+    // Retrieves the singleton instance of the ThrowHandler
+    static ThrowHandler& instance() {
+        static ThrowHandler instance;
+        return instance;
+    }
+
+    // Prevent copying and assignment
+    ThrowHandler(const ThrowHandler&) = delete;
+    ThrowHandler& operator=(const ThrowHandler&) = delete;
+
+    void set(CustomThrowHandlerType handler) {
+        customThrowHandler_ = std::move(handler);
+    }
+
+    [[nodiscard]] CustomThrowHandlerType const& get() const {
+        return customThrowHandler_;
+    }
+
+private:
+    CustomThrowHandlerType customThrowHandler_;
+    ThrowHandler() = default; // Private constructor for singleton
+};
+
+
+/**
+ * Template function that accepts any exception type
+ * and constructor arguments. Runs the custom exception
+ * handler callback if it is set, and then calls C++ throw.
+ */
+template<typename ExceptionType, typename... Args>
+[[noreturn]] void raise(Args&&... args)
+{
+    ExceptionType exceptionInstance(std::forward<Args>(args)...);
+
+    if (auto const& excHandler = ThrowHandler::instance().get()) {
+        std::string typeName = typeid(ExceptionType).name();
+        std::string errorMessage;
+        if constexpr (requires {exceptionInstance.what();})
+            errorMessage = exceptionInstance.what();
+        excHandler(typeName, errorMessage);
+    }
+
+    throw std::move(exceptionInstance);
+}
+
+}

--- a/include/simfil/exception-handler.h
+++ b/include/simfil/exception-handler.h
@@ -22,26 +22,19 @@ class ThrowHandler
 {
 public:
     // Retrieves the singleton instance of the ThrowHandler
-    static ThrowHandler& instance() {
-        static ThrowHandler instance;
-        return instance;
-    }
+    static ThrowHandler& instance();
 
     // Prevent copying and assignment
     ThrowHandler(const ThrowHandler&) = delete;
     ThrowHandler& operator=(const ThrowHandler&) = delete;
 
-    void set(CustomThrowHandlerType handler) {
-        customThrowHandler_ = std::move(handler);
-    }
+    void set(CustomThrowHandlerType handler);
 
-    [[nodiscard]] CustomThrowHandlerType const& get() const {
-        return customThrowHandler_;
-    }
+    [[nodiscard]] CustomThrowHandlerType const& get() const;
 
 private:
     CustomThrowHandlerType customThrowHandler_;
-    ThrowHandler() = default; // Private constructor for singleton
+    ThrowHandler() = default; // Private constructor for singleton.
 };
 
 

--- a/include/simfil/model/arena.h
+++ b/include/simfil/model/arena.h
@@ -8,6 +8,8 @@
 #include <cmath>
 #include <sfl/segmented_vector.hpp>
 
+#include "../exception-handler.h"
+
 // Define this to enable array arena read-write locking.
 // #define ARRAY_ARENA_THREAD_SAFE
 
@@ -389,7 +391,7 @@ private:
             if (remaining < current->capacity && remaining < current->size)
                 return self.data_[current->offset + remaining];
             if (current->next == -1)
-                throw std::out_of_range("Index out of range");
+                raise<std::out_of_range>("Index out of range");
             remaining -= current->capacity;
             current = &self.continuations_[current->next];
         }

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <variant>
+#include <functional>
 
 #include "arena.h"
 #include "point.h"

--- a/include/simfil/operator.h
+++ b/include/simfil/operator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "simfil/value.h"
+#include "exception-handler.h"
 
 #include <cstdint>
 #include <string_view>
@@ -428,28 +429,28 @@ struct OperatorDiv
     auto operator()(int64_t l, int64_t r) const -> int64_t
     {
         if (r == 0)
-            throw std::runtime_error("Division by zero");
+            raise<std::runtime_error>("Division by zero");
         return static_cast<int64_t>(l / r);
     }
 
     auto operator()(int64_t l, double r) const -> double
     {
         if (r == 0)
-            throw std::runtime_error("Division by zero");
+            raise<std::runtime_error>("Division by zero");
         return static_cast<double>(l / r);
     }
 
     auto operator()(double l, int64_t r) const -> double
     {
         if (r == 0)
-            throw std::runtime_error("Division by zero");
+            raise<std::runtime_error>("Division by zero");
         return static_cast<double>(l / r);
     }
 
     auto operator()(double l, double r) const -> double
     {
         if (r == 0)
-            throw std::runtime_error("Division by zero");
+            raise<std::runtime_error>("Division by zero");
         return static_cast<double>(l / r);
     }
 };
@@ -463,7 +464,7 @@ struct OperatorMod
     auto operator()(int64_t l, int64_t r) const -> int64_t
     {
         if (r == 0)
-            throw std::runtime_error("Division by zero");
+            raise<std::runtime_error>("Division by zero");
         return static_cast<int64_t>(l % r);
     }
 };
@@ -701,7 +702,7 @@ inline Value makeOperatorResult(Value value)
 template <class _Operator>
 inline Value makeOperatorResult(InvalidOperands)
 {
-    throw InvalidOperandsError(_Operator::name());
+    raise<InvalidOperandsError>(_Operator::name());
 }
 
 }
@@ -725,7 +726,7 @@ struct UnaryOperatorDispatcher
             } catch (...) {
                 ltype = valueType2String(value.type);
             }
-            throw std::runtime_error("Invalid operand "s + ltype +
+            raise<std::runtime_error>("Invalid operand "s + ltype +
                                      " for operator "s + std::string(err.operatorName));
         }
     }
@@ -794,7 +795,7 @@ struct BinaryOperatorDispatcher
                 ltype = valueType2String(lhs.type);
                 rtype = valueType2String(rhs.type);
             }
-            throw std::runtime_error("Invalid operands "s + ltype +
+            raise<std::runtime_error>("Invalid operands "s + ltype +
                                      " and "s + rtype +
                                      " for operator "s + std::string(err.operatorName));
         }

--- a/include/simfil/typed-meta-type.h
+++ b/include/simfil/typed-meta-type.h
@@ -4,6 +4,7 @@
 
 #include "value.h"
 #include "operator.h"
+#include "exception-handler.h"
 
 namespace simfil
 {
@@ -75,7 +76,7 @@ struct TypedMetaType : MetaType
 
     virtual auto unpack(const Type&, std::function<bool(Value)> fn) const -> void
     {
-        throw InvalidOperandsError("...");
+        raise<InvalidOperandsError>("...");
     }
 };
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -12,7 +12,7 @@ Environment::Environment(std::shared_ptr<Fields> fieldNames)
       fieldNames_(std::move(fieldNames))
 {
     if (!fieldNames_)
-        throw std::runtime_error("The string cache must not be null.");
+        raise<std::runtime_error>("The string cache must not be null.");
 
     functions["any"]    = &AnyFn::Fn;
     functions["each"]   = &EachFn::Fn;

--- a/src/exception-handler.cpp
+++ b/src/exception-handler.cpp
@@ -1,0 +1,17 @@
+#include "simfil/exception-handler.h"
+
+simfil::ThrowHandler& simfil::ThrowHandler::instance()
+{
+    static ThrowHandler instance;
+    return instance;
+}
+
+void simfil::ThrowHandler::set(simfil::CustomThrowHandlerType handler)
+{
+    customThrowHandler_ = std::move(handler);
+}
+
+const simfil::CustomThrowHandlerType& simfil::ThrowHandler::get() const
+{
+    return customThrowHandler_;
+}

--- a/src/ext-geo.cpp
+++ b/src/ext-geo.cpp
@@ -427,7 +427,7 @@ auto PointType::unaryOp(std::string_view op, const Point<double>& self) const ->
 {
     COMMON_UNARY_OPS(self);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operand {}", op, ident));
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operand {}", op, ident));
 }
 
 auto PointType::binaryOp(std::string_view op, const Point<double>& p, const Value& r) const -> Value
@@ -456,7 +456,7 @@ auto PointType::binaryOp(std::string_view op, const Point<double>& p, const Valu
             return Value::make(o->contains(p));
     }
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, ident, valueType2String(r.type)));
 }
 
@@ -465,7 +465,7 @@ auto PointType::binaryOp(std::string_view op, const Value& l, const Point<double
     if (op == OperatorEq::name() || op == OperatorNeq::name() || op == OP_NAME_INTERSECTS)
         return binaryOp(op, r, l);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, valueType2String(l.type), ident));
 }
 
@@ -504,7 +504,7 @@ auto BBoxType::unaryOp(std::string_view op, const BBox& self) const -> Value
 {
     COMMON_UNARY_OPS(self);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operand {}", op, ident));
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operand {}", op, ident));
 }
 
 auto BBoxType::binaryOp(std::string_view op, const BBox& b, const Value& r) const -> Value
@@ -546,7 +546,7 @@ auto BBoxType::binaryOp(std::string_view op, const BBox& b, const Value& r) cons
             return Value::make(o->intersects(b));
     }
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, ident, valueType2String(r.type)));
 }
 
@@ -555,7 +555,7 @@ auto BBoxType::binaryOp(std::string_view op, const Value& l, const BBox& r) cons
     if (op == OperatorEq::name() || op == OperatorNeq::name() || op == OP_NAME_INTERSECTS)
         return binaryOp(op, r, l);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, valueType2String(l.type), ident));
 }
 
@@ -588,7 +588,7 @@ auto LineStringType::unaryOp(std::string_view op, const LineString& self) const 
     if (op == OperatorLen::name())
         return Value::make((int64_t)self.points.size());
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operand {}", op, ident));
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operand {}", op, ident));
 }
 
 auto LineStringType::binaryOp(std::string_view op, const LineString& ls, const Value& r) const -> Value
@@ -617,7 +617,7 @@ auto LineStringType::binaryOp(std::string_view op, const LineString& ls, const V
             return Value::make(ls.intersects(*o));
     }
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, ident, valueType2String(r.type)));
 }
 
@@ -626,7 +626,7 @@ auto LineStringType::binaryOp(std::string_view op, const Value& l, const LineStr
     if (op == OperatorEq::name() || op == OperatorNeq::name() || op == OP_NAME_INTERSECTS)
         return binaryOp(op, r, l);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, valueType2String(l.type), ident));
 }
 
@@ -668,7 +668,7 @@ auto PolygonType::unaryOp(std::string_view op, const Polygon& self) const -> Val
     if (op == OperatorLen::name())
         return Value::make(self.polys.size() > 0 ? (int64_t)self.polys[0].points.size() : 0);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operand {}", op, ident));
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operand {}", op, ident));
 }
 
 auto PolygonType::binaryOp(std::string_view op, const Polygon& l, const Value& r) const -> Value
@@ -708,7 +708,7 @@ auto PolygonType::binaryOp(std::string_view op, const Polygon& l, const Value& r
             return Value::make(l.intersects(*o));
     }
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, ident, valueType2String(r.type)));
 }
 
@@ -717,7 +717,7 @@ auto PolygonType::binaryOp(std::string_view op, const Value& l, const Polygon& r
     if (op == OperatorEq::name() || op == OperatorNeq::name() || op == OP_NAME_INTERSECTS)
         return binaryOp(op, r, l);
 
-    throw std::runtime_error(fmt::format("Invalid operator {} for operands {} and {}",
+    raise<std::runtime_error>(fmt::format("Invalid operator {} for operands {} and {}",
                                          op, valueType2String(l.type), ident));
 }
 
@@ -748,7 +748,7 @@ auto GeoFn::ident() const -> const FnInfo&
 auto GeoFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() > 1)
-        throw ArgumentCountError(*this, 0, 1, args.size());
+        raise<ArgumentCountError>(*this, 0, 1, args.size());
 
     if (ctx.phase == Context::Phase::Compilation)
         return res(ctx, Value::undef());
@@ -937,23 +937,23 @@ auto PointFn::ident() const -> const FnInfo&
 auto PointFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() != 2)
-        throw ArgumentCountError(*this, 2, 2, args.size());
+        raise<ArgumentCountError>(*this, 2, 2, args.size());
 
     auto [xok, xval] = util::evalArg1Any(ctx, val, args[0]);
     if (!xok)
-        throw ArgumentValueCountError(*this, 0);
+        raise<ArgumentValueCountError>(*this, 0);
 
     auto [yok, yval] = util::evalArg1Any(ctx, val, args[1]);
     if (!yok)
-        throw ArgumentValueCountError(*this, 1);
+        raise<ArgumentValueCountError>(*this, 1);
 
     auto [xtypeok, x] = getNumeric<double>(xval);
     if (!xtypeok)
-        throw ArgumentTypeError(*this, 0, "numeric", valueType2String(xval.type));
+        raise<ArgumentTypeError>(*this, 0, "numeric", valueType2String(xval.type));
 
     auto [ytypeok, y] = getNumeric<double>(yval);
     if (!ytypeok)
-        throw ArgumentTypeError(*this, 1, "numeric", valueType2String(xval.type));
+        raise<ArgumentTypeError>(*this, 1, "numeric", valueType2String(xval.type));
 
     return res(ctx, meta::PointType::Type.make(x, y));
 }
@@ -976,7 +976,7 @@ auto BBoxFn::eval(Context ctx, Value v, const std::vector<ExprPtr>& args, const 
     if (args.size() == 1) {
         auto [ok, val] = util::evalArg1Any(ctx, v, args[0]);
         if (!ok)
-            throw ArgumentValueCountError(*this, 0);
+            raise<ArgumentValueCountError>(*this, 0);
 
         if (auto o = getObject<BBox>(val, &meta::BBoxType::Type))
             return res(ctx, meta::BBoxType::Type.make(*o));
@@ -992,38 +992,38 @@ auto BBoxFn::eval(Context ctx, Value v, const std::vector<ExprPtr>& args, const 
     if (args.size() == 2) {
         auto [p1ok, p1val] = util::evalArg1Any(ctx, v, args[0]);
         if (!p1ok)
-            throw ArgumentValueCountError(*this, 0);
+            raise<ArgumentValueCountError>(*this, 0);
 
         auto [p2ok, p2val] = util::evalArg1Any(ctx, v, args[1]);
         if (!p2ok)
-            throw ArgumentValueCountError(*this, 1);
+            raise<ArgumentValueCountError>(*this, 1);
 
         Point<double> p1, p2;
         if (auto a1 = getObject<Point<double>>(p1val, &meta::PointType::Type))
             p1 = *a1;
         else
-            throw ArgumentTypeError(*this, 0, "point", valueType2String(p1val.type));
+            raise<ArgumentTypeError>(*this, 0, "point", valueType2String(p1val.type));
         if (auto a2 = getObject<Point<double>>(p2val, &meta::PointType::Type))
             p2 = *a2;
         else
-            throw ArgumentTypeError(*this, 1, "point", valueType2String(p2val.type));
+            raise<ArgumentTypeError>(*this, 1, "point", valueType2String(p2val.type));
 
         return res(ctx, meta::BBoxType::Type.make(p1.x, p1.y, p2.x, p2.y));
     }
 
     /* Construct with 4 values */
     if (args.size() != 4)
-        throw ArgumentCountError(*this, 1, 1, args.size());
+        raise<ArgumentCountError>(*this, 1, 1, args.size());
 
     std::array<double, 4> fargs;
     for (auto i = 0; i < 4; ++i) {
         auto [ok, val] = util::evalArg1Any(ctx, v, args[i]);
         if (!ok)
-            throw ArgumentValueCountError(*this, i);
+            raise<ArgumentValueCountError>(*this, i);
 
         auto [typeok, v] = getNumeric<double>(val);
         if (!typeok)
-            throw ArgumentTypeError(*this, i, "numeric", valueType2String(val.type));
+            raise<ArgumentTypeError>(*this, i, "numeric", valueType2String(val.type));
 
         fargs[i] = v;
     }
@@ -1046,7 +1046,7 @@ auto LineStringFn::ident() const -> const FnInfo&
 auto LineStringFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() < 1)
-        throw ArgumentCountError(*this, 1, 1, args.size());
+        raise<ArgumentCountError>(*this, 1, 1, args.size());
 
     enum {
         None,
@@ -1065,14 +1065,14 @@ auto LineStringFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args
 
             if (auto pt = getObject<Point<double>>(v, &meta::PointType::Type)) {
                 if (mode != Points)
-                    throw std::runtime_error("linestring: Expected value of type point; got "s + v.toString());
+                    raise<std::runtime_error>("linestring: Expected value of type point; got "s + v.toString());
 
                 floats.push_back(pt->x);
                 floats.push_back(pt->y);
             } else {
                 auto [ok, f] = getNumeric<double>(v);
                 if (!ok)
-                    throw std::runtime_error("linestring: Expected numeric value; got "s + v.toString());
+                    raise<std::runtime_error>("linestring: Expected numeric value; got "s + v.toString());
 
                 floats.push_back(f);
             }
@@ -1083,7 +1083,7 @@ auto LineStringFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args
 
     if (mode == Floats)
         if (floats.size() % 2 != 0)
-            throw std::runtime_error("linestring: Uneven number of values");
+            raise<std::runtime_error>("linestring: Uneven number of values");
 
     std::vector<Point<double>> points;
     for (auto i = 1; i < floats.size(); i += 2) {

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -62,18 +62,18 @@ struct ArgParser
         , idx(idx)
     {
         if (args.size() < idx)
-            throw std::runtime_error(fname + ": too few arguments"s);
+            raise<std::runtime_error>(fname + ": too few arguments"s);
     }
 
     auto arg(const char* name, ValueType type, Value& outValue) -> ArgParser&
     {
         if (args.size() <= idx)
-            throw std::runtime_error(fname + ": missing argument "s + name);
+            raise<std::runtime_error>(fname + ": missing argument "s + name);
 
         auto subctx = ctx;
         args[idx]->eval(subctx, value, LambdaResultFn([&, n = 0](Context, Value vv) mutable {
             if (++n > 1)
-                throw std::runtime_error(fname + ": argument "s + name + " must return a single value"s);
+                raise<std::runtime_error>(fname + ": argument "s + name + " must return a single value"s);
 
             if (vv.isa(ValueType::Undef)) {
                 anyUndef = true;
@@ -82,7 +82,7 @@ struct ArgParser
             }
 
             if (!vv.isa(type))
-                throw std::runtime_error(fname + ": invalid value type for argument '"s + name + "'"s);
+                raise<std::runtime_error>(fname + ": invalid value type for argument '"s + name + "'"s);
 
             outValue = std::move(vv);
 
@@ -104,7 +104,7 @@ struct ArgParser
         auto subctx = ctx;
         args[idx]->eval(subctx, value, LambdaResultFn([&, n = 0](Context, Value vv) mutable {
             if (++n > 1)
-                throw std::runtime_error(fname + ": argument "s + name + " must return a single value"s);
+                raise<std::runtime_error>(fname + ": argument "s + name + " must return a single value"s);
 
             if (vv.isa(ValueType::Undef)) {
                 anyUndef = true;
@@ -113,7 +113,7 @@ struct ArgParser
             }
 
             if (!vv.isa(type))
-                throw std::runtime_error(fname + ": invalid value type for argument '"s + name + "'"s);
+                raise<std::runtime_error>(fname + ": invalid value type for argument '"s + name + "'"s);
 
             outValue = std::move(vv);
             if (set) *set = true;
@@ -157,7 +157,7 @@ auto AnyFn::ident() const -> const FnInfo&
 auto AnyFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() < 1)
-        throw std::runtime_error("any(...) expects one argument; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("any(...) expects one argument; got "s + std::to_string(args.size()));
 
     auto subctx = ctx;
     auto result = false; /* At least one value is true  */
@@ -202,7 +202,7 @@ auto EachFn::ident() const -> const FnInfo&
 auto EachFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() < 1)
-        throw std::runtime_error("each(...) expects one argument; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("each(...) expects one argument; got "s + std::to_string(args.size()));
 
     auto subctx = ctx;
     auto result = true; /* All values are true  */
@@ -246,7 +246,7 @@ auto CountFn::ident() const -> const FnInfo&
 auto CountFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() < 1)
-        throw std::runtime_error("count(...) expects one argument; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("count(...) expects one argument; got "s + std::to_string(args.size()));
 
     auto subctx = ctx;
     auto undef = false; /* At least one value is undef */
@@ -351,7 +351,7 @@ auto RangeFn::ident() const -> const FnInfo&
 auto RangeFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() != 2)
-        throw std::runtime_error("range(begin, end) expects 2 arguments; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("range(begin, end) expects 2 arguments; got "s + std::to_string(args.size()));
 
     Value begin = Value::undef();
     Value end = Value::undef();
@@ -548,7 +548,7 @@ auto SumFn::ident() const -> const FnInfo&
 auto SumFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() < 1 || args.size() > 3)
-        throw std::runtime_error("sum: Expected at least 1 argument; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("sum: Expected at least 1 argument; got "s + std::to_string(args.size()));
 
     Value sum = Value::make((int64_t)0);
 
@@ -603,7 +603,7 @@ auto KeysFn::ident() const -> const FnInfo&
 auto KeysFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const ResultFn& res) const -> Result
 {
     if (args.size() != 1)
-        throw std::runtime_error("keys: Expected 1 argument; got "s + std::to_string(args.size()));
+        raise<std::runtime_error>("keys: Expected 1 argument; got "s + std::to_string(args.size()));
 
     auto result = args[0]->eval(ctx, val, LambdaResultFn([&res](Context ctx, Value vv) {
         if (ctx.phase == Context::Phase::Compilation)

--- a/src/model/fields.cpp
+++ b/src/model/fields.cpp
@@ -1,4 +1,5 @@
 #include "simfil/model/fields.h"
+#include "simfil/exception-handler.h"
 
 #include <algorithm>
 #include <bitsery/bitsery.h>
@@ -193,7 +194,7 @@ void Fields::read(std::istream& inputStream)
     }
 
     if (s.adapter().error() != bitsery::ReaderError::NoError) {
-        throw std::runtime_error(fmt::format(
+        raise<std::runtime_error>(fmt::format(
             "Failed to read Fields: Error {}",
             static_cast<std::underlying_type_t<bitsery::ReaderError>>(s.adapter().error())));
     }

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -38,7 +38,7 @@ void Model::resolve(const ModelNode& n, const ResolveFn& cb) const
             cb(ValueNode(n));
             break;
         default:
-            throw std::runtime_error(fmt::format("Bad column reference: col={}", (uint16_t)n.addr_.column()));
+            raise<std::runtime_error>(fmt::format("Bad column reference: col={}", (uint16_t)n.addr_.column()));
     }
 }
 
@@ -174,7 +174,7 @@ void ModelPool::validate() const
 {
     auto errors = checkForErrors();
     if (!errors.empty()) {
-        throw std::runtime_error(
+        raise<std::runtime_error>(
             fmt::format("Model Error(s): {}", fmt::join(errors, ", ")));
     }
 }
@@ -203,7 +203,7 @@ void ModelPool::resolve(ModelNode const& n, ResolveFn const& cb) const
     auto get = [&n](auto const& vec) -> auto& {
         auto idx = n.addr_.index();
         if (idx >= vec.size())
-            throw std::runtime_error(
+            raise<std::runtime_error>(
                 fmt::format(
                     "Bad node reference: col={}, i={}",
                     (uint16_t)n.addr_.column(), idx
@@ -267,7 +267,7 @@ size_t ModelPool::numRoots() const {
 
 ModelNode::Ptr ModelPool::root(size_t const& i) const {
     if (i < 0 || i > impl_->columns_.roots_.size())
-        throw std::runtime_error("Root index does not exist.");
+        raise<std::runtime_error>("Root index does not exist.");
     return ModelNode(shared_from_this(), impl_->columns_.roots_[i]);
 }
 
@@ -365,28 +365,28 @@ shared_model_ptr<Geometry> ModelPool::newGeometryView(
 
 shared_model_ptr<Object> ModelPool::resolveObject(const ModelNode::Ptr& n) const {
     if (n->addr_.column() != Objects)
-        throw std::runtime_error("Cannot cast this node to an object.");
+        raise<std::runtime_error>("Cannot cast this node to an object.");
     return Object(shared_from_this(), n->addr_);
 }
 
 shared_model_ptr<Array> ModelPool::resolveArray(ModelNode::Ptr const& n) const
 {
     if (n->addr_.column() != Arrays)
-        throw std::runtime_error("Cannot cast this node to an array.");
+        raise<std::runtime_error>("Cannot cast this node to an array.");
     return Array(shared_from_this(), n->addr_);
 }
 
 shared_model_ptr<GeometryCollection> ModelPool::resolveGeometryCollection(ModelNode::Ptr const& n) const
 {
     if (n->addr_.column() != GeometryCollections)
-        throw std::runtime_error("Cannot cast this node to a GeometryCollection.");
+        raise<std::runtime_error>("Cannot cast this node to a GeometryCollection.");
     return GeometryCollection(shared_from_this(), n->addr_);
 }
 
 shared_model_ptr<Geometry> ModelPool::resolveGeometry(ModelNode::Ptr const& n) const
 {
     if (n->addr_.column() != Geometries)
-        throw std::runtime_error("Cannot cast this node to a Geometry.");
+        raise<std::runtime_error>("Cannot cast this node to a Geometry.");
     auto& geomData = impl_->columns_.geom_[n->addr_.index()];
     return Geometry(&geomData, shared_from_this(), n->addr_);
 }
@@ -429,7 +429,7 @@ void ModelPool::read(std::istream& inputStream) {
     bitsery::Deserializer<bitsery::InputStreamAdapter> s(inputStream);
     impl_->readWrite(s);
     if (s.adapter().error() != bitsery::ReaderError::NoError) {
-        throw std::runtime_error(fmt::format(
+        raise<std::runtime_error>(fmt::format(
             "Failed to read ModelPool: Error {}",
             static_cast<std::underlying_type_t<bitsery::ReaderError>>(s.adapter().error())));
     }

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -367,7 +367,7 @@ ModelNode::Ptr GeometryCollection::at(int64_t i) const {
         return singleGeomEntry->at(i);
     if (i == 0) return ValueNode(GeometryCollectionStr, model_);
     if (i == 1) return ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Arrays, addr_.index()});
-    throw std::out_of_range("geom collection: Out of range.");
+    raise<std::out_of_range>("geom collection: Out of range.");
 }
 
 uint32_t GeometryCollection::size() const {
@@ -389,7 +389,7 @@ FieldId GeometryCollection::keyAt(int64_t i) const {
         return singleGeomEntry->keyAt(i);
     if (i == 0) return Fields::Type;
     if (i == 1) return Fields::Geometries;
-    throw std::out_of_range("geom collection: Out of range.");
+    raise<std::out_of_range>("geom collection: Out of range.");
 }
 
 shared_model_ptr<Geometry> GeometryCollection::newGeometry(Geometry::GeomType type, size_t initialCapacity) {
@@ -449,7 +449,7 @@ ModelNode::Ptr Geometry::at(int64_t i) const {
             model_);
     if (i == 1) return ModelNode::Ptr::make(
         model_, ModelNodeAddress{ModelPool::PointBuffers, addr_.index()});
-    throw std::out_of_range("geom: Out of range.");
+    raise<std::out_of_range>("geom: Out of range.");
 }
 
 uint32_t Geometry::size() const {
@@ -465,13 +465,13 @@ ModelNode::Ptr Geometry::get(const FieldId& f) const {
 FieldId Geometry::keyAt(int64_t i) const {
     if (i == 0) return Fields::Type;
     if (i == 1) return Fields::Coordinates;
-    throw std::out_of_range("geom: Out of range.");
+    raise<std::out_of_range>("geom: Out of range.");
 }
 
 void Geometry::append(geo::Point<double> const& p)
 {
     if (geomData_->isView_)
-        throw std::runtime_error("Cannot append to geometry view.");
+        raise<std::runtime_error>("Cannot append to geometry view.");
 
     auto& geomData = geomData_->detail_.geom_;
 
@@ -538,7 +538,7 @@ VertexBufferNode::VertexBufferNode(Geometry::Data const* geomData, ModelConstPtr
 
         auto maxSize = 1 + storage_->size(baseGeomData_->detail_.geom_.vertexArray_);
         if (offset_ + size_ > maxSize)
-            throw std::runtime_error("Geometry view is out of bounds.");
+            raise<std::runtime_error>("Geometry view is out of bounds.");
     }
     else {
         // Just get the correct length.
@@ -553,7 +553,7 @@ ValueType VertexBufferNode::type() const {
 
 ModelNode::Ptr VertexBufferNode::at(int64_t i) const {
     if (i < 0 || i >= size())
-        throw std::out_of_range("vertex-buffer: Out of range.");
+        raise<std::out_of_range>("vertex-buffer: Out of range.");
     i += offset_;
     return ModelNode::Ptr::make(model_, ModelNodeAddress{ModelPool::Points, baseGeomAddress_.index()}, i);
 }
@@ -591,7 +591,7 @@ VertexNode::VertexNode(ModelNode const& baseNode, Geometry::Data const* geomData
     : MandatoryModelPoolNodeBase(baseNode)
 {
     if (geomData->isView_)
-        throw std::runtime_error("Point must be constructed through VertexBuffer which resolves view to geometry.");
+        raise<std::runtime_error>("Point must be constructed through VertexBuffer which resolves view to geometry.");
     auto i = std::get<int64_t>(data_);
     point_ = geomData->detail_.geom_.offset_;
     if (i > 0)
@@ -606,7 +606,7 @@ ModelNode::Ptr VertexNode::at(int64_t i) const {
     if (i == 0) return shared_model_ptr<ValueNode>::make(point_.x, model_);
     if (i == 1) return shared_model_ptr<ValueNode>::make(point_.y, model_);
     if (i == 2) return shared_model_ptr<ValueNode>::make(point_.z, model_);
-    throw std::out_of_range("vertex: Out of range.");
+    raise<std::out_of_range>("vertex: Out of range.");
 }
 
 uint32_t VertexNode::size() const {
@@ -624,7 +624,7 @@ FieldId VertexNode::keyAt(int64_t i) const {
     if (i == 0) return Fields::Lon;
     if (i == 1) return Fields::Lat;
     if (i == 2) return Fields::Elevation;
-    throw std::out_of_range("vertex: Out of range.");
+    raise<std::out_of_range>("vertex: Out of range.");
 }
 
 bool VertexNode::iterate(const IterCallback& cb) const

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -47,14 +47,14 @@ auto Parser::consume() -> const Token&
 {
     if (!eof())
         return tokens_[pos_++];
-    throw std::runtime_error("Parser EOF (consume)");
+    raise<std::runtime_error>("Parser EOF (consume)");
 }
 
 auto Parser::current() const -> const Token&
 {
     if (!eof())
         return tokens_[pos_];
-    throw std::runtime_error("Parser EOF (current)");
+    raise<std::runtime_error>("Parser EOF (current)");
 }
 
 auto Parser::precedence(Token token) const -> int
@@ -70,7 +70,7 @@ auto Parser::parseInfix(ExprPtr left, int prec) -> ExprPtr
         auto token = consume();
         auto parser = findInfixParser(token);
         if (!parser)
-            throw std::runtime_error("Error parsing infix expression");
+            raise<std::runtime_error>("Error parsing infix expression");
 
         left = parser->parse(*this, std::move(left), token);
     }
@@ -83,7 +83,7 @@ auto Parser::parsePrecedence(int precedence, bool optional) -> ExprPtr
     auto parser = findPrefixParser(token);
     if (!parser) {
         if (!optional)
-            throw std::runtime_error("Error parsing left expression");
+            raise<std::runtime_error>("Error parsing left expression");
         return nullptr;
     }
     consume();
@@ -101,12 +101,12 @@ auto Parser::parseTo(Token::Type type) -> ExprPtr
 {
     auto expr = parse();
     if (!expr)
-        throw std::runtime_error("Expected expression"s);
+        raise<std::runtime_error>("Expected expression"s);
 
     if (!match(type)) {
         auto msg = "Expected "s + Token::toString(type) +
             " got "s + current().toString();
-        throw std::runtime_error(msg);
+        raise<std::runtime_error>(msg);
     }
     consume();
 
@@ -129,7 +129,7 @@ auto Parser::parseList(Token::Type stop) -> std::vector<ExprPtr>
             if (match(Token::COMMA))
                 consume();
             else
-                throw std::runtime_error("Expected "s + Token::toString(stop) +
+                raise<std::runtime_error>("Expected "s + Token::toString(stop) +
                                          " got "s + current().toString());
         } else {
             consume();

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -77,7 +77,7 @@ static auto expect(const ExprPtr& e, Type... types)
     };
 
     if (!e)
-        throw std::runtime_error("Expected expression"s);
+        raise<std::runtime_error>("Expected expression"s);
 
     if constexpr (sizeof...(types) >= 1) {
         Expr::Type list[] = {types...};
@@ -93,7 +93,7 @@ static auto expect(const ExprPtr& e, Type... types)
             typeNames += type2str(list[i]);
         }
 
-        throw std::runtime_error("Expected "s + typeNames + " got "s + type2str(e->type()));
+        raise<std::runtime_error>("Expected "s + typeNames + " got "s + type2str(e->type()));
     }
 }
 
@@ -482,7 +482,7 @@ public:
         if (!fn_)
             fn_ = ctx.env->findFunction(name_);
         if (!fn_)
-            throw std::runtime_error("Unknown function "s + name_);
+            raise<std::runtime_error>("Unknown function "s + name_);
 
         auto anyval = false;
         auto result = fn_->eval(ctx, val, args_, LambdaResultFn([&res, &anyval](Context ctx, Value vv) {
@@ -711,7 +711,7 @@ public:
                 return res(ctx, obj.meta->unaryOp(ident_, obj));
             }
 
-            throw std::runtime_error(fmt::format("Invalid operator '{}' for value of type {}",
+            raise<std::runtime_error>(fmt::format("Invalid operator '{}' for value of type {}",
                                                  ident_, valueType2String(val.type)));
         }));
     }
@@ -756,7 +756,7 @@ public:
                     return res(ctx, obj.meta->binaryOp(ident_, lval, obj));
                 }
 
-                throw std::runtime_error(fmt::format("Invalid operator '{}' for values of type {} and {}",
+                raise<std::runtime_error>(fmt::format("Invalid operator '{}' for values of type {} and {}",
                                                      ident_, valueType2String(lval.type), valueType2String(rval.type)));
             }));
         }));
@@ -940,7 +940,7 @@ public:
             return std::make_unique<ConstExpr>(Value::null());
 
         if (type.type != Token::Type::WORD)
-            throw std::runtime_error("'as' expected typename got "s + type.toString());
+            raise<std::runtime_error>("'as' expected typename got "s + type.toString());
 
         auto name = std::get<std::string>(type.value);
         return simplifyOrForward(p.env, [&]() -> ExprPtr {
@@ -953,7 +953,7 @@ public:
             if (name == strings::TypenameString)
                 return std::make_unique<UnaryExpr<OperatorAsString>>(std::move(left));
 
-            throw std::runtime_error("Invalid type name for cast '"s + name + "'"s);
+            raise<std::runtime_error>("Invalid type name for cast '"s + name + "'"s);
         }());
     }
 
@@ -1312,14 +1312,14 @@ auto compile(Environment& env, std::string_view sv, bool any) -> ExprPtr
     }();
 
     if (!p.match(Token::Type::NIL))
-        throw std::runtime_error("Expected end-of-input; got "s + p.current().toString());
+        raise<std::runtime_error>("Expected end-of-input; got "s + p.current().toString());
     return expr;
 }
 
 auto eval(Environment& env, const Expr& ast, ModelPool const& model, size_t rootIndex) -> std::vector<Value>
 {
     if (env.fieldNames() != model.fieldNames())
-        throw std::runtime_error("Environment must use same field name resource as model.");
+        raise<std::runtime_error>("Environment must use same field name resource as model.");
 
     return eval(env, ast, *model.root(rootIndex));
 }
@@ -1327,7 +1327,7 @@ auto eval(Environment& env, const Expr& ast, ModelPool const& model, size_t root
 auto eval(Environment& env, const Expr& ast, const ModelNode& node) -> std::vector<Value>
 {
     if (!node.model_)
-        throw std::runtime_error("ModelNode must have a model!");
+        raise<std::runtime_error>("ModelNode must have a model!");
 
     Context ctx(&env);
 

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
 
 #include "simfil/token.h"
+#include "simfil/exception-handler.h"
 
 #include <cctype>
 #include <cmath>
@@ -165,7 +166,7 @@ struct Scanner
         if (pos_ < orig_.size())
             msg += " ("s + std::string(orig_.substr(pos_)) + ")"s;
 
-        throw std::runtime_error(std::move(msg));
+        raise<std::runtime_error>(std::move(msg));
     }
 
     auto pos() const

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -35,7 +35,7 @@ auto IRangeType::unaryOp(std::string_view op, const IRange& self) const -> Value
     if (op == OperatorLen::name())
         return Value::make((int64_t)self.high() - self.low());
 
-    throw InvalidOperandsError(op);
+    raise<InvalidOperandsError>(op);
 }
 
 auto IRangeType::binaryOp(std::string_view op, const IRange& l, const Value& r) const -> Value
@@ -62,7 +62,7 @@ auto IRangeType::binaryOp(std::string_view op, const IRange& l, const Value& r) 
             return Value::make(l.begin == o->begin && l.end == o->end);
     }
 
-    throw InvalidOperandsError(op);
+    raise<InvalidOperandsError>(op);
 }
 
 auto IRangeType::binaryOp(std::string_view op, const Value& l, const IRange& r) const -> Value
@@ -70,7 +70,7 @@ auto IRangeType::binaryOp(std::string_view op, const Value& l, const IRange& r) 
     if (op == OperatorEq::name() || op == OperatorNeq::name())
         return binaryOp(op, r, l);
 
-    throw InvalidOperandsError(op);
+    raise<InvalidOperandsError>(op);
 }
 
 auto IRangeType::unpack(const IRange& self, std::function<bool(Value)> res) const -> void

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -1,4 +1,5 @@
 #include "simfil/simfil.h"
+#include "simfil/exception-handler.h"
 #include "simfil/model/json.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -490,4 +491,19 @@ TEST_CASE("Switch Model Fields Dict", "[model.setfieldnames]")
     REQUIRE(pool->fieldNames() == oldFieldDict);
     REQUIRE_NOTHROW(pool->validate());
     REQUIRE(oldFieldDict->size() != newFieldDict->size());
+}
+
+TEST_CASE("Exception Handler", "[exception]")
+{
+    bool handlerCalled = false;
+    std::string message;
+
+    simfil::ThrowHandler::instance().set([&](auto&& type, auto&& msg){
+        handlerCalled = true;
+        message = msg;
+    });
+
+    REQUIRE_THROWS(raise<std::runtime_error>("TestMessage"));
+    REQUIRE(handlerCalled);
+    REQUIRE(message == "TestMessage");
 }

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -506,4 +506,7 @@ TEST_CASE("Exception Handler", "[exception]")
     REQUIRE_THROWS(raise<std::runtime_error>("TestMessage"));
     REQUIRE(handlerCalled);
     REQUIRE(message == "TestMessage");
+
+    // Reset throw-handler, so it isn't erroneously used by other tests.
+    simfil::ThrowHandler::instance().set(nullptr);
 }


### PR DESCRIPTION
We need some way to read simfil exceptions in WASM without using the native WASM exception support. The reason is, that native WASM exceptions disable JIT execution once they are thrown, which effectively makes the page unusable until it is reloaded (even if the exception is caught in WASM).

Used for Erdblick PR: https://github.com/ndsev/erdblick/pull/96
