### PR TITLE
conan: Expose SIMFIL_WITH_MODEL_JSON definition

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -82,3 +82,5 @@ class SimfilRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["simfil"]
+        if self.options.with_json:
+            self.cpp_info.defines = ["SIMFIL_WITH_MODEL_JSON=1"]

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -9,6 +9,10 @@ class SimfilTestPackageConanFile(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
+    default_options = {
+        "simfil/*:with_json": True,
+    }
+
     def requirements(self):
         self.requires(self.tested_reference_str)
 

--- a/test_package/src/example.cpp
+++ b/test_package/src/example.cpp
@@ -1,5 +1,9 @@
 #include "simfil/value.h"
 
+#ifndef SIMFIL_WITH_MODEL_JSON
+#  error "Definition SIMFIL_WITH_MODEL_JSON is not visible to the consumer!"
+#endif
+
 int main() {
     auto value = simfil::Value::make(static_cast<int64_t>(123));
     (void)value;


### PR DESCRIPTION
The conan recipe must expose the public definition via its `package_info` struct.