### PR TITLE
Add Support for Constants, Single-Value Queries and Symbols

### DIFF
--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -106,11 +106,11 @@ public:
     std::unique_ptr<std::mutex> traceMtx;
     std::map<std::string, Trace> traces;
 
-    /* lower-case function ident -> function */
+    /* function ident -> function */
     std::map<std::string, const Function*, CaseInsensitiveCompare> functions;
 
-    /* case-sensitive constant ident -> value */
-    std::map<std::string, Value> constants;
+    /* constant ident -> value */
+    std::map<std::string, Value, CaseInsensitiveCompare> constants;
 
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -5,12 +5,14 @@
 #include "simfil/value.h"
 #include "simfil/model/model.h"
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <vector>
 #include <chrono>
 #include <functional>
 #include <mutex>
+#include <string>
 
 namespace simfil
 {
@@ -19,6 +21,17 @@ class Expr;
 class Function;
 struct ResultFn;
 struct Debug;
+
+/** Case-insensitive comparator. */
+struct CaseInsensitiveCompare
+{
+    auto operator()(const std::string& l, const std::string& r) const -> bool
+    {
+        return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end(), [](auto lc, auto rc) {
+            return tolower(lc) < tolower(rc);
+        });
+    }
+};
 
 /** Trace call stats. */
 struct Trace
@@ -94,10 +107,10 @@ public:
     std::map<std::string, Trace> traces;
 
     /* lower-case function ident -> function */
-    std::map<std::string, const Function*> functions;
+    std::map<std::string, const Function*, CaseInsensitiveCompare> functions;
 
     /* lower-case constant ident -> value */
-    std::map<std::string, Value> constants;
+    std::map<std::string, Value, CaseInsensitiveCompare> constants;
 
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <functional>
 #include <mutex>
-#include <string>
+#include <string_view>
 
 namespace simfil
 {
@@ -25,7 +25,7 @@ struct Debug;
 /** Case-insensitive comparator. */
 struct CaseInsensitiveCompare
 {
-    auto operator()(const std::string& l, const std::string& r) const -> bool
+    auto operator()(const std::string_view& l, const std::string_view& r) const -> bool
     {
         return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end(), [](auto lc, auto rc) {
             return tolower(lc) < tolower(rc);
@@ -85,12 +85,12 @@ public:
     /**
      * Query function by name.
      */
-    auto findFunction(const std::string&) const -> const Function*;
+    auto findFunction(const std::string& name) const -> const Function*;
 
     /**
      * Query constant by name.
      */
-    auto findConstant(const std::string&) const -> const Value*;
+    auto findConstant(const std::string& name) const -> const Value*;
 
     /**
      * Obtain a strong reference to this environment's string cache.

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -109,8 +109,8 @@ public:
     /* lower-case function ident -> function */
     std::map<std::string, const Function*, CaseInsensitiveCompare> functions;
 
-    /* lower-case constant ident -> value */
-    std::map<std::string, Value, CaseInsensitiveCompare> constants;
+    /* case-sensitive constant ident -> value */
+    std::map<std::string, Value> constants;
 
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -72,7 +72,12 @@ public:
     /**
      * Query function by name.
      */
-    auto findFunction(std::string) const -> const Function*;
+    auto findFunction(const std::string&) const -> const Function*;
+
+    /**
+     * Query constant by name.
+     */
+    auto findConstant(const std::string&) const -> const Value*;
 
     /**
      * Obtain a strong reference to this environment's string cache.
@@ -90,6 +95,9 @@ public:
 
     /* lower-case function ident -> function */
     std::map<std::string, const Function*> functions;
+
+    /* lower-case constant ident -> value */
+    std::map<std::string, Value> constants;
 
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -29,6 +29,10 @@ public:
 
     /* Category */
     virtual auto type() const -> Type = 0;
+    virtual auto constant() const -> bool
+    {
+        return false;
+    }
 
     /* Debug */
     virtual auto toString() const -> std::string = 0;

--- a/include/simfil/parser.h
+++ b/include/simfil/parser.h
@@ -51,6 +51,10 @@ public:
 class Parser
 {
 public:
+    struct Context {
+        bool inPath = false;
+    };
+
     Parser(Environment*, std::vector<Token> tokens);
     Parser(Environment*, std::string_view expr);
 
@@ -87,6 +91,7 @@ public:
      */
     auto precedence(Token token) const -> int;
 
+    Context ctx;
     Environment* const env;
     std::unordered_map<Token::Type, std::unique_ptr<PrefixParselet>> prefixParsers;
     std::unordered_map<Token::Type, std::unique_ptr<InfixParselet>> infixParsers;

--- a/include/simfil/simfil.h
+++ b/include/simfil/simfil.h
@@ -23,8 +23,10 @@ namespace simfil
  *   src  Source code to compile into an expression-tree.
  * Param:
  *   any  If true, wrap expression with call to `any(...)`.
+ * Param:
+ *   autoWildcard  If true, expand constant expressions to `** = <const>`.
  */
-auto compile(Environment& env, std::string_view src, bool any = true) -> ExprPtr;
+auto compile(Environment& env, std::string_view src, bool any = true, bool autoWildcard = false) -> ExprPtr;
 
 /**
  * Evaluate compiled expression.

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 #endif
 
     auto model = std::make_shared<simfil::ModelPool>();
-    std::map<std::string, simfil::Value> constants;
+    std::map<std::string, simfil::Value, simfil::CaseInsensitiveCompare> constants;
 
     auto load_json = [&model](const std::string_view& filename) {
 #if defined(SIMFIL_WITH_MODEL_JSON)

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -1,3 +1,4 @@
+#include "simfil/environment.h"
 #include "simfil/simfil.h"
 #include "simfil/expression.h"
 #include "simfil/value.h"
@@ -161,7 +162,7 @@ int main(int argc, char *argv[])
 #endif
 
     auto model = std::make_shared<simfil::ModelPool>();
-    std::map<std::string, simfil::Value> constants;
+    std::map<std::string, simfil::Value, simfil::CaseInsensitiveCompare> constants;
 
     auto load_json = [&model](const std::string_view& filename) {
 #if defined(SIMFIL_WITH_MODEL_JSON)

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -26,6 +26,7 @@ using namespace std::string_literals;
 struct
 {
     bool auto_any = false;
+    bool auto_wildcard = false;
     bool verbose = true;
     bool multi_threaded = true;
 } options;
@@ -208,6 +209,7 @@ int main(int argc, char *argv[])
             continue;
         if (cmd[0] == '/') {
             set_option("any", options.auto_any, cmd);
+            set_option("wildcard", options.auto_wildcard, cmd);
             set_option("verbose", options.verbose, cmd);
             set_option("mt", options.multi_threaded, cmd);
             continue;
@@ -218,7 +220,7 @@ int main(int argc, char *argv[])
 
         simfil::ExprPtr expr;
         try {
-            expr = simfil::compile(env, cmd, options.auto_any);
+            expr = simfil::compile(env, cmd, options.auto_any, options.auto_wildcard);
         } catch (const std::exception& e) {
             std::cout << "Compile:\n  " << e.what() << "\n";
             continue;

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -141,7 +141,7 @@ static auto eval_mt(simfil::Environment& env, const simfil::Expr& expr, const st
     return result;
 }
 
-void show_help()
+static void show_help()
 {
     std::cout << "Usage: simfil-repl [OPTIONS] [--] FILENAME...\n"
         << "\n"
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     auto model = std::make_shared<simfil::ModelPool>();
     std::map<std::string, simfil::Value> constants;
 
-    auto load_json = [&](std::string_view filename) {
+    auto load_json = [&model](const std::string_view& filename) {
 #if defined(SIMFIL_WITH_MODEL_JSON)
         std::cout << "Parsing " << filename << "\n";
         auto f = std::ifstream(std::string(filename));
@@ -171,9 +171,9 @@ int main(int argc, char *argv[])
     };
 
     auto tail_args = false;
-    while (*++argv) {
+    while (*++argv != nullptr) {
         std::string_view arg = *argv;
-        if (!tail_args && arg[0] == '-') {
+        if ((!tail_args) && (arg[0] == '-')) {
             switch (arg[1]) {
             case '-':
                 tail_args = true;
@@ -183,10 +183,11 @@ int main(int argc, char *argv[])
                 return 0;
             case 'D':
                 arg.remove_prefix(2);
-                if (arg.empty())
+                if (arg.empty()) {
                     arg = *++argv;
-                if (auto pos = arg.find("="); pos != std::string::npos && pos > 0) {
-                    constants.emplace(std::string(arg.substr(0, pos)), simfil::Value::make(std::string(arg.substr(pos + 1))));
+                }
+                if (auto pos = arg.find("="); (pos != std::string::npos) && (pos > 0)) {
+                    constants.try_emplace(std::string(arg.substr(0, pos)), simfil::Value::make(std::string(arg.substr(pos + 1))));
                 } else {
                     std::cerr << "Invalid definition: " << arg << "\n";
                     return 1;

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 #endif
 
     auto model = std::make_shared<simfil::ModelPool>();
-    std::map<std::string, simfil::Value, simfil::CaseInsensitiveCompare> constants;
+    std::map<std::string, simfil::Value> constants;
 
     auto load_json = [&model](const std::string_view& filename) {
 #if defined(SIMFIL_WITH_MODEL_JSON)

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -7,7 +7,7 @@ structured data.
 
 ### Syntax
 
-The syntax of simfil is case-insensitive. This means that `any(...)`, `ANY(...)` and `Any(...)` all compile
+The syntax of simfil is case-insensitive in all cases but for symbols. This means that `any(...)`, `ANY(...)` and `Any(...)` all compile
 to the same function.
 
 ### Paths
@@ -29,6 +29,17 @@ The path `**` (double asterisk) represents any child (recursive) plus the curren
 
 If you need to access field names dynamically, you can use the subscript operator `[<expression>]`.
 Example: `*.["field name with spaces"]`.
+
+### Symbols
+
+Simfil parses identifiers containing only uppercase letters and underscores
+as strings, but only if not on either side of a path operator `.`.
+This means, that expressions like `**.field = ABC` get parsed as
+`**.field = "ABC"`. Note that this is not the case if a symbol appears on 
+either side of `.`, such as `ABC.field`!
+
+To force parsing a symbol as a field, you can put it in a path expression:
+`_.FIELD` or use the subscript operator `[FIELD]`.
 
 ### Sub-Queries
 

--- a/simfil-language.md
+++ b/simfil-language.md
@@ -27,6 +27,9 @@ The path `_` (underscore) represents the current node.
 The path `*` (asterisk) represents any direct child node.
 The path `**` (double asterisk) represents any child (recursive) plus the current element.
 
+If you need to access field names dynamically, you can use the subscript operator `[<expression>]`.
+Example: `*.["field name with spaces"]`.
+
 ### Sub-Queries
 
 Sub-queries can be written as a brace-enclosed expression. Path modifications inside
@@ -61,6 +64,8 @@ To check the existence of the string `"hello"` inside an array `b` you could wri
 ```
 a.b.*{_ == "hello"}
 ```
+
+Specific array elements can be accessed using the subscript `[<expression>]` operator.
 
 ## Modes
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -44,10 +44,17 @@ auto Environment::trace(const std::string& name, std::function<void(Trace&)> fn)
     fn(traces[name]);
 }
 
-auto Environment::findFunction(std::string name) const -> const Function*
+auto Environment::findFunction(const std::string& name) const -> const Function*
 {
     if (auto iter = functions.find(name); iter != functions.end())
         return iter->second;
+    return nullptr;
+}
+
+auto Environment::findConstant(const std::string& name) const -> const Value*
+{
+    if (auto iter = constants.find(name); iter != constants.end())
+        return &iter->second;
     return nullptr;
 }
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -46,14 +46,14 @@ auto Environment::trace(const std::string& name, std::function<void(Trace&)> fn)
 
 auto Environment::findFunction(const std::string& name) const -> const Function*
 {
-    if (auto iter = functions.find(name); iter != functions.end())
+    if (const auto iter = functions.find(name); iter != functions.end())
         return iter->second;
     return nullptr;
 }
 
 auto Environment::findConstant(const std::string& name) const -> const Value*
 {
-    if (auto iter = constants.find(name); iter != constants.end())
+    if (const auto iter = constants.find(name); iter != constants.end())
         return &iter->second;
     return nullptr;
 }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -60,15 +60,6 @@ enum Precedence {
 };
 
 /**
- * Downcase string.
- */
-static auto downcase(std::string s) -> std::string
-{
-    std::transform(s.begin(), s.end(), s.begin(), [](auto c) { return tolower(c); });
-    return s;
-}
-
-/**
  *
  */
 template <class ...Type>
@@ -1233,10 +1224,10 @@ class WordParser : public PrefixParselet
             p.consume();
 
             auto arguments = p.parseList(Token::RPAREN);
-            return simplifyOrForward(p.env, std::make_unique<CallExpression>(downcase(word), std::move(arguments)));
+            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
         }
         /* Constant */
-        else if (auto constant = p.env->findConstant(downcase(word))) {
+        else if (auto constant = p.env->findConstant(word)) {
             return std::make_unique<ConstExpr>(*constant);
         }
 

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -450,7 +450,7 @@ public:
         auto res = CountedResultFn<const ResultFn&>(ores, ctx);
 
         auto r = left_->eval(ctx, val, LambdaResultFn([this, &res](Context ctx, Value lv) {
-            return sub_->eval(ctx, lv, LambdaResultFn([this, &res, &lv](Context ctx, Value vv) {
+            return sub_->eval(ctx, lv, LambdaResultFn([&res, &lv](Context ctx, Value vv) {
                 auto bv = UnaryOperatorDispatcher<OperatorBool>::dispatch(vv);
                 if (bv.isa(ValueType::Undef))
                     return Result::Continue;
@@ -682,7 +682,7 @@ public:
     auto ieval(Context ctx, Value val, const ResultFn& res) const -> Result override
     {
         return left_->eval(ctx, val, LambdaResultFn([this, &res, &val](Context ctx, Value lv) {
-            return right_->eval(ctx, val, LambdaResultFn([this, &res, &lv](Context ctx, Value rv) {
+            return right_->eval(ctx, val, LambdaResultFn([&res, &lv](Context ctx, Value rv) {
                 return res(ctx, BinaryOperatorDispatcher<Operator>::dispatch(std::move(lv),
                                                                              std::move(rv)));
             }));
@@ -954,6 +954,8 @@ public:
 
         auto name = std::get<std::string>(type.value);
         return simplifyOrForward(p.env, [&]() -> ExprPtr {
+            if (name == strings::TypenameNull)
+                return std::make_unique<ConstExpr>(Value::null());
             if (name == strings::TypenameBool)
                 return std::make_unique<UnaryExpr<OperatorBool>>(std::move(left));
             if (name == strings::TypenameInt)

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -104,9 +104,14 @@ static auto expect(const ExprPtr& e, Type... types)
  */
 static auto isSymbolWord(std::string_view sv) -> bool
 {
-    return std::all_of(sv.begin(), sv.end(), [](auto c) {
-       return c == '_' || (std::isupper(c) != 0);
-    });
+    auto numUpperCaseLetters = 0;
+    return std::all_of(sv.begin(), sv.end(), [&numUpperCaseLetters](auto c) {
+       if (std::isupper(c)) {
+           ++numUpperCaseLetters;
+           return true;
+       }
+       return c == '_' || std::isdigit(c) != 0;
+    }) && numUpperCaseLetters > 0;
 }
 
 /**

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -60,6 +60,15 @@ enum Precedence {
 };
 
 /**
+ * Downcase string.
+ */
+static auto downcase(std::string s) -> std::string
+{
+    std::transform(s.begin(), s.end(), s.begin(), [](auto c) { return tolower(c); });
+    return s;
+}
+
+/**
  *
  */
 template <class ...Type>
@@ -1213,13 +1222,12 @@ class WordParser : public PrefixParselet
         if (p.match(Token::LPAREN)) {
             p.consume();
 
-            /* Downcase function name */
-            std::transform(word.begin(), word.end(), word.begin(), [](auto c) {
-                return tolower(c);
-            });
-
             auto arguments = p.parseList(Token::RPAREN);
-            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
+            return simplifyOrForward(p.env, std::make_unique<CallExpression>(downcase(word), std::move(arguments)));
+        }
+        /* Constant */
+        else if (auto constant = p.env->findConstant(downcase(word))) {
+            return std::make_unique<ConstExpr>(*constant);
         }
 
         /* Single field name */

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -1,6 +1,7 @@
 #include "simfil/simfil.h"
 #include "simfil/exception-handler.h"
 #include "simfil/model/json.h"
+#include "simfil/value.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -12,6 +13,7 @@ static const auto StaticTestKey = StringPool::NextStaticId;
 static auto getASTString(std::string_view input)
 {
     Environment env(Environment::WithNewStringCache);
+    env.constants.emplace("a_number", simfil::Value::make((int64_t)123));
     return compile(env, input, false);
 }
 
@@ -204,6 +206,10 @@ TEST_CASE("OperatorAndOr", "[ast.operator-and-or]") {
     REQUIRE_AST("1 and null", "null");
     REQUIRE_AST("1 and 2",    "2");
     REQUIRE_AST("a and b",    "(and a b)");
+}
+
+TEST_CASE("Constants", "[ast.constant]") {
+    REQUIRE_AST("a_number", "123");
 }
 
 TEST_CASE("ModeSetter", "[ast.mode-setter]") {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -220,6 +220,19 @@ TEST_CASE("Constants", "[ast.constant]") {
     REQUIRE_AST("a_number", "123");
 }
 
+TEST_CASE("Symbols", "[ast.symbol]") {
+    REQUIRE_AST("ABC", "\"ABC\"");
+    REQUIRE_AST("ABC == ABC", "true");
+    REQUIRE_AST("a.ABC", "(. a ABC)");
+    REQUIRE_AST("a.ABC.DEF", "(. (. a ABC) DEF)");
+    REQUIRE_AST("a.(ABC)", "(. a \"ABC\")");
+    REQUIRE_AST("a.(_.ABC)", "(. a (. _ ABC))");
+    REQUIRE_AST("a[ABC]", "(index a \"ABC\")");
+    REQUIRE_AST("a[_.ABC]", "(index a (. _ ABC))");
+    REQUIRE_AST("a{ABC}", "(sub a \"ABC\")");
+    REQUIRE_AST("a{_.ABC}", "(sub a (. _ ABC))");
+}
+
 TEST_CASE("ModeSetter", "[ast.mode-setter]") {
     REQUIRE_AST("any(true)",   "true");
     REQUIRE_AST("any(a.b)",    "(any (. a b))");

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -165,6 +165,7 @@ TEST_CASE("Auto Expand Constant", "[ast.auto-expand-constant]") {
     REQUIRE_AST_AUTOWILDCARD("** = 1",  "(== ** 1)");
     REQUIRE_AST_AUTOWILDCARD("1",       "(== ** 1)");
     REQUIRE_AST_AUTOWILDCARD("1+4",     "(== ** 5)");
+    REQUIRE_AST_AUTOWILDCARD("ABC",     "(== ** \"ABC\"");
 }
 
 TEST_CASE("CompareIncompatibleTypesFields", "[ast.compare-incompatible-types-fields]") {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -221,6 +221,8 @@ TEST_CASE("OperatorAndOr", "[ast.operator-and-or]") {
 
 TEST_CASE("Constants", "[ast.constant]") {
     REQUIRE_AST("a_number", "123");
+    REQUIRE_AST("A_number", "123");
+    REQUIRE_AST("A_NUMBER", "123");
 }
 
 TEST_CASE("ModeSetter", "[ast.mode-setter]") {
@@ -251,8 +253,8 @@ TEST_CASE("UtilityFns", "[ast.functions]") {
     REQUIRE_AST("trace('test', a.b)", "(trace \"test\" (. a b))");
 
     /* Test case-insensitivity */
-    REQUIRE_AST("TRACE(1)",      "(trace 1)");
-    REQUIRE_AST("Trace(1)",      "(trace 1)");
+    REQUIRE_AST("TRACE(1)",      "(TRACE 1)");
+    REQUIRE_AST("Trace(1)",      "(Trace 1)");
 }
 
 static const char* const doc = R"json(

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Auto Expand Constant", "[ast.auto-expand-constant]") {
     REQUIRE_AST_AUTOWILDCARD("** = 1",  "(== ** 1)");
     REQUIRE_AST_AUTOWILDCARD("1",       "(== ** 1)");
     REQUIRE_AST_AUTOWILDCARD("1+4",     "(== ** 5)");
-    REQUIRE_AST_AUTOWILDCARD("ABC",     "(== ** \"ABC\"");
+    REQUIRE_AST_AUTOWILDCARD("ABC",     "(== ** \"ABC\")");
 }
 
 TEST_CASE("CompareIncompatibleTypesFields", "[ast.compare-incompatible-types-fields]") {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -23,9 +23,6 @@ static auto getASTString(std::string_view input, bool autoWildcard = false)
 #define REQUIRE_AST_AUTOWILDCARD(input, output) \
     REQUIRE(getASTString(input, true)->toString() == output);
 
-#define REQUIRE_UNDEF(input) \
-    REQUIRE(getASTString(input, false)-> == output);
-
 TEST_CASE("Path", "[ast.path]") {
     REQUIRE_AST("a", "a");
     REQUIRE_AST("a.b", "(. a b)");
@@ -221,8 +218,6 @@ TEST_CASE("OperatorAndOr", "[ast.operator-and-or]") {
 
 TEST_CASE("Constants", "[ast.constant]") {
     REQUIRE_AST("a_number", "123");
-    REQUIRE_AST("A_number", "123");
-    REQUIRE_AST("A_NUMBER", "123");
 }
 
 TEST_CASE("ModeSetter", "[ast.mode-setter]") {


### PR DESCRIPTION
- Change from downcasing functions and constants to case insensitive comparison
- Adds support for constants registered to the environment
- Adds an option `autoWildcard` to `compile` that expands constant queries to queries of the form `** == <constant>`, allowing to query all fields by entering just a value
- Parse upper-case words as strings (e.g. `AN_ENUM_VALUE`), if not part of a path