### PR TITLE
Fix ModelNode Field Iterator

### DIFF
--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -261,7 +261,7 @@ struct ModelNode
         FieldIterator& operator++() { ++index; return *this; }
         bool operator==(const FieldIterator& other) const { return index == other.index; }
         bool operator!=(const FieldIterator& other) const { return index != other.index; }
-        std::pair<FieldId, Ptr> operator*() const { return std::make_pair(parent->keyAt(index), parent->get(parent->keyAt(index))); }
+        std::pair<FieldId, Ptr> operator*() const { return std::make_pair(parent->keyAt(index), parent->at(index)); }
     };
     class FieldRange
     {


### PR DESCRIPTION
For objects with multiple values for the same key, it would only return the first value. It is also now O(1) instead of O(n).