### PR TITLE
Use explicit shared_ptr deref to fix compiler confusion.

### DIFF
--- a/include/simfil/model/nodes.impl.h
+++ b/include/simfil/model/nodes.impl.h
@@ -42,7 +42,7 @@ bool BaseArray<ModelType, ModelNodeType>::iterate(const ModelNode::IterCallback&
         members_,
         [&, this](auto&& member)
         {
-            model_->resolve(*ModelNode::Ptr::make(model_, member), resolveAndCb);
+            (*model_).resolve(*ModelNode::Ptr::make(model_, member), resolveAndCb);
             return cont;
         });
     return cont;
@@ -139,7 +139,7 @@ bool BaseObject<ModelType, ModelNodeType>::iterate(const ModelNode::IterCallback
         members_,
         [&, this](auto&& member)
         {
-            model_->resolve(*ModelNode::Ptr::make(model_, member.node_), resolveAndCb);
+            (*model_).resolve(*ModelNode::Ptr::make(model_, member.node_), resolveAndCb);
             return cont;
         });
     return cont;


### PR DESCRIPTION
... at least with default GCC for Ubuntu 22 (arm64 version) there is a problem with usage of `model_->resolve(...)` - the compiler seems to be confused and only  using explicit deref helped.