### PR TITLE
Less Strict Comparison Operators

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         valgrind --tool=callgrind --instr-atstart=no ./test.simfil
     - name: Publish Callgrind Output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Callgrind Output
         path: build/test/callgrind.out.*

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
         less coverage.xml
 
     - name: Publish Coverage HTML
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test Coverage
         path: coverage

--- a/include/simfil/operator.h
+++ b/include/simfil/operator.h
@@ -8,8 +8,6 @@
 #include <cstdint>
 #include <string_view>
 #include <string>
-#include <regex>
-#include <type_traits>
 
 namespace simfil
 {
@@ -17,7 +15,7 @@ namespace simfil
 using namespace std::string_literals;
 
 /**
- * Special return type for Operator type mismatch.
+ * Special return type for operator type mismatch.
  */
 struct InvalidOperands {
     auto operator!() const -> InvalidOperands

--- a/include/simfil/operator.h
+++ b/include/simfil/operator.h
@@ -315,6 +315,13 @@ struct OperatorAsString
         return {};                                                      \
     }
 
+#define IGNORE_INCOMPATIBLE()                                           \
+    template <class Left, class Right>                                  \
+    auto operator()(const Left&, const Right&) const                    \
+    {                                                                   \
+        return false;                                                   \
+    }
+
 #define NULL_AS_NULL()                              \
     template <class Right>                          \
     auto operator()(NullType, const Right& b) const \
@@ -470,25 +477,13 @@ struct OperatorMod
 struct OperatorEq
 {
     NAME("==")
-    DENY_OTHER()
+    IGNORE_INCOMPATIBLE()
     DECL_OPERATION(bool,               bool,               ==)
     DECL_OPERATION(int64_t,            int64_t,            ==)
     DECL_OPERATION(int64_t,            double,             ==)
     DECL_OPERATION(double,             int64_t,            ==)
     DECL_OPERATION(double,             double,             ==)
     DECL_OPERATION(const std::string&, const std::string&, ==)
-
-    template <class Right>
-    auto operator()(NullType, const Right&) const
-    {
-        return false;
-    }
-
-    template <class Left>
-    auto operator()(const Left&, NullType) const
-    {
-        return false;
-    }
 
     auto operator()(NullType, NullType) const
     {
@@ -510,24 +505,12 @@ struct OperatorNeq
 struct OperatorLt
 {
     NAME("<")
-    DENY_OTHER()
+    IGNORE_INCOMPATIBLE()
     DECL_OPERATION(int64_t,            int64_t,            <)
     DECL_OPERATION(int64_t,            double,             <)
     DECL_OPERATION(double,             int64_t,            <)
     DECL_OPERATION(double,             double,             <)
     DECL_OPERATION(const std::string&, const std::string&, <)
-
-    template <class Right>
-    auto operator()(NullType, const Right&) const
-    {
-        return false;
-    }
-
-    template <class Left>
-    auto operator()(const Left&, NullType) const
-    {
-        return false;
-    }
 
     auto operator()(NullType, NullType) const
     {
@@ -538,24 +521,12 @@ struct OperatorLt
 struct OperatorLtEq
 {
     NAME("<=")
-    DENY_OTHER()
+    IGNORE_INCOMPATIBLE()
     DECL_OPERATION(int64_t,            int64_t,            <=)
     DECL_OPERATION(int64_t,            double,             <=)
     DECL_OPERATION(double,             int64_t,            <=)
     DECL_OPERATION(double,             double,             <=)
     DECL_OPERATION(const std::string&, const std::string&, <=)
-
-    template <class Right>
-    auto operator()(NullType, const Right&) const
-    {
-        return false;
-    }
-
-    template <class Left>
-    auto operator()(const Left&, NullType) const
-    {
-        return false;
-    }
 
     auto operator()(NullType, NullType) const
     {

--- a/include/simfil/token.h
+++ b/include/simfil/token.h
@@ -57,7 +57,7 @@ struct Token
         OP_LT, OP_LTEQ, // < <=
         OP_GT, OP_GTEQ, // > >=
         OP_BOOL,        // ?
-        /* Regexp */
+        /* Special */
         OP_LEN,         // #
         /* Path */
         OP_TYPEOF,      // typeof

--- a/include/simfil/types.h
+++ b/include/simfil/types.h
@@ -4,7 +4,9 @@
 
 #include "value.h"
 #include "typed-meta-type.h"
+
 #include <string_view>
+#include <regex>
 
 namespace simfil
 {

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -163,6 +163,9 @@ The following types can be target types for a cast:
 | `a or b`            | Logical or, returning the first non-false argument (like JavaScript).                                   |
 | `a and b`           | Logical and, returning the first false argument (like JavaScript).                                      |
 
+*Note:* When comparing values of incompatible types (e.g. `1 == "a"` or `"text" > 1`), the result is always `false`.
+The `!=` operator will always return `true` in such cases.
+
 ### Precedence
 
 | Operators                              | Precedence |
@@ -185,8 +188,8 @@ The following types can be target types for a cast:
 ### `trace(expr, limit=<...>, name=<...>)`
 
 Counts and measures all calls to its expression under the identifier `name` or the string
-representation of `expr`, if no name is given. Returnts the value of `expr`. Result values
-of `expr` are stored for debugging reasons; see `limit`.
+representation of `expr` if no name is given. Returns the value of `expr`. The result values
+of `expr` are stored for debugging purposes; see `limit`.
 
 *Example*
 ```
@@ -194,15 +197,15 @@ trace(a.**.b{trace("sub", c == "test")})
 ```
 
 Arguments:
-- `expr` Expression to trace
-- `limit` Limit of values of `expr` to store with the trace entry
-- `name` Human readable name of the trace entry; defaults to the string repr. of `expr`.
+- `expr` The expression to trace
+- `limit` The maximum number of values of `expr` to store with the trace entry
+- `name` A human-readable name of the trace entry; defaults to the string representation of `expr`.
 
 ### `range(begin, end)`
 
-The function returns a value of type `irange` which overloads the following operators:
-- `==` Tests if an element is insides the range
-- `!=` Tests if an element is outsides the range
+The function returns a value of type `irange`, which overloads the following operators:
+- `==` Tests if an element is inside the range
+- `!=` Tests if an element is outside the range
 - `...` Unpacks the range to its values (e.G. `range(1,5)... => {1, 2, 3, 4, 5}`)
 - `string` Converts the range to a string representation (`'begin..end'`)
 

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -674,7 +674,7 @@ public:
         return left_->eval(ctx, val, LambdaResultFn([this, &res, &val](Context ctx, Value lv) {
             return right_->eval(ctx, val, LambdaResultFn([this, &res, &lv](Context ctx, Value rv) {
                 return res(ctx, BinaryOperatorDispatcher<Operator>::dispatch(std::move(lv),
-                                                                              std::move(rv)));
+                                                                             std::move(rv)));
             }));
         }));
     }
@@ -757,7 +757,7 @@ public:
                 }
 
                 raise<std::runtime_error>(fmt::format("Invalid operator '{}' for values of type {} and {}",
-                                                     ident_, valueType2String(lval.type), valueType2String(rval.type)));
+                                                      ident_, valueType2String(lval.type), valueType2String(rval.type)));
             }));
         }));
     }
@@ -858,7 +858,7 @@ public:
 
 /**
  * Tries to evaluate the input expression on a stub context.
- * Returns the evaluated result on success, erwise the original expression is returned.
+ * Returns the evaluated result on success, otherwise the original expression is returned.
  */
 static auto simplifyOrForward(Environment* env, ExprPtr expr) -> ExprPtr
 {
@@ -977,7 +977,7 @@ public:
     {
         auto right = p.parsePrecedence(precedence());
         return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(std::move(left),
-                                                                                std::move(right)));
+                                                                               std::move(right)));
     }
 
     int precedence() const override

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -53,14 +53,13 @@ auto IRangeType::binaryOp(std::string_view op, const IRange& l, const Value& r) 
         auto inRange = [&](auto v) {
             return Value::make(l.low() <= v && v <= l.high());
         };
-        if (r.isa(ValueType::Null))
-            return Value::f();
         if (r.isa(ValueType::Int))
             return inRange(r.as<ValueType::Int>());
         if (r.isa(ValueType::Float))
             return inRange(r.as<ValueType::Float>());
         if (auto o = getObject<IRange>(r, &IRangeType::Type))
             return Value::make(l.begin == o->begin && l.end == o->end);
+        return Value::f();
     }
 
     raise<InvalidOperandsError>(op);
@@ -138,6 +137,12 @@ auto ReType::binaryOp(std::string_view op, const Value& l, const Re& r) const ->
         if (op == OperatorNeq::name())
             return std::regex_match(str, r.re) ? Value::f() : Value::make(str);
     }
+
+    // Just ignore incompatible types
+    if (op == OperatorEq::name())
+        return Value::f();
+    if (op == OperatorNeq::name())
+        return Value::t();
 
     raise<InvalidOperandsError>(op);
 }

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -94,8 +94,6 @@ TEST_CASE("Regular Expression", "[complex.regexp]") {
 
 TEST_CASE("Runtime Error", "[complex.runtime-error]") {
     REQUIRE_THROWS(joined_result("1 / (nonexisting as int)")); /* Division by zero */
-    REQUIRE_THROWS(joined_result("not nonexisting == 0"));     /* Invalid operands int and bool */
-    REQUIRE_THROWS(joined_result("not *.nonexisting == 0"));   /* Invalid operands int and bool */
 }
 
 TEST_CASE("Multimap JSON", "[multimap.serialization]") {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Path", "[ast.path]") {
     REQUIRE_AST("a.b", "(. a b)");
     REQUIRE_AST("a.b.c", "(. (. a b) c)");
 }
+
 TEST_CASE("Wildcard", "[ast.wildcard]") {
     REQUIRE_AST("*", "*");
     REQUIRE_AST("**", "**");

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -158,7 +158,7 @@ TEST_CASE("CompareIncompatibleTypes", "[ast.compare-incompatible]") {
 }
 
 TEST_CASE("CompareIncompatibleTypesFields", "[ast.compare-incompatible-types-fields]") {
-    static const char* doc = R"json(
+    const char* const doc = R"json(
         [
             {"field": 1, "another": 1.5},
             {"field": "text"},
@@ -166,10 +166,10 @@ TEST_CASE("CompareIncompatibleTypesFields", "[ast.compare-incompatible-types-fie
         ]
     )json";
 
-    auto model = simfil::json::parse(doc);
-    Environment env(model->strings());
+    const auto model = simfil::json::parse(doc);
+    auto test = [&model](auto query) {
+        Environment env(model->strings());
 
-    auto test = [&](auto query) {
         auto ast = compile(env, query, false);
         INFO("AST: " << ast->toString());
 
@@ -238,7 +238,7 @@ TEST_CASE("UtilityFns", "[ast.functions]") {
     REQUIRE_AST("Trace(1)",      "(trace 1)");
 }
 
-static const char* doc = R"json(
+static const char* const doc = R"json(
 {
   "a": 1,
   "b": 2,


### PR DESCRIPTION
Do not hard-fail if types are incompatible, but return `false` (or `true` for `!=`).
The comparison operators (`==` and `!=`) should now act like in JS, Lua & Python:
```
"a" == 1 // false
"a" != 1 // true
```

In addition, this changes `<` and `>` for incompatible types to return false:
```
"a" > 1  // false
         // ... (same for >=, <, <=, re == and !=, range == and !=)
```

Why not `undefined`? Undefined must be returned during _compilation_ only, as it is not considered a `simfil::Value` to be used during evaluation.

Fixes #96.