### PR TITLE
Support Model JSON Serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(simfil ${LIBRARY_TYPE}
   src/exception-handler.cpp
   src/model/model.cpp
   src/model/nodes.cpp
-  src/model/fields.cpp)
+  src/model/string-pool.cpp)
 
 target_sources(simfil PUBLIC
   FILE_SET public_headers
@@ -75,7 +75,7 @@ target_sources(simfil PUBLIC
       include/simfil/exception-handler.h
 
       include/simfil/model/arena.h
-      include/simfil/model/fields.h
+      include/simfil/model/string-pool.h
       include/simfil/model/model.h
       include/simfil/model/nodes.h
       include/simfil/model/bitsery-traits.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if (SIMFIL_WITH_MODEL_JSON)
         include/simfil/model/json.h)
 
   target_link_libraries(simfil
-    PRIVATE
+    PUBLIC
       nlohmann_json::nlohmann_json)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ target_link_libraries(<my-app> PUBLIC simfil)
 ```c++
 #include "simfil/simfil.h"
 #include "simfil/model/model.h"
-#include "simfil/model/fields.h"
+#include "simfil/model/string-pool.h"
 
 // Shared string pool used for string interning
-auto strings = std::make_shared<simfil::Fields>();
+auto strings = std::make_shared<simfil::StringPool>();
 
 // Declare a model with one object
 auto model = std::make_shared<simfil::ModelPool>(strings);

--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -3,12 +3,12 @@
 
 #include "simfil/simfil.h"
 #include "simfil/model/model.h"
-#include "simfil/model/fields.h"
+#include "simfil/model/string-pool.h"
 
 int main()
 {
     // Shared string pool.
-    auto strings = std::make_shared<simfil::Fields>();
+    auto strings = std::make_shared<simfil::StringPool>();
 
     // Data model pool
     auto model = std::make_shared<simfil::ModelPool>(strings);

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -34,11 +34,11 @@ public:
     /**
      * Construct a SIMFIL execution environment with a string cache,
      * which is used to map field names to short integer IDs.
-     * @param fieldNames The string cache used by this environment.
+     * @param strings The string cache used by this environment.
      *  Must be the same cache that is also used by ModelPools which
      *  are queried using this environment.
      */
-    explicit Environment(std::shared_ptr<Fields> fieldNames);
+    explicit Environment(std::shared_ptr<StringPool> strings);
 
     /**
      * Constructor for instantiating an environment explicitly with
@@ -78,7 +78,8 @@ public:
      * Obtain a strong reference to this environment's string cache.
      * Guaranteed not-null.
      */
-    auto fieldNames() const -> std::shared_ptr<Fields>;
+    [[nodiscard]]
+    auto strings() const -> std::shared_ptr<StringPool>;
 
 public:
     std::unique_ptr<std::mutex> warnMtx;
@@ -91,7 +92,7 @@ public:
     std::map<std::string, const Function*> functions;
 
     Debug* debug = nullptr;
-    std::shared_ptr<Fields> fieldNames_;
+    std::shared_ptr<StringPool> stringPool;
 };
 
 /**

--- a/include/simfil/model/fields.h
+++ b/include/simfil/model/fields.h
@@ -53,7 +53,7 @@ struct Fields
     ///  nullopt if the given ID is invalid.
     /// Virtual to allow defining an inherited StringPool which understands
     /// additional StaticFieldIds.
-    virtual std::optional<std::string_view> resolve(FieldId const& id);
+    virtual std::optional<std::string_view> resolve(FieldId const& id) const;
 
     /// Get highest stored field id
     FieldId highest() const;

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -159,7 +159,7 @@ public:
     std::shared_ptr<StringPool> strings() const;
 
     /**
-     * Change the fields dict of this model to a different one.
+     * Change the string pool of this model to a different one.
      * Note: This will potentially create new field entries in the newDict,
      * for field names which were not there before.
      */

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -47,25 +47,29 @@ public:
         T fn_;
     };
 
-    /// Virtual destructor to allow polymorphism
+    /** Virtual destructor to allow polymorphism */
     virtual ~Model() = default;
 
-    /// Get a callback with the actual class of the given node.
-    /// This facilitates the Virtual Function Table role of the Model.
+    /**
+     *  Get a callback with the actual class of the given node.
+     *  This facilitates the Virtual Function Table role of the Model.
+     */
     virtual void resolve(ModelNode const& n, ResolveFn const& cb) const;
 
-    /// Add a small scalar value and get its model node view
+    /** Add a small scalar value and get its model node view */
     ModelNode::Ptr newSmallValue(bool value);
     ModelNode::Ptr newSmallValue(int16_t value);
     ModelNode::Ptr newSmallValue(uint16_t value);
 
-    /// Lookup a field name for a field-id.
-    ///
-    /// This is in the base Model class to allow JSON
-    /// serialization, without having to downcast to ModelPool;
-    /// which contains the `fieldNames()` function. The base
-    /// implementation returns an unset optional.
-    virtual std::optional<std::string_view> lookupFieldId(FieldId) const;
+    /**
+     * Lookup a field name for a field-id.
+     *
+     * This is in the base Model class to allow JSON
+     * serialization, without having to downcast to ModelPool;
+     * which contains the `fieldNames()` function. The base
+     * implementation returns an unset optional.
+     */
+    virtual std::optional<std::string_view> lookupFieldId(FieldId id) const;
 };
 
 /**
@@ -80,8 +84,8 @@ class ModelPool : public Model
 public:
     /**
      * The pool consists of multiple ModelNode columns,
-     *  each for a different data type. Each column
-     *  is identified by a static column ID.
+     * each for a different data type. Each column
+     * is identified by a static column ID.
      */
     enum ColumnId : uint8_t {
         Objects = FirstNontrivialColumnId,
@@ -93,69 +97,79 @@ public:
         FirstCustomColumnId = 128,
     };
 
-    /// Default ctor with own string storage
+    /** Default ctor with own string storage */
     ModelPool();
     ~ModelPool();
 
-    /// Ctor with shared string storage
+    /** Ctor with shared string storage */
     explicit ModelPool(std::shared_ptr<Fields> stringStore);
 
-    /// Validate that all internal string/node references are valid
-    /// Returns a list of found errors.
+    /**
+     * Validate that all internal string/node references are valid
+     * Returns a list of found errors.
+     */
     virtual std::vector<std::string> checkForErrors() const;
 
-    /// Get a callback with the actual class of the given node.
-    /// This facilitates the Virtual Function Table role of the ModelPool.
+    /**
+     * Get a callback with the actual class of the given node.
+     * This facilitates the Virtual Function Table role of the ModelPool.
+     */
     void resolve(ModelNode const& n, ResolveFn const& cb) const override;
 
-    /// Clear all columns and roots
+    /** Clear all columns and roots */
     virtual void clear();
 
-    /// Check for errors, throw if there are any
+    /** Check for errors, throw if there are any */
     void validate() const;
 
-    /// Get number of root nodes
+    /** Get number of root nodes */
     [[nodiscard]] size_t numRoots() const;
 
-    /// Get specific root node
+    /** Get specific root node */
     [[nodiscard]] ModelNode::Ptr root(size_t const& i) const;
 
-    /// Designate a model node index as a root
+    /** Designate a model node index as a root */
     void addRoot(ModelNode::Ptr const& rootNode);
 
-    /// Adopt members from the given vector and obtain a new object
-    ///  model index which has these members.
+    /**
+     * Adopt members from the given vector and obtain a new object
+     * model index which has these members.
+     */
     shared_model_ptr<Object> newObject(size_t initialFieldCapacity = 2);
 
-    /// Adopt members from the given vector and obtain a new array
-    ///  model index which has these members.
+    /**
+     * Adopt members from the given vector and obtain a new array
+     * model index which has these members.
+     */
     shared_model_ptr<Array> newArray(size_t initialFieldCapacity = 2);
 
-    /// Add a scalar value and get its new model node index.
+    /** Add a scalar value and get its new model node index. */
     ModelNode::Ptr newValue(int64_t const& value);
     ModelNode::Ptr newValue(double const& value);
     ModelNode::Ptr newValue(std::string_view const& value);
 
-    /// Node-type-specific resolve-functions
+    /** Node-type-specific resolve-functions */
     shared_model_ptr<Object> resolveObject(ModelNode::Ptr const& n) const;
     shared_model_ptr<Array> resolveArray(ModelNode::Ptr const& n) const;
 
-    /// Access the field name storage
+    /** Access the field name storage */
     std::shared_ptr<Fields> fieldNames() const;
 
-    /// Change the fields dict of this model to a different one.
-    /// Note: This will potentially create new field entries in the newDict,
-    /// for field names which were not there before.
+    /**
+     * Change the fields dict of this model to a different one.
+     * Note: This will potentially create new field entries in the newDict,
+     * for field names which were not there before.
+     */
     virtual void setFieldNames(std::shared_ptr<simfil::Fields> const& newDict);
 
-    std::optional<std::string_view> lookupFieldId(FieldId) const override;
+    std::optional<std::string_view> lookupFieldId(FieldId id) const override;
 
-    /// Serialization
+    /** Serialization */
     virtual void write(std::ostream& outputStream);
     virtual void read(std::istream& inputStream);
 
 #if defined(SIMFIL_WITH_MODEL_JSON)
-    /// JSON Serialization
+    /** JSON Serialization */
     virtual nlohmann::json toJson() const;
 #endif
 
@@ -163,8 +177,9 @@ protected:
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
-    /// Protected object/array member storage access,
-    /// so derived ModelPools can create Object/Array-derived nodes.
+    /* Protected object/array member storage access,
+     * so derived ModelPools can create Object/Array-derived nodes.
+     */
     Object::Storage& objectMemberStorage();
     Array::Storage& arrayMemberStorage();
 };

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -177,7 +177,8 @@ protected:
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
-    /* Protected object/array member storage access,
+    /**
+     * Protected object/array member storage access,
      * so derived ModelPools can create Object/Array-derived nodes.
      */
     Object::Storage& objectMemberStorage();

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -1,10 +1,13 @@
 // Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
-
 #pragma once
 
-#include "simfil/value.h"
+#include "simfil/model/fields.h"
+#if defined(SIMFIL_WITH_MODEL_JSON)
+#  include "nlohmann/json.hpp"
+#endif
 
 #include <memory>
+#include <string_view>
 #include <vector>
 #include <istream>
 #include <ostream>
@@ -55,6 +58,14 @@ public:
     ModelNode::Ptr newSmallValue(bool value);
     ModelNode::Ptr newSmallValue(int16_t value);
     ModelNode::Ptr newSmallValue(uint16_t value);
+
+    /// Lookup a field name for a field-id.
+    ///
+    /// This is in the base Model class to allow JSON
+    /// serialization, without having to downcast to ModelPool;
+    /// which contains the `fieldNames()` function. The base
+    /// implementation returns an unset optional.
+    virtual std::optional<std::string_view> lookupFieldId(FieldId) const;
 };
 
 /**
@@ -137,9 +148,16 @@ public:
     /// for field names which were not there before.
     virtual void setFieldNames(std::shared_ptr<simfil::Fields> const& newDict);
 
+    std::optional<std::string_view> lookupFieldId(FieldId) const override;
+
     /// Serialization
     virtual void write(std::ostream& outputStream);
     virtual void read(std::istream& inputStream);
+
+#if defined(SIMFIL_WITH_MODEL_JSON)
+    /// JSON Serialization
+    virtual nlohmann::json toJson() const;
+#endif
 
 protected:
     struct Impl;

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -1,7 +1,7 @@
 // Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
 #pragma once
 
-#include "simfil/model/fields.h"
+#include "simfil/model/string-pool.h"
 #if defined(SIMFIL_WITH_MODEL_JSON)
 #  include "nlohmann/json.hpp"
 #endif
@@ -66,10 +66,10 @@ public:
      *
      * This is in the base Model class to allow JSON
      * serialization, without having to downcast to ModelPool;
-     * which contains the `fieldNames()` function. The base
+     * which contains the `strings()` function. The base
      * implementation returns an unset optional.
      */
-    virtual std::optional<std::string_view> lookupFieldId(FieldId id) const;
+    virtual std::optional<std::string_view> lookupStringId(StringId id) const;
 };
 
 /**
@@ -102,7 +102,7 @@ public:
     ~ModelPool();
 
     /** Ctor with shared string storage */
-    explicit ModelPool(std::shared_ptr<Fields> stringStore);
+    explicit ModelPool(std::shared_ptr<StringPool> stringStore);
 
     /**
      * Validate that all internal string/node references are valid
@@ -149,20 +149,23 @@ public:
     ModelNode::Ptr newValue(std::string_view const& value);
 
     /** Node-type-specific resolve-functions */
+    [[nodiscard]]
     shared_model_ptr<Object> resolveObject(ModelNode::Ptr const& n) const;
+    [[nodiscard]]
     shared_model_ptr<Array> resolveArray(ModelNode::Ptr const& n) const;
 
     /** Access the field name storage */
-    std::shared_ptr<Fields> fieldNames() const;
+    [[nodiscard]]
+    std::shared_ptr<StringPool> strings() const;
 
     /**
      * Change the fields dict of this model to a different one.
      * Note: This will potentially create new field entries in the newDict,
      * for field names which were not there before.
      */
-    virtual void setFieldNames(std::shared_ptr<simfil::Fields> const& newDict);
+    virtual void setStrings(std::shared_ptr<simfil::StringPool> const& strings);
 
-    std::optional<std::string_view> lookupFieldId(FieldId id) const override;
+    std::optional<std::string_view> lookupStringId(StringId id) const override;
 
     /** Serialization */
     virtual void write(std::ostream& outputStream);

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -9,6 +9,10 @@
 
 #include <sfl/small_vector.hpp>
 
+#if defined(SIMFIL_WITH_MODEL_JSON)
+#  include "nlohmann/json.hpp"
+#endif
+
 namespace bitsery {
     // Pre-declare bitsery protected member accessor.
     class Access;
@@ -293,6 +297,10 @@ struct ModelNode
     };
     [[nodiscard]] ChildIterator begin() const { return {0, this}; }
     [[nodiscard]] ChildIterator end() const { return {size(), this}; }
+
+#if defined(SIMFIL_WITH_MODEL_JSON)
+    [[nodiscard]] virtual nlohmann::json toJson() const;
+#endif
 
 protected:
     ModelNode() = default;

--- a/include/simfil/model/string-pool.h
+++ b/include/simfil/model/string-pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 #include <unordered_map>
 #include <shared_mutex>
 #include <atomic>
@@ -14,6 +15,7 @@ namespace simfil
 {
 
 using StringId = uint16_t;
+static_assert(std::is_unsigned_v<StringId>, "StringId must be unsigned!");
 
 /**
  * Fast and efficient case-insensitive string interner,

--- a/include/simfil/model/string-pool.h
+++ b/include/simfil/model/string-pool.h
@@ -1,8 +1,7 @@
 #pragma once
 
+#include <cstddef>
 #include <unordered_map>
-#include <deque>
-#include <mutex>
 #include <shared_mutex>
 #include <atomic>
 #include <optional>
@@ -14,15 +13,15 @@
 namespace simfil
 {
 
-using FieldId = uint16_t;
+using StringId = uint16_t;
 
 /**
- * Fast and efficient case-insensitive field name storage -
- *  used to store object keys.
+ * Fast and efficient case-insensitive string interner,
+ * used to store object keys.
  */
-struct Fields
+struct StringPool
 {
-    enum StaticFieldIds: FieldId {
+    enum StaticStringIds : StringId {
         Empty = 0,
         OverlaySum,
         OverlayValue,
@@ -33,30 +32,30 @@ struct Fields
     };
 
     /// Default constructor initializes strings for static Ids
-    Fields();
+    StringPool();
 
     /// Copy constructor
-    Fields(Fields const&);
+    StringPool(StringPool const& other);
 
     /// Virtual destructor to allow polymorphism
-    virtual ~Fields() = default;
+    virtual ~StringPool() = default;
 
     /// Use this function to lookup a stored string, or insert it
     /// if it doesn't exist yet.
-    FieldId emplace(std::string_view const& str);
+    StringId emplace(std::string_view const& str);
 
     /// Returns the ID of the given string, or `Empty` if
     /// no such string was ever inserted.
-    FieldId get(std::string_view const& str);
+    StringId get(std::string_view const& str);
 
     /// Get the actual string for the given ID, or
     ///  nullopt if the given ID is invalid.
     /// Virtual to allow defining an inherited StringPool which understands
-    /// additional StaticFieldIds.
-    virtual std::optional<std::string_view> resolve(FieldId const& id) const;
+    /// additional StaticStringIds.
+    virtual std::optional<std::string_view> resolve(StringId const& id) const;
 
     /// Get highest stored field id
-    FieldId highest() const;
+    StringId highest() const;
 
     /// Get stats
     size_t size() const;
@@ -65,18 +64,18 @@ struct Fields
     size_t misses() const;
 
     /// Add a static key-string mapping - Warning: Not thread-safe.
-    void addStaticKey(FieldId k, std::string const& v);
+    void addStaticKey(StringId k, std::string const& v);
 
     /// Serialization - write to stream, starting from a specific
     ///  id offset if necessary (for partial serialisation).
-    virtual void write(std::ostream& outputStream, FieldId offset=0) const; // NOLINT
+    virtual void write(std::ostream& outputStream, StringId offset = {}) const; // NOLINT
     virtual void read(std::istream& inputStream);
 
 private:
     mutable std::shared_mutex stringStoreMutex_;
-    std::unordered_map<std::string, FieldId> idForString_;
-    std::unordered_map<FieldId, std::string> stringForId_;
-    FieldId nextId_ = FirstDynamicId;
+    std::unordered_map<std::string, StringId> idForString_;
+    std::unordered_map<StringId, std::string> stringForId_;
+    StringId nextId_ = FirstDynamicId;
     std::atomic_int64_t byteSize_{0};
     std::atomic_int64_t cacheHits_{0};
     std::atomic_int64_t cacheMisses_{0};

--- a/include/simfil/overlay.h
+++ b/include/simfil/overlay.h
@@ -10,7 +10,7 @@ namespace simfil
 struct OverlayNodeStorage final : public Model
 {
     Value value_;
-    std::map<FieldId, Value> overlayChildren_;
+    std::map<StringId, Value> overlayChildren_;
 
     explicit OverlayNodeStorage(Value const& val) : value_(val) {} // NOLINT
 
@@ -24,12 +24,12 @@ class OverlayNode final : public MandatoryDerivedModelNodeBase<OverlayNodeStorag
 public:
     explicit OverlayNode(Value const& val);
     explicit OverlayNode(ModelNode const& n);
-    auto set(FieldId const& key, Value const& child) -> void;
+    auto set(StringId const& key, Value const& child) -> void;
     [[nodiscard]] ScalarValueType value() const override;
     [[nodiscard]] ValueType type() const override;
-    [[nodiscard]] ModelNode::Ptr get(const FieldId& key) const override;
+    [[nodiscard]] ModelNode::Ptr get(const StringId& key) const override;
     [[nodiscard]] ModelNode::Ptr at(int64_t i) const override;
-    [[nodiscard]] FieldId keyAt(int64_t i) const override;
+    [[nodiscard]] StringId keyAt(int64_t i) const override;
     [[nodiscard]] uint32_t size() const override;
     [[nodiscard]] bool iterate(IterCallback const& cb) const override;
 };

--- a/include/simfil/value.h
+++ b/include/simfil/value.h
@@ -4,10 +4,6 @@
 #include <string>
 #include <cstdint>
 #include <cassert>
-#include <functional>
-#include <optional>
-#include <memory>
-#include <vector>
 
 #include "model/nodes.h"
 #include "transient.h"
@@ -66,9 +62,13 @@ struct ValueToString
         return "<transient>"s;
     }
 
-    auto operator()(const ModelNode&) const
+    auto operator()(const ModelNode& node) const
     {
-        return "model"s;
+#if defined(SIMFIL_WITH_MODEL_JSON)
+        return nlohmann::to_string(node.toJson());
+#else
+        return "<model>"s;
+#endif
     }
 };
 }

--- a/include/simfil/value.h
+++ b/include/simfil/value.h
@@ -62,7 +62,7 @@ struct ValueToString
         return "<transient>"s;
     }
 
-    auto operator()(const ModelNode& node) const
+    auto operator()([[maybe_unused]] const ModelNode& node) const
     {
 #if defined(SIMFIL_WITH_MODEL_JSON)
         return nlohmann::to_string(node.toJson());

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        simfil::Environment env(model->fieldNames());
+        simfil::Environment env(model->strings());
         simfil::ExprPtr expr;
         try {
             expr = simfil::compile(env, cmd, options.auto_any);

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -4,13 +4,12 @@
 namespace simfil
 {
 
-Environment::Environment(std::shared_ptr<Fields> fieldNames)
+Environment::Environment(std::shared_ptr<StringPool> strings)
     : warnMtx(std::make_unique<std::mutex>())
     , traceMtx(std::make_unique<std::mutex>())
-    ,
-      fieldNames_(std::move(fieldNames))
+    , stringPool(std::move(strings))
 {
-    if (!fieldNames_)
+    if (!stringPool)
         raise<std::runtime_error>("The string cache must not be null.");
 
     functions["any"]    = &AnyFn::Fn;
@@ -26,8 +25,8 @@ Environment::Environment(std::shared_ptr<Fields> fieldNames)
     functions["trace"]  = &TraceFn::Fn;
 }
 
-Environment::Environment(NewStringCache_) :
-    Environment(std::make_shared<Fields>()) {}
+Environment::Environment(NewStringCache_)
+    : Environment(std::make_shared<StringPool>()) {}
 
 Environment::~Environment()
 {}
@@ -51,8 +50,8 @@ auto Environment::findFunction(std::string name) const -> const Function*
     return nullptr;
 }
 
-auto Environment::fieldNames() const -> std::shared_ptr<Fields> {
-    return fieldNames_;
+auto Environment::strings() const -> std::shared_ptr<StringPool> {
+    return stringPool;
 }
 
 Context::Context(Environment* env, Context::Phase phase)

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -563,12 +563,12 @@ auto SumFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const
     (void)args[0]->eval(ctx, val, LambdaResultFn([&, n = 0](Context ctx, Value vv) mutable {
         if (subexpr) {
             auto ov = shared_model_ptr<OverlayNode>::make(vv);
-            ov->set(Fields::OverlaySum, sum);
-            ov->set(Fields::OverlayValue, vv);
-            ov->set(Fields::OverlayIndex, Value::make((int64_t)n++));
+            ov->set(StringPool::OverlaySum, sum);
+            ov->set(StringPool::OverlayValue, vv);
+            ov->set(StringPool::OverlayIndex, Value::make((int64_t)n++));
 
             subexpr->eval(ctx, Value::field(ov), LambdaResultFn([&ov, &sum](auto ctx, auto vv) {
-                ov->set(Fields::OverlaySum, vv);
+                ov->set(StringPool::OverlaySum, vv);
                 sum = vv;
                 return Result::Continue;
             }));
@@ -612,7 +612,7 @@ auto KeysFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, cons
 
         if (vv.node)
             for (auto&& fieldName : vv.node->fieldNames()) {
-                if (auto key = ctx.env->fieldNames_->resolve(fieldName)) {
+                if (auto key = ctx.env->stringPool->resolve(fieldName)) {
                     if (res(ctx, Value::strref(*key)) == Result::Stop)
                         return Result::Stop;
                 }

--- a/src/model/fields.cpp
+++ b/src/model/fields.cpp
@@ -80,7 +80,7 @@ FieldId Fields::get(std::string_view const& str)
     return Fields::Empty;
 }
 
-std::optional<std::string_view> Fields::resolve(FieldId const& id)
+std::optional<std::string_view> Fields::resolve(FieldId const& id) const
 {
     std::shared_lock stringStoreReadAccess_(stringStoreMutex_);
     auto it = stringForId_.find(id);

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -278,7 +278,7 @@ ModelNode::Ptr Model::newSmallValue(uint16_t value)
     return ModelNode(shared_from_this(), {UInt16, (uint32_t)value});
 }
 
-std::optional<std::string_view> Model::lookupFieldId(FieldId) const
+std::optional<std::string_view> Model::lookupFieldId(const FieldId) const
 {
     return {};
 }
@@ -339,7 +339,7 @@ void ModelPool::setFieldNames(std::shared_ptr<Fields> const& newDict)
     impl_->fieldNames_ = newDict;
 }
 
-std::optional<std::string_view> ModelPool::lookupFieldId(FieldId id) const
+std::optional<std::string_view> ModelPool::lookupFieldId(const FieldId id) const
 {
     return impl_->fieldNames_->resolve(id);
 }
@@ -371,8 +371,10 @@ void ModelPool::read(std::istream& inputStream) {
 nlohmann::json ModelPool::toJson() const
 {
     auto roots = nlohmann::json::array();
-    for (auto i = 0u; i < numRoots(); ++i)
+    const auto n = numRoots();
+    for (auto i = 0u; i < n; ++i) {
         roots.push_back(root(i)->toJson());
+    }
 
     return roots;
 }

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -43,8 +43,8 @@ void Model::resolve(const ModelNode& n, const ResolveFn& cb) const
 
 struct ModelPool::Impl
 {
-    explicit Impl(std::shared_ptr<Fields> fieldNames) :
-        fieldNames_(std::move(fieldNames))
+    explicit Impl(std::shared_ptr<StringPool> strings) :
+        strings_(std::move(strings))
     {
         columns_.stringData_.reserve(detail::ColumnPageSize*4);
     }
@@ -61,7 +61,7 @@ struct ModelPool::Impl
     };
 
     /// This model pool's field name store
-    std::shared_ptr<Fields> fieldNames_;
+    std::shared_ptr<StringPool> strings_;
 
     struct {
         sfl::segmented_vector<ModelNodeAddress, detail::ColumnPageSize> roots_;
@@ -92,10 +92,10 @@ struct ModelPool::Impl
 };
 
 ModelPool::ModelPool()
-    : impl_(std::make_unique<ModelPool::Impl>(std::make_shared<Fields>()))
+    : impl_(std::make_unique<ModelPool::Impl>(std::make_shared<StringPool>()))
 {}
 
-ModelPool::ModelPool(std::shared_ptr<Fields> stringStore)
+ModelPool::ModelPool(std::shared_ptr<StringPool> stringStore)
     : impl_(std::make_unique<ModelPool::Impl>(std::move(stringStore)))
 {}
 
@@ -114,11 +114,11 @@ std::vector<std::string> ModelPool::checkForErrors() const
         return true;
     };
 
-    auto validateFieldName = [&, this](FieldId const& str)
+    auto validateFieldName = [&, this](StringId const& str)
     {
-        if (!impl_->fieldNames_)
+        if (!impl_->strings_)
             return;
-        if (!impl_->fieldNames_->resolve(str))
+        if (!impl_->strings_->resolve(str))
             errors.push_back(fmt::format("Bad string ID: {}", str));
     };
 
@@ -278,7 +278,7 @@ ModelNode::Ptr Model::newSmallValue(uint16_t value)
     return ModelNode(shared_from_this(), {UInt16, (uint32_t)value});
 }
 
-std::optional<std::string_view> Model::lookupFieldId(const FieldId) const
+std::optional<std::string_view> Model::lookupStringId(const StringId) const
 {
     return {};
 }
@@ -322,26 +322,26 @@ shared_model_ptr<Array> ModelPool::resolveArray(ModelNode::Ptr const& n) const
     return Array(shared_from_this(), n->addr_);
 }
 
-std::shared_ptr<Fields> ModelPool::fieldNames() const
+std::shared_ptr<StringPool> ModelPool::strings() const
 {
-    return impl_->fieldNames_;
+    return impl_->strings_;
 }
 
-void ModelPool::setFieldNames(std::shared_ptr<Fields> const& newDict)
+void ModelPool::setStrings(std::shared_ptr<StringPool> const& strings)
 {
     // Translate object field IDs to the new dictionary.
     for (auto memberArray : impl_->columns_.objectMemberArrays_) {
         for (auto& member : memberArray) {
-            if (auto resolvedName = impl_->fieldNames_->resolve(member.name_))
-                member.name_ = newDict->emplace(*resolvedName);
+            if (auto resolvedName = impl_->strings_->resolve(member.name_))
+                member.name_ = strings->emplace(*resolvedName);
         }
     }
-    impl_->fieldNames_ = newDict;
+    impl_->strings_ = strings;
 }
 
-std::optional<std::string_view> ModelPool::lookupFieldId(const FieldId id) const
+std::optional<std::string_view> ModelPool::lookupStringId(const StringId id) const
 {
-    return impl_->fieldNames_->resolve(id);
+    return impl_->strings_->resolve(id);
 }
 
 Object::Storage& ModelPool::objectMemberStorage() {

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -75,15 +75,17 @@ nlohmann::json ModelNode::toJson() const
     if (type() == ValueType::Object) {
         auto j = nlohmann::json::object();
         for (const auto& [fieldId, childNode] : fields()) {
-            if (auto resolvedField = model_->lookupFieldId(fieldId))
+            if (auto resolvedField = model_->lookupFieldId(fieldId)) {
                 j[*resolvedField] = childNode->toJson();
+            }
         }
         return j;
     }
     else if (type() == ValueType::Array) {
         auto j = nlohmann::json::array();
-        for (const auto& i : *this)
+        for (const auto& i : *this) {
             j.push_back(i->toJson());
+        }
         return j;
     }
     else {
@@ -91,11 +93,12 @@ nlohmann::json ModelNode::toJson() const
         std::visit(
             [&j](auto&& v)
             {
-                if constexpr (!std::is_same_v<std::decay_t<decltype(v)>, std::monostate>)
-                    j = v;
-                else
+                using T = decltype(v);
+                if constexpr (!std::is_same_v<std::decay_t<T>, std::monostate>) {
+                    j = std::forward<T>(v);
+                } else {
                     j = nullptr;
-
+                }
             }, value());
         return j;
     }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -18,7 +18,7 @@ OverlayNode::OverlayNode(ModelNode const& n)
     : MandatoryDerivedModelNodeBase<OverlayNodeStorage>(n)
 {}
 
-auto OverlayNode::set(FieldId const& key, Value const& child) -> void
+auto OverlayNode::set(StringId const& key, Value const& child) -> void
 {
     model().overlayChildren_.insert({key, child});
 }
@@ -33,7 +33,7 @@ auto OverlayNode::set(FieldId const& key, Value const& child) -> void
     return ValueType::Object;
 }
 
-[[nodiscard]] ModelNode::Ptr OverlayNode::get(const FieldId& key) const
+[[nodiscard]] ModelNode::Ptr OverlayNode::get(const StringId& key) const
 {
     auto iter = model().overlayChildren_.find(key);
     if (iter != model().overlayChildren_.end()) {
@@ -49,7 +49,7 @@ auto OverlayNode::set(FieldId const& key, Value const& child) -> void
     return model().value_.node->at(i);
 }
 
-[[nodiscard]] FieldId OverlayNode::keyAt(int64_t i) const
+[[nodiscard]] StringId OverlayNode::keyAt(int64_t i) const
 {
     return model().value_.node->keyAt(i);
 }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -258,7 +258,7 @@ public:
             return res(ctx, Value::null());
 
         if (!nameId_)
-            nameId_ = ctx.env->fieldNames()->get(name_);
+            nameId_ = ctx.env->strings()->get(name_);
 
         if (!nameId_)
             /* If the field name is not in the string cache, then there
@@ -281,7 +281,7 @@ public:
     }
 
     std::string name_;
-    mutable FieldId nameId_ = {};
+    mutable StringId nameId_ = {};
 };
 
 class MultiConstExpr : public Expr
@@ -388,7 +388,7 @@ public:
                     /* String subscript */
                     else if (ival.isa(ValueType::String)) {
                         auto key = ival.as<ValueType::String>();
-                        if (auto keyStrId = ctx.env->fieldNames()->get(key))
+                        if (auto keyStrId = ctx.env->strings()->get(key))
                             node = lval.node->get(keyStrId);
                     }
 
@@ -1318,7 +1318,7 @@ auto compile(Environment& env, std::string_view sv, bool any) -> ExprPtr
 
 auto eval(Environment& env, const Expr& ast, ModelPool const& model, size_t rootIndex) -> std::vector<Value>
 {
-    if (env.fieldNames() != model.fieldNames())
+    if (env.strings() != model.strings())
         raise<std::runtime_error>("Environment must use same field name resource as model.");
 
     return eval(env, ast, *model.root(rootIndex));

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -33,7 +33,7 @@ auto IRangeType::unaryOp(std::string_view op, const IRange& self) const -> Value
         return Value::make(fmt::format("{}..{}", self.begin, self.end));
 
     if (op == OperatorLen::name())
-        return Value::make((int64_t)self.high() - self.low());
+        return Value::make(static_cast<int64_t>(self.high() - self.low()));
 
     raise<InvalidOperandsError>(op);
 }

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 #include <sstream>
-#include <iostream>
 
+#include "simfil/model/string-pool.h"
 #include "simfil/simfil.h"
 #include "simfil/model/json.h"
 
@@ -55,7 +55,7 @@ static const auto invoice = R"json(
 static auto joined_result(std::string_view query)
 {
     auto model = json::parse(invoice);
-    Environment env(model->fieldNames());
+    Environment env(model->strings());
     auto ast = compile(env, query, false);
     INFO("AST: " << ast->toString());
 
@@ -126,15 +126,15 @@ TEST_CASE("Serialization", "[yaml.complex.serialization]") {
     SECTION("Test Fields write/read")
     {
         std::stringstream stream;
-        model->fieldNames()->write(stream);
+        model->strings()->write(stream);
 
-        auto recoveredFields = std::make_shared<Fields>();
+        const auto recoveredFields = std::make_shared<StringPool>();
         recoveredFields->read(stream);
 
-        REQUIRE(model->fieldNames()->size() == recoveredFields->size());
-        REQUIRE(model->fieldNames()->highest() == recoveredFields->highest());
-        REQUIRE(model->fieldNames()->bytes() == recoveredFields->bytes());
-        for (FieldId fieldId = 0; fieldId <= recoveredFields->highest(); ++fieldId)
-            REQUIRE(model->fieldNames()->resolve(fieldId) == recoveredFields->resolve(fieldId));
+        REQUIRE(model->strings()->size() == recoveredFields->size());
+        REQUIRE(model->strings()->highest() == recoveredFields->highest());
+        REQUIRE(model->strings()->bytes() == recoveredFields->bytes());
+        for (StringId sId = 0; sId <= recoveredFields->highest(); ++sId)
+            REQUIRE(model->strings()->resolve(sId) == recoveredFields->resolve(StringId(sId)));
     }
 }

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -112,7 +112,7 @@ static auto generate_model(std::size_t n)
 
 static auto result(const ModelPoolPtr& model, std::string_view query)
 {
-    Environment env(model->fieldNames());
+    Environment env(model->strings());
     auto ast = compile(env, query, false);
     INFO("AST: " << ast->toString());
 

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -6,7 +6,7 @@
 
 using namespace simfil;
 
-static const auto StaticTestKey = Fields::NextStaticId;
+static const auto StaticTestKey = StringPool::NextStaticId;
 
 
 static auto getASTString(std::string_view input)
@@ -218,7 +218,7 @@ static const char* doc = R"json(
 static auto joined_result(std::string_view query)
 {
     auto model = simfil::json::parse(doc);
-    Environment env(model->fieldNames());
+    Environment env(model->strings());
 
     auto ast = compile(env, query, false);
     INFO("AST: " << ast->toString());
@@ -388,7 +388,7 @@ TEST_CASE("Model Pool Validation", "[model.validation]") {
 
 TEST_CASE("Procedural Object Node", "[model.procedural]") {
     auto pool = std::make_shared<ModelPool>();
-    pool->fieldNames()->addStaticKey(StaticTestKey, "test");
+    pool->strings()->addStaticKey(StaticTestKey, "test");
 
     struct DerivedProceduralObject : public ProceduralObject<2, DerivedProceduralObject> {
         DerivedProceduralObject(ModelConstPtr pool, ModelNodeAddress a)
@@ -404,7 +404,7 @@ TEST_CASE("Procedural Object Node", "[model.procedural]") {
     baseObj->addField("mood", "blue");
 
     auto proceduralObj = shared_model_ptr<DerivedProceduralObject>::make(pool, baseObj->addr());
-    REQUIRE(proceduralObj->get(pool->fieldNames()->get("mood"))->value() == ScalarValueType(std::string_view("blue")));
+    REQUIRE(proceduralObj->get(pool->strings()->get("mood"))->value() == ScalarValueType(std::string_view("blue")));
     REQUIRE(proceduralObj->get(StaticTestKey)->value() == ScalarValueType(std::string_view("static")));
 }
 
@@ -465,21 +465,21 @@ TEST_CASE("Object/Array Extend", "[model.extend]") {
     }
 }
 
-TEST_CASE("Switch Model Fields Dict", "[model.setfieldnames]")
+TEST_CASE("Switch Model String Pool", "[model.setStrings]")
 {
     auto pool = std::make_shared<ModelPool>();
-    auto oldFieldDict = pool->fieldNames();
-    auto newFieldDict = std::make_shared<simfil::Fields>(*oldFieldDict);
-    pool->setFieldNames(newFieldDict);
-    REQUIRE(pool->fieldNames() == newFieldDict);
+    auto oldFieldDict = pool->strings();
+    auto newFieldDict = std::make_shared<simfil::StringPool>(*oldFieldDict);
+    pool->setStrings(newFieldDict);
+    REQUIRE(pool->strings() == newFieldDict);
 
     auto obj = pool->newObject();
     obj->addField("hello", "world");
 
     oldFieldDict->emplace("gobbledigook");
-    pool->setFieldNames(oldFieldDict);
+    pool->setStrings(oldFieldDict);
 
-    REQUIRE(pool->fieldNames() == oldFieldDict);
+    REQUIRE(pool->strings() == oldFieldDict);
     REQUIRE_NOTHROW(pool->validate());
     REQUIRE(oldFieldDict->size() != newFieldDict->size());
 }


### PR DESCRIPTION
Adds a  `toJson()` to `ModelPool` and `ModelNode` + converting an object to a string will give a JSON representation.

Marks `Fields::resolve` as const.