### PR TITLE
Improve Regular Expression Support

### DIFF
--- a/include/simfil/function.h
+++ b/include/simfil/function.h
@@ -134,6 +134,17 @@ public:
     auto eval(Context, Value, const std::vector<ExprPtr>&, const ResultFn&) const -> Result override;
 };
 
+class ReFn : public Function
+{
+public:
+    static ReFn Fn;
+
+    ReFn();
+
+    auto ident() const -> const FnInfo& override;
+    auto eval(Context, Value, const std::vector<ExprPtr>&, const ResultFn&) const -> Result override;
+};
+
 class ArrFn : public Function
 {
 public:

--- a/include/simfil/operator.h
+++ b/include/simfil/operator.h
@@ -587,34 +587,6 @@ struct OperatorGtEq
     }
 };
 
-struct OperatorMatch
-{
-    NAME("=~")
-    DENY_OTHER()
-
-    auto operator()(const std::string& s, const std::string& pattern) const -> Value
-    {
-        std::regex re(pattern);
-        return std::regex_match(s, re) ? Value::make(s) : Value::f();
-    }
-
-    NULL_AS_NULL()
-};
-
-struct OperatorNotMatch
-{
-    NAME("!~")
-    DENY_OTHER()
-
-    auto operator()(const std::string& s, const std::string& pattern) const -> Value
-    {
-        std::regex re(pattern);
-        return std::regex_match(s, re) ? Value::f() : Value::make(s);
-    }
-
-    NULL_AS_NULL()
-};
-
 struct OperatorSubscript
 {
     NAME("[]")

--- a/include/simfil/token.h
+++ b/include/simfil/token.h
@@ -27,7 +27,8 @@ struct Token
         WILDCARD,       // **
         INT,            //
         FLOAT,          //
-        STRING,         // "..." or '...'
+        STRING,         // [r]"..." or [r]'...'
+        REGEXP,         // A string prefixed by re or RE
         WORD,           //
         SELF,           // _
         /* Constants */

--- a/include/simfil/token.h
+++ b/include/simfil/token.h
@@ -59,8 +59,6 @@ struct Token
         OP_BOOL,        // ?
         /* Regexp */
         OP_LEN,         // #
-        OP_MATCH,       // =~
-        OP_NOT_MATCH,   // !~
         /* Path */
         OP_TYPEOF,      // typeof
         /* Cast/Type */

--- a/include/simfil/types.h
+++ b/include/simfil/types.h
@@ -4,6 +4,7 @@
 
 #include "value.h"
 #include "typed-meta-type.h"
+#include <string_view>
 
 namespace simfil
 {
@@ -38,6 +39,26 @@ public:
     auto binaryOp(std::string_view op, const Value& l, const IRange& r) const -> Value override;
 
     auto unpack(const IRange& , std::function<bool(Value)> res) const -> void override;
+};
+
+struct Re
+{
+    std::string str;
+    std::regex re;
+};
+
+class ReType : public TypedMetaType<Re>
+{
+public:
+    static ReType Type;
+
+    ReType();
+
+    auto make(std::string_view expr) -> Value;
+
+    auto unaryOp(std::string_view op, const Re&) const -> Value override;
+    auto binaryOp(std::string_view op, const Re&, const Value&) const -> Value override;
+    auto binaryOp(std::string_view op, const Value&, const Re&) const -> Value override;
 };
 
 }

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -284,3 +284,12 @@ Returns all sub-element keys of object `object`
 ```
 keys(a.b) => 'c', 'd', ...
 ```
+
+### `re(str)`
+
+Compiles a regular expression string to an `re` object, which holds a compiled regular expression.
+
+*Example*
+```
+a.b =~ re("prefix.*")
+```

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -117,7 +117,7 @@ count(mylist.*)
 
 ## Types
 
-Simfil supports the following scalar types: `null`, `bool`, `int`, `float` (double precision) and `string`.
+Simfil supports the following scalar types: `null`, `bool`, `int`, `float` (double precision), `string` and `re`.
 Additionally, the `model` type represents compound object/array container nodes.
 All values but `null` and `false` are considered `true`, implicit boolean conversion takes place for operators
 `and` and `or` only.
@@ -288,6 +288,7 @@ keys(a.b) => 'c', 'd', ...
 ### `re(str)`
 
 Compiles a regular expression string to an `re` object, which holds a compiled regular expression.
+For regular expression literals you can also use a string literal prefixed by `re` as a short form: `re'prefix.*'`.
 
 *Example*
 ```

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -160,7 +160,6 @@ The following types can be target types for a cast:
 | `a < b` / `a <= b`  | Less than / less than or equal to.                                                                      |
 | `a > b` / `a >= b`  | Greater than / greater than or equal to.                                                                |
 | `a == b` / `a != b` | Equal to / not equal to. `a = b` is an alias for `a == b`.                                              |
-| `a =~ b` / `a !~ b` | `a` matches regular expression `b` / `a` does not match regular expression `b`. Returns `a` or `false`  |
 | `a or b`            | Logical or, returning the first non-false argument (like JavaScript).                                   |
 | `a and b`           | Logical and, returning the first false argument (like JavaScript).                                      |
 
@@ -178,7 +177,7 @@ The following types can be target types for a cast:
 | `+`, `-`                               | 5          |
 | `<<`, `>>`, `&`, `\|`, `^`             | 4          |
 | `<`, `<=`, `>`, `>=`                   | 3          |
-| `==`/`=`, `!=`, `=~`, `!~`             | 2          |
+| `==`/`=`, `!=`,                        | 2          |
 | `and`, `or`                            | 1          |
 
 ## Functions
@@ -292,5 +291,9 @@ For regular expression literals you can also use a string literal prefixed by `r
 
 *Example*
 ```
-a.b =~ re("prefix.*")
+-- Test if a.b matches the regular expression "prefix.*"
+a.b = re("prefix.*")
+
+-- Test if a.b does not match "prefix.*"
+a.b != re("prefix.*")
 ```

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -23,6 +23,7 @@ Environment::Environment(std::shared_ptr<StringPool> strings)
     functions["sum"]    = &SumFn::Fn;
     functions["keys"]   = &KeysFn::Fn;
     functions["trace"]  = &TraceFn::Fn;
+    functions["re"]     = &ReFn::Fn;
 }
 
 Environment::Environment(NewStringCache_)

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -143,8 +143,7 @@ auto boolify(Value v) -> bool
 }
 
 AnyFn AnyFn::Fn;
-AnyFn::AnyFn()
-{}
+AnyFn::AnyFn() = default;
 
 auto AnyFn::ident() const -> const FnInfo&
 {
@@ -188,8 +187,7 @@ auto AnyFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const
 }
 
 EachFn EachFn::Fn;
-EachFn::EachFn()
-{}
+EachFn::EachFn() = default;
 
 auto EachFn::ident() const -> const FnInfo&
 {
@@ -232,8 +230,7 @@ auto EachFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, cons
 }
 
 CountFn CountFn::Fn;
-CountFn::CountFn()
-{}
+CountFn::CountFn() = default;
 
 auto CountFn::ident() const -> const FnInfo&
 {
@@ -276,8 +273,7 @@ auto CountFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, con
 }
 
 TraceFn TraceFn::Fn;
-TraceFn::TraceFn()
-{}
+TraceFn::TraceFn() = default;
 
 auto TraceFn::ident() const -> const FnInfo&
 {
@@ -337,8 +333,7 @@ auto TraceFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, con
 
 
 RangeFn RangeFn::Fn;
-RangeFn::RangeFn()
-{}
+RangeFn::RangeFn() = default;
 
 auto RangeFn::ident() const -> const FnInfo&
 {
@@ -372,8 +367,7 @@ auto RangeFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, con
 }
 
 ReFn ReFn::Fn;
-ReFn::ReFn()
-{}
+ReFn::ReFn() = default;
 
 auto ReFn::ident() const -> const FnInfo&
 {
@@ -400,7 +394,7 @@ auto ReFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const 
 
         // Passing another <re> object is a no-op
         if (vv.isa(ValueType::TransientObject))
-            if (auto obj = vv.as<ValueType::TransientObject>(); obj.meta == &ReType::Type)
+            if (const auto obj = vv.as<ValueType::TransientObject>(); obj.meta == &ReType::Type)
                 return res(ctx, std::move(vv));
 
         raise<std::runtime_error>("re: invalid value type for argument 'expr'"s);
@@ -409,8 +403,7 @@ auto ReFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const 
 }
 
 ArrFn ArrFn::Fn;
-ArrFn::ArrFn()
-{}
+ArrFn::ArrFn() = default;
 
 auto ArrFn::ident() const -> const FnInfo&
 {
@@ -439,8 +432,7 @@ auto ArrFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const
 }
 
 SplitFn SplitFn::Fn;
-SplitFn::SplitFn()
-{}
+SplitFn::SplitFn() = default;
 
 auto SplitFn::ident() const -> const FnInfo&
 {
@@ -523,8 +515,7 @@ auto SplitFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, con
 };
 
 SelectFn SelectFn::Fn;
-SelectFn::SelectFn()
-{}
+SelectFn::SelectFn() = default;
 
 auto SelectFn::ident() const -> const FnInfo&
 {
@@ -571,8 +562,7 @@ auto SelectFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, co
 }
 
 SumFn SumFn::Fn;
-SumFn::SumFn()
-{}
+SumFn::SumFn() = default;
 
 auto SumFn::ident() const -> const FnInfo&
 {
@@ -626,8 +616,7 @@ auto SumFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, const
 }
 
 KeysFn KeysFn::Fn;
-KeysFn::KeysFn()
-{}
+KeysFn::KeysFn() = default;
 
 auto KeysFn::ident() const -> const FnInfo&
 {

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -55,7 +55,7 @@ enum Precedence {
     TERM        = 5,  // +, -
     BITWISE     = 4,  // <<, >>, &, |, ^
     COMPARISON  = 3,  // <, <=, >, >=
-    EQUALITY    = 2,  // ==, !=, =~, !~
+    EQUALITY    = 2,  // =, ==, !=
     LOGIC       = 1,  // and, or
 };
 
@@ -1290,8 +1290,6 @@ auto compile(Environment& env, std::string_view sv, bool any) -> ExprPtr
     p.infixParsers[Token::OP_LTEQ]   = std::make_unique<BinaryOpParser<OperatorLtEq, Precedence::EQUALITY>>();
     p.infixParsers[Token::OP_GT]     = std::make_unique<BinaryOpParser<OperatorGt,   Precedence::EQUALITY>>();
     p.infixParsers[Token::OP_GTEQ]   = std::make_unique<BinaryOpParser<OperatorGtEq, Precedence::EQUALITY>>();
-    p.infixParsers[Token::OP_MATCH]  = std::make_unique<BinaryOpParser<OperatorMatch,Precedence::EQUALITY>>();
-    p.infixParsers[Token::OP_NOT_MATCH] = std::make_unique<BinaryOpParser<OperatorNotMatch, Precedence::EQUALITY>>();
     p.infixParsers[Token::OP_AND]    = std::make_unique<AndOrParser>();
     p.infixParsers[Token::OP_OR]     = std::make_unique<AndOrParser>();
 

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -1,4 +1,5 @@
 #include "simfil/simfil.h"
+#include "simfil/model/nodes.h"
 #include "simfil/token.h"
 #include "simfil/operator.h"
 #include "simfil/value.h"
@@ -7,6 +8,7 @@
 #include "simfil/parser.h"
 #include "simfil/environment.h"
 #include "simfil/model/model.h"
+#include "simfil/types.h"
 #include "fmt/core.h"
 
 #include <algorithm>
@@ -18,8 +20,6 @@
 #include <type_traits>
 #include <deque>
 #include <unordered_map>
-#include <ostream>
-#include <iostream>
 #include <stdexcept>
 #include <cassert>
 #include <vector>
@@ -1073,6 +1073,20 @@ class ScalarParser : public PrefixParselet
 };
 
 /**
+ * Parser for parsing regular expression literals.
+ *
+ * <token>
+ */
+class RegExpParser : public PrefixParselet
+{
+    auto parse(Parser& p, Token t) const -> ExprPtr override
+    {
+        auto value = ReType::Type.make(std::get<std::string>(t.value));
+        return std::make_unique<ConstExpr>(std::move(value));
+    }
+};
+
+/**
  * Parser emitting constant expressions.
  */
 class ConstParser : public PrefixParselet
@@ -1243,6 +1257,7 @@ auto compile(Environment& env, std::string_view sv, bool any) -> ExprPtr
     p.prefixParsers[Token::INT]     = std::make_unique<ScalarParser<int64_t>>();
     p.prefixParsers[Token::FLOAT]   = std::make_unique<ScalarParser<double>>();
     p.prefixParsers[Token::STRING]  = std::make_unique<ScalarParser<std::string>>();
+    p.prefixParsers[Token::REGEXP]  = std::make_unique<RegExpParser>();
 
     /* Unary Operators */
     p.prefixParsers[Token::OP_SUB]    = std::make_unique<UnaryOpParser<OperatorNegate>>();

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -92,8 +92,6 @@ auto Token::toString(Type t) -> std::string
     case Token::OP_GTEQ:      return ">=";
     case Token::OP_BOOL:      return "?";
     case Token::OP_LEN:       return "#";
-    case Token::OP_MATCH:     return "=~";
-    case Token::OP_NOT_MATCH: return "!~";
     case Token::OP_TYPEOF:    return "typeof";
     case Token::OP_CAST:      return "as";
     case Token::OP_UNPACK:    return "...";
@@ -403,8 +401,6 @@ std::optional<Token> scanSyntax(Scanner& s)
         {"#", Token::OP_LEN},
         {"^", Token::OP_BITXOR},
         {"?", Token::OP_BOOL},
-        {"=~",Token::OP_MATCH},
-        {"!~",Token::OP_NOT_MATCH},
         {"<=",Token::OP_LTEQ},
         {"<", Token::OP_LT},
         {">=",Token::OP_GTEQ},

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -132,10 +132,10 @@ auto ReType::binaryOp(std::string_view op, const Value& l, const Re& r) const ->
     if (l.isa(ValueType::String)) {
         const auto& str = l.as<ValueType::String>();
 
-        if (op == OperatorMatch::name())
+        if (op == OperatorEq::name())
             return std::regex_match(str, r.re) ? Value::make(str) : Value::f();
 
-        if (op == OperatorNotMatch::name())
+        if (op == OperatorNeq::name())
             return std::regex_match(str, r.re) ? Value::f() : Value::make(str);
     }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -121,7 +121,7 @@ auto ReType::unaryOp(std::string_view op, const Re& self) const -> Value
 
 auto ReType::binaryOp(std::string_view op, const Re& l, const Value& r) const -> Value
 {
-    raise<InvalidOperandsError>(op);
+    return binaryOp(op, r, l);
 }
 
 auto ReType::binaryOp(std::string_view op, const Value& l, const Re& r) const -> Value

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,5 +1,6 @@
 #include "simfil/types.h"
 
+#include "simfil/model/nodes.h"
 #include "simfil/operator.h"
 #include "fmt/core.h"
 
@@ -87,6 +88,58 @@ auto IRangeType::unpack(const IRange& self, std::function<bool(Value)> res) cons
         if (!res(Value(ValueType::Int, static_cast<int64_t>(i))))
             return;
     } while (i != end);
+}
+
+ReType ReType::Type;
+ReType::ReType()
+    : TypedMetaType("re")
+{}
+
+auto ReType::make(std::string_view expr) -> Value
+{
+    auto obj = TransientObject(&ReType::Type);
+    auto re = get(obj);
+    re->str = expr;
+    re->re = std::regex(std::string(expr));
+
+    return Value(ValueType::TransientObject, std::move(obj));
+}
+
+auto ReType::unaryOp(std::string_view op, const Re& self) const -> Value
+{
+    if (op == OperatorTypeof::name())
+        return Value::make(ident);
+
+    if (op == OperatorBool::name())
+        return Value::t();
+
+    if (op == OperatorAsString::name())
+        return Value::make(self.str);
+
+    raise<InvalidOperandsError>(op);
+}
+
+auto ReType::binaryOp(std::string_view op, const Re& l, const Value& r) const -> Value
+{
+    raise<InvalidOperandsError>(op);
+}
+
+auto ReType::binaryOp(std::string_view op, const Value& l, const Re& r) const -> Value
+{
+    if (l.isa(ValueType::Null))
+        return Value::null();
+
+    if (l.isa(ValueType::String)) {
+        const auto& str = l.as<ValueType::String>();
+
+        if (op == OperatorMatch::name())
+            return std::regex_match(str, r.re) ? Value::make(str) : Value::f();
+
+        if (op == OperatorNotMatch::name())
+            return std::regex_match(str, r.re) ? Value::f() : Value::make(str);
+    }
+
+    raise<InvalidOperandsError>(op);
 }
 
 }

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -84,6 +84,13 @@ TEST_CASE("Invoice", "[yaml.complex.invoice-sum]") {
                             "336.360000");
 }
 
+TEST_CASE("Regular Expression", "[complex.regexp]") {
+    REQUIRE_RESULT("re'a.c' = 'abc'", "abc");
+    REQUIRE_RESULT("'abc' = re'a.c'", "abc");
+    REQUIRE_RESULT("re'a.x' != 'abc'", "abc");
+    REQUIRE_RESULT("'abc' != re'a.x'", "abc");
+}
+
 TEST_CASE("Runtime Error", "[yaml.complex.runtime-error]") {
     REQUIRE_THROWS(joined_result("1 / (nonexisting as int)")); /* Division by zero */
     REQUIRE_THROWS(joined_result("not nonexisting == 0"));     /* Invalid operands int and bool */

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -26,6 +26,7 @@ static auto getFirst(std::string_view input, Token::Type t) -> Type
 static auto asInt(std::string_view input)   {return getFirst<int64_t>(input, Token::Type::INT);}
 static auto asFloat(std::string_view input) {return getFirst<double>(input, Token::Type::FLOAT);}
 static auto asStr(std::string_view input)   {return getFirst<std::string>(input, Token::Type::STRING);}
+static auto asRegexp(std::string_view input)   {return getFirst<std::string>(input, Token::Type::REGEXP);}
 static auto asWord(std::string_view input)  {return getFirst<std::string>(input, Token::Type::WORD);}
 
 TEST_CASE("Tokenize integers", "[token.integer]") {
@@ -90,6 +91,11 @@ TEST_CASE("Tokenize strings", "[token.string]") {
     REQUIRE(asStr("r''") == "");
     REQUIRE(asStr("R''") == "");
     REQUIRE(asStr("r'\"'") == "\"");
+
+    /* re'...' */
+    REQUIRE(asRegexp("re''") == "");
+    REQUIRE(asRegexp("RE''") == "");
+    REQUIRE(asRegexp("re'\"'") == "\"");
 
     /* Quote mismatch */
     CHECK_THROWS(asStr("'abc"));

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -23,11 +23,11 @@ static auto getFirst(std::string_view input, Token::Type t) -> Type
     return std::get<Type>(tokens.at(0).value);
 }
 
-static auto asInt(std::string_view input)   {return getFirst<int64_t>(input, Token::Type::INT);}
-static auto asFloat(std::string_view input) {return getFirst<double>(input, Token::Type::FLOAT);}
-static auto asStr(std::string_view input)   {return getFirst<std::string>(input, Token::Type::STRING);}
-static auto asRegexp(std::string_view input)   {return getFirst<std::string>(input, Token::Type::REGEXP);}
-static auto asWord(std::string_view input)  {return getFirst<std::string>(input, Token::Type::WORD);}
+static auto asInt(const std::string_view input)   {return getFirst<int64_t>(input, Token::Type::INT);}
+static auto asFloat(const std::string_view input) {return getFirst<double>(input, Token::Type::FLOAT);}
+static auto asStr(const std::string_view input)   {return getFirst<std::string>(input, Token::Type::STRING);}
+static auto asRegexp(const std::string_view input)   {return getFirst<std::string>(input, Token::Type::REGEXP);}
+static auto asWord(const std::string_view input)  {return getFirst<std::string>(input, Token::Type::WORD);}
 
 TEST_CASE("Tokenize integers", "[token.integer]") {
     /* Decimal */

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -78,6 +78,19 @@ TEST_CASE("Tokenize strings", "[token.string]") {
     REQUIRE(asStr("\"abc\"") == "abc");
     REQUIRE(asStr("\"\\\"abc\\\"\"") == "\"abc\"");
 
+    /* r"..." */
+    REQUIRE(asStr("r\"\"") == "");
+    REQUIRE(asStr("R\"\"") == "");
+    REQUIRE(asStr("r\"abc\"") == "abc");
+    REQUIRE(asStr("r\"\\\"abc\\\"\"") == "\"abc\"");
+    REQUIRE(asStr("r\"\\\\\"\"") == "\\\"");
+    REQUIRE(asStr("r\"\\a\"") == "\\a");
+
+    /* r'...' */
+    REQUIRE(asStr("r''") == "");
+    REQUIRE(asStr("R''") == "");
+    REQUIRE(asStr("r'\"'") == "\"");
+
     /* Quote mismatch */
     CHECK_THROWS(asStr("'abc"));
     CHECK_THROWS(asStr("abc'"));

--- a/test/token.cpp
+++ b/test/token.cpp
@@ -118,7 +118,6 @@ TEST_CASE("Tokenize symbols", "[token.symbol]") {
     /* Some random tokens */
     REQUIRE(getFirstType("_")      == Token::Type::SELF);
     REQUIRE(getFirstType("+")      == Token::Type::OP_ADD);
-    REQUIRE(getFirstType("=~")     == Token::Type::OP_MATCH);
     REQUIRE(getFirstType("==")     == Token::Type::OP_EQ);
     REQUIRE(getFirstType("=")      == Token::Type::OP_EQ);
     REQUIRE(getFirstType("<")      == Token::Type::OP_LT);


### PR DESCRIPTION
- Adds Python-like raw string literals `r"..."` and `r'...'`
- Adds RegExp literals `re"..."` and `re'...'` that are in fact raw literals converted to a regular experssion when building the AST
- Adds a new `re(...)` function that returns a new `re` type, which is a regular expression
- Removes the match operator `=~` and `!~`; use `=` and `!=` with `re` objects on one side