### PR TITLE
Remove Exceptions - Part I

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(simfil ${LIBRARY_TYPE}
   src/diagnostics.cpp
   src/completion.h
   src/completion.cpp
+  src/error.cpp
   src/function.cpp
   src/parser.cpp
   src/token.cpp
@@ -66,6 +67,8 @@ target_sources(simfil PUBLIC
   FILE_SET public_headers
     TYPE HEADERS
     FILES
+      include/simfil/error.h
+      include/simfil/sourcelocation.h
       include/simfil/environment.h
       include/simfil/diagnostics.h
       include/simfil/expression.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(simfil
   PUBLIC
     sfl::sfl
     fmt::fmt
+    tl::expected
     Bitsery::bitsery)
 
 if (SIMFIL_FPIC OR NOT SIMFIL_SHARED)

--- a/README.md
+++ b/README.md
@@ -141,11 +141,15 @@ auto env = simfil::Environment{strings};
 
 // Compile query string to a simfil::Expression.
 auto query = simfil::compile(env, "name", false);
+if (!query)
+    std::cerr << query.error() << "\n";
 
 // Evalualte query and get result of type simfil::Value.
-auto result = simfil::eval(env, *query, *model, nullptr);
+auto result = simfil::eval(env, query.value(), *model, nullptr);
+if (!result)
+    std::cerr << result.error() << "\n";
 
-for (auto&& value : result)
+for (auto&& value : result.value())
     std::cout << value.toString() << "\n";
 ```
 
@@ -156,3 +160,4 @@ The full source of the example can be found [here](./examples/minimal/main.cpp).
 - [fraillt/bitsery](https://github.com/fraillt/bitsery) for binary en- and decoding.
 - [slavenf/sfl-library](https://github.com/slavenf/sfl-library.git) for small and segmented vector containers.
 - [fmtlib/fmt](https://github.com/fmtlib/fmt) string formatting library.
+- [tl/excpected](https://github.com/TartanLlama/expected) `std::expected` implementation.

--- a/README.md
+++ b/README.md
@@ -141,13 +141,17 @@ auto env = simfil::Environment{strings};
 
 // Compile query string to a simfil::Expression.
 auto query = simfil::compile(env, "name", false);
-if (!query)
+if (!query) {
     std::cerr << query.error() << "\n";
+    return -1;
+}
 
-// Evalualte query and get result of type simfil::Value.
-auto result = simfil::eval(env, query.value(), *model, nullptr);
-if (!result)
+// Evaluate query and get result of type simfil::Value.
+auto result = simfil::eval(env, *query, *model->root(0), nullptr);
+if (!result) {
     std::cerr << result.error() << "\n";
+    return -1;
+}
 
 for (auto&& value : result.value())
     std::cout << value.toString() << "\n";

--- a/deps.cmake
+++ b/deps.cmake
@@ -28,6 +28,16 @@ if (NOT TARGET Bitsery::bitsery)
   FetchContent_MakeAvailable(bitsery)
 endif()
 
+if (NOT TARGET tl::expected)
+  set(EXPECTED_BUILD_TESTS NO)
+  set(EXPECTED_BUILD_PACKAGE_DEB NO)
+  FetchContent_Declare(expected
+    GIT_REPOSITORY "https://github.com/TartanLlama/expected.git"
+    GIT_TAG        "v1.1.0"
+    GIT_SHALLOW    ON)
+  FetchContent_MakeAvailable(expected)
+endif()
+
 if (SIMFIL_WITH_MODEL_JSON)
   if (NOT TARGET nlohmann_json::nlohmann_json)
     FetchContent_Declare(nlohmann_json

--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -33,6 +33,11 @@ int main()
 
     // Evalualte query and get result of type simfil::Value.
     auto result = simfil::eval(env, **ast, *model->root(0), nullptr);
+    if (!result) {
+        std::cerr << result.error().message << '\n';
+        return -1;
+    }
+
 
     for (auto&& value : result.value())
         std::cout << value.toString() << "\n";

--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -25,11 +25,15 @@ int main()
     auto env = simfil::Environment{strings};
 
     // Compile query string to a simfil::Expression.
-    auto query = simfil::compile(env, "name", false);
+    auto ast = simfil::compile(env, "name", false);
+    if (!ast) {
+        std::cerr << ast.error().message << '\n';
+        return -1;
+    }
 
     // Evalualte query and get result of type simfil::Value.
-    auto result = simfil::eval(env, *query, *model->root(0), nullptr);
+    auto result = simfil::eval(env, **ast, *model->root(0), nullptr);
 
-    for (auto&& value : result)
+    for (auto&& value : result.value())
         std::cout << value.toString() << "\n";
 }

--- a/include/simfil/diagnostics.h
+++ b/include/simfil/diagnostics.h
@@ -4,7 +4,9 @@
 
 #include "simfil/value.h"
 #include "simfil/token.h"
+#include "simfil/error.h"
 
+#include <tl/expected.hpp>
 #include <optional>
 #include <vector>
 #include <string>
@@ -45,8 +47,8 @@ public:
 
     struct Data;
 private:
-    friend auto eval(Environment&, const AST&, const ModelNode&, Diagnostics*) -> std::vector<Value>;
-    friend auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> std::vector<Message>;
+    friend auto eval(Environment&, const AST&, const ModelNode&, Diagnostics*) -> tl::expected<std::vector<Value>, Error>;
+    friend auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Message>, Error>;
 
     using ExprId = size_t;
 

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -195,7 +195,7 @@ struct CompletionCandidate
 
     auto operator<=>(const CompletionCandidate& r) const
     {
-        return std::tie(text, location.begin, location.size) <=> std::tie(r.text, r.location.begin, r.location.size);
+        return std::tie(text, location.offset, location.size) <=> std::tie(r.text, r.location.offset, r.location.size);
     }
 };
 

--- a/include/simfil/error.h
+++ b/include/simfil/error.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+
+#include "simfil/sourcelocation.h"
+
+namespace simfil
+{
+
+struct Token;
+
+struct Error
+{
+    enum Type {
+        ParserError,
+        InvalidType,
+        InvalidExpression,
+        ExpectedEOF,
+        NullModel,
+    };
+
+    explicit Error(Type type);
+    Error(Type type, std::string message);
+    Error(Type type, std::string message, SourceLocation location);
+    Error(Type type, std::string message, const Token& token);
+
+    Type type;
+    SourceLocation location;
+    std::string message;
+};
+
+}

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -34,7 +34,7 @@ public:
     explicit Expr(const Token& token)
     {
         assert(token.end >= token.begin);
-        sourceLocation_.begin = token.begin;
+        sourceLocation_.offset = token.begin;
         sourceLocation_.size = token.end - token.begin;
     }
 

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <bitset>
+#include <tl/expected.hpp>
 #include <memory>
 #include <type_traits>
 #include <variant>
 #include <functional>
+#include <bitset>
 
 #include "arena.h"
 #include "string-pool.h"
+#include "simfil/error.h"
 
 #include <sfl/small_vector.hpp>
 
@@ -199,7 +201,7 @@ struct ModelNode
     friend class ModelPool;
     friend class Model;
     friend class OverlayNode;
-    friend std::vector<Value> eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics*);
+    friend auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics*) -> tl::expected<std::vector<Value>, Error>;
 
     /// Get the node's scalar value if it has one
     [[nodiscard]] virtual ScalarValueType value() const;

--- a/include/simfil/simfil.h
+++ b/include/simfil/simfil.h
@@ -4,15 +4,18 @@
 
 #include <vector>
 #include <string_view>
+#include <tl/expected.hpp>
 
 #include "simfil/expression.h"
 #include "simfil/environment.h"
 #include "simfil/diagnostics.h"
 #include "simfil/value.h"
-#include "simfil/model/model.h"
+#include "simfil/error.h"
 
 namespace simfil
 {
+
+struct ModelNode;
 
 /**
  * Compile expression `src`.
@@ -25,7 +28,7 @@ namespace simfil
  * Param:
  *   autoWildcard  If true, expand constant expressions to `** = <const>`.
  */
-auto compile(Environment& env, std::string_view query, bool any = true, bool autoWildcard = false) -> ASTPtr;
+auto compile(Environment& env, std::string_view query, bool any = true, bool autoWildcard = false) -> tl::expected<ASTPtr, Error>;
 
 /**
  * Evaluate compiled expression.
@@ -38,7 +41,7 @@ auto compile(Environment& env, std::string_view query, bool any = true, bool aut
  * Param:
  *   diag   Optional pointer to a diagnostics object to merge results into.
  */
-auto eval(Environment& env, const AST& ast, ModelNode const& node, Diagnostics* diag) -> std::vector<Value>;
+auto eval(Environment& env, const AST& ast, ModelNode const& node, Diagnostics* diag) -> tl::expected<std::vector<Value>, Error>;
 
 /**
  * Build messages for diagnostics collected by `eval`.
@@ -49,7 +52,7 @@ auto eval(Environment& env, const AST& ast, ModelNode const& node, Diagnostics* 
  * Param:
  *   diag   Diagnostics data filled by eval.
  */
-auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> std::vector<Diagnostics::Message>;
+auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Diagnostics::Message>, Error>;
 
 /**
  * Find completion candidates for an expression.
@@ -62,6 +65,6 @@ auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> s
  * Param:
  *   node   Root node of the data model to query in
  */
-auto complete(Environment& env, std::string_view query, size_t point, ModelNode const& node, CompletionOptions const& options) -> std::vector<CompletionCandidate>;
+auto complete(Environment& env, std::string_view query, size_t point, ModelNode const& node, CompletionOptions const& options) -> tl::expected<std::vector<CompletionCandidate>, Error>;
 
 }

--- a/include/simfil/sourcelocation.h
+++ b/include/simfil/sourcelocation.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace simfil
+{
+
+struct SourceLocation
+{
+    size_t begin = 0;
+    size_t size = 0;
+};
+
+}

--- a/include/simfil/sourcelocation.h
+++ b/include/simfil/sourcelocation.h
@@ -1,12 +1,24 @@
 #pragma once
 
+#include <cstddef>
+
 namespace simfil
 {
 
 struct SourceLocation
 {
-    size_t begin = 0;
+    size_t offset = 0;
     size_t size = 0;
+
+    SourceLocation()
+        : offset(0), size(0)
+    {}
+
+    SourceLocation(size_t offset, size_t size)
+        : offset(offset), size(size)
+    {}
+
+    SourceLocation(const SourceLocation&) = default;
 };
 
 }

--- a/include/simfil/token.h
+++ b/include/simfil/token.h
@@ -7,15 +7,12 @@
 #include <string_view>
 #include <variant>
 #include <cstdint>
+#include <tl/expected.hpp>
+
+#include "simfil/error.h"
 
 namespace simfil
 {
-
-struct SourceLocation
-{
-    size_t begin = 0;
-    size_t size = 0;
-};
 
 struct Token
 {
@@ -105,6 +102,6 @@ std::ostream& operator<<(std::ostream&, const Token&);
 /**
  * Split a SIMFIL expression `expr` into parser tokens
  */
-std::vector<Token> tokenize(std::string_view expr);
+auto tokenize(std::string_view expr) -> tl::expected<std::vector<Token>, Error>;
 
 }

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -77,16 +77,17 @@ char* command_generator(const char* text, int state)
         }
 
         if (current_env) {
-            try {
-                simfil::CompletionOptions opts;
-                opts.limit = 25;
-                opts.autoWildcard = options.auto_wildcard;
+            simfil::CompletionOptions opts;
+            opts.limit = 25;
+            opts.autoWildcard = options.auto_wildcard;
 
-                auto comp = simfil::complete(*current_env, query, rl_point, *model->root(0), opts);
-                for (const auto& candidate : comp) {
-                    matches.push_back(query.substr(0, candidate.location.begin) + candidate.text);
-                }
-            } catch (const std::runtime_error&) {}
+            auto comp = simfil::complete(*current_env, query, rl_point, *model->root(0), opts);
+            if (!comp)
+                return nullptr;
+
+            for (const auto& candidate : *comp) {
+                matches.push_back(query.substr(0, candidate.location.begin) + candidate.text);
+            }
         }
     }
 
@@ -133,7 +134,10 @@ static auto eval_mt(simfil::Environment& env, const simfil::AST& ast, const std:
 
     if (!model->numRoots()) {
         model->addRoot(simfil::ModelNode::Ptr());
-        result[0] = simfil::eval(env, ast, *model->root(0), &diag);
+        auto res = simfil::eval(env, ast, *model->root(0), &diag);
+        if (res)
+            result[0] = std::move(*res);
+        // TODO: Output eval errors
         return result;
     }
 
@@ -147,16 +151,19 @@ static auto eval_mt(simfil::Environment& env, const simfil::AST& ast, const std:
     auto threads = std::vector<std::thread>();
     threads.reserve(n_threads);
     for (auto i = 0; i < n_threads; ++i) {
-        threads.emplace_back(std::thread([&, i]() {
+        threads.emplace_back([&, i]() {
             size_t next;
             while ((next = idx++) < model->numRoots()) {
                 try {
-                    result[next] = simfil::eval(env, ast, *model->root(next), &diag);
+                    auto res = simfil::eval(env, ast, *model->root(next), &diag);
+                    if (res)
+                        result[next] = std::move(*res);
+                    // TODO: Output eval errors
                 } catch (...) {
                     return;
                 }
             }
-        }));
+        });
     }
 
     for (auto& thread : threads)
@@ -178,10 +185,10 @@ static void show_help()
         << "\n";
 }
 
-static void display_error(std::string_view expression, const simfil::ParserError& e)
+static void display_error(std::string_view expression, const simfil::Error& e)
 {
     static const auto indent = "  ";
-    auto [begin, end] = e.range();
+    auto [begin, end] = e.location;
 
     std::string underline;
     if (end >= begin) {
@@ -193,7 +200,7 @@ static void display_error(std::string_view expression, const simfil::ParserError
     }
 
     std::cout << "Error:\n"
-        << indent << e.what() << ".\n\n"
+        << indent << e.message << ".\n\n"
         << indent << expression << "\n"
         << indent << underline << "\n";
 }
@@ -262,20 +269,14 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        simfil::ASTPtr ast;
-        try {
-            ast = simfil::compile(env, cmd, options.auto_any, options.auto_wildcard);
-        } catch (const simfil::ParserError& e) {
-            display_error(cmd, e);
-        } catch (const std::exception& e) {
-            std::cout << "Compile:\n  " << e.what() << "\n";
+        auto ast = simfil::compile(env, cmd, options.auto_any, options.auto_wildcard);
+        if (!ast) {
+            display_error(cmd, ast.error());
+            continue;
         }
 
-        if (!ast)
-            continue;
-
         if (options.verbose)
-            std::cout << "Expression:\n  " << ast->expr().toString() << "\n";
+            std::cout << "Expression:\n  " << (*ast)->expr().toString() << "\n";
 
         simfil::Diagnostics diag;
         std::vector<std::vector<simfil::Value>> res;
@@ -283,7 +284,7 @@ int main(int argc, char *argv[])
 
         try {
             auto eval_begin = std::chrono::steady_clock::now();
-            res = eval_mt(env, *ast, model, diag);
+            res = eval_mt(env, **ast, model, diag);
             msec = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - eval_begin);
         } catch (const std::exception& e) {
             std::cout << "Error:\n  " << e.what() << "\n";
@@ -304,8 +305,13 @@ int main(int argc, char *argv[])
             std::cout << "  " << v.toString() << "\n";
         }
 
-        auto messages = simfil::diagnostics(env, *ast, diag);
-        if (!messages.empty()) {
+        auto messages = simfil::diagnostics(env, **ast, diag);
+        if (!messages) {
+            std::cerr << "Error: " << messages.error().message << "\n";
+            continue;
+        }
+
+        if (!messages->empty()) {
             std::cout << "Diagnostics:\n";
 
             auto underlineQuery = [&](simfil::SourceLocation loc) {
@@ -317,9 +323,9 @@ int main(int argc, char *argv[])
                 return underline;
             };
 
-            for (const auto& m : messages) {
+            for (const auto& m : *messages) {
                 std::cout << "  " << m.message << "\n"
-                          << "  Here: " << ast->query() << "\n"
+                          << "  Here: " << (*ast)->query() << "\n"
                           << "        " << underlineQuery(m.location) << "\n"
                           << "   Fix: " << m.fix.value_or("-") << "\n";
             }

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -86,7 +86,7 @@ char* command_generator(const char* text, int state)
                 return nullptr;
 
             for (const auto& candidate : *comp) {
-                matches.push_back(query.substr(0, candidate.location.begin) + candidate.text);
+                matches.push_back(query.substr(0, candidate.location.offset) + candidate.text);
             }
         }
     }
@@ -188,15 +188,15 @@ static void show_help()
 static void display_error(std::string_view expression, const simfil::Error& e)
 {
     static const auto indent = "  ";
-    auto [begin, end] = e.location;
+    auto [offset, end] = e.location;
 
     std::string underline;
-    if (end >= begin) {
-        if (begin > 0)
-            std::generate_n(std::back_inserter(underline), begin, []() { return ' '; });
+    if (end >= offset) {
+        if (offset > 0)
+            std::generate_n(std::back_inserter(underline), offset, []() { return ' '; });
         underline.push_back('^');
-        if (end > begin)
-            std::generate_n(std::back_inserter(underline), end - begin - 1, []() { return '~'; });
+        if (end > offset)
+            std::generate_n(std::back_inserter(underline), end - offset - 1, []() { return '~'; });
     }
 
     std::cout << "Error:\n"
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
             auto underlineQuery = [&](simfil::SourceLocation loc) {
                 std::string underline;
-                std::fill_n(std::back_inserter(underline), loc.begin, ' ');
+                std::fill_n(std::back_inserter(underline), loc.offset, ' ');
                 underline.push_back('^');
                 if (loc.size > 0)
                     std::fill_n(std::back_inserter(underline), loc.size - 1, '~');

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -188,15 +188,15 @@ static void show_help()
 static void display_error(std::string_view expression, const simfil::Error& e)
 {
     static const auto indent = "  ";
-    auto [offset, end] = e.location;
+    auto [offset, size] = e.location;
 
     std::string underline;
-    if (end >= offset) {
+    if (size >= 0) {
         if (offset > 0)
             std::generate_n(std::back_inserter(underline), offset, []() { return ' '; });
         underline.push_back('^');
-        if (end > offset)
-            std::generate_n(std::back_inserter(underline), end - offset - 1, []() { return '~'; });
+        if (size > 0)
+            std::generate_n(std::back_inserter(underline), size - 1, []() { return '~'; });
     }
 
     std::cout << "Error:\n"

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -124,8 +124,8 @@ struct FindExpressionRange : ExprVisitor
 
         auto loc = expr.sourceLocation();
         if (loc.size > 0) {
-            min = std::min<size_t>(min, loc.begin);
-            max = std::max<size_t>(max, loc.begin + loc.size);
+            min = std::min<size_t>(min, loc.offset);
+            max = std::max<size_t>(max, loc.offset + loc.size);
         }
     }
 };

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -112,7 +112,7 @@ auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::
             if (!guess.empty()) {
                 std::string fix = ast.query();
                 if (auto loc = e.sourceLocation(); loc.size > 0)
-                    fix.replace(loc.begin, loc.size, guess);
+                    fix.replace(loc.offset, loc.size, guess);
 
                 addMessage(fmt::format("No matches for field '{}'. Did you mean '{}'?", e.name_, guess), e, fix);
             } else {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,0 +1,24 @@
+#include "simfil/error.h"
+
+#include "simfil/token.h"
+
+namespace simfil
+{
+
+Error::Error(Type type)
+    : type(type)
+{}
+
+Error::Error(Type type, std::string message)
+    : type(type), message(std::move(message))
+{}
+
+Error::Error(Type type, std::string message, SourceLocation location)
+    : type(type), message(std::move(message)), location(location)
+{}
+
+Error::Error(Type type, std::string message, const Token& token)
+    : type(type), message(std::move(message)), location(token.begin, token.begin - token.end)
+{}
+
+}

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -18,7 +18,7 @@ Error::Error(Type type, std::string message, SourceLocation location)
 {}
 
 Error::Error(Type type, std::string message, const Token& token)
-    : type(type), message(std::move(message)), location(token.begin, token.begin - token.end)
+    : type(type), message(std::move(message)), location(token.begin, token.end - token.begin)
 {}
 
 }

--- a/src/expected.h
+++ b/src/expected.h
@@ -10,8 +10,13 @@
     }                                                                          \
   } while (false)
 
+namespace simfil
+{
+
 template <class T, class E>
-using expected = tl::expected<T, E>;
+using expected = ::tl::expected<T, E>;
 
 template <class E>
-using unexpected = tl::unexpected<E>;
+using unexpected = ::tl::unexpected<E>;
+
+}

--- a/src/expected.h
+++ b/src/expected.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "tl/expected.hpp"
+
+// Helper macro for bubbling-up tl::expected errors.
+#define TRY_EXPECTED(res)                                                      \
+  do {                                                                         \
+    if (!(res).has_value()) {                                                  \
+      return tl::unexpected(std::move((res).error()));                         \
+    }                                                                          \
+  } while (false)
+
+template <class T, class E>
+using expected = tl::expected<T, E>;
+
+template <class E>
+using unexpected = tl::unexpected<E>;

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -801,6 +801,7 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
             return root;
         }
     }();
+    TRY_EXPECTED(expr);
 
     if (!p.match(Token::Type::NIL))
         return unexpected<Error>(Error::ExpectedEOF, "Expected end-of-input; got "s + p.current().toString());

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -511,6 +511,9 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
         /* Prefix sub-selects are transformed to a right side path expression,
          * with the current node on the left. As "standalone" sub-selects are not useful. */
         auto body = p.parseTo(Token::RBRACE);
+        if (!body)
+            return unexpected<Error>(std::move(body.error()));
+
         return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::make_unique<FieldExpr>("_"),
                                                                   std::move(*body)));
     }
@@ -522,6 +525,9 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
 
         auto _ = scopedNotInPath(p);
         auto body = p.parseTo(Token::RBRACE);
+        if (!body)
+            return unexpected<Error>(std::move(body.error()));
+
         return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::move(left),
                                                                   std::move(*body)));
     }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -10,10 +10,12 @@
 #include "simfil/environment.h"
 #include "simfil/model/model.h"
 #include "simfil/types.h"
+#include "simfil/error.h"
 #include "fmt/core.h"
 
 #include "expressions.h"
 #include "completion.h"
+#include "expected.h"
 
 #include <algorithm>
 #include <cctype>
@@ -21,11 +23,11 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <deque>
 #include <unordered_map>
-#include <stdexcept>
 #include <cassert>
 #include <vector>
 
@@ -66,7 +68,7 @@ enum Precedence {
  *
  */
 template <class ...Type>
-static auto expect(const ExprPtr& e, Type... types)
+static auto expect(const ExprPtr& e, Type... types) -> std::optional<unexpected<Error>>
 {
     const auto type2str = [](Expr::Type t) {
         switch (t) {
@@ -80,13 +82,13 @@ static auto expect(const ExprPtr& e, Type... types)
     };
 
     if (!e)
-        raise<std::runtime_error>("Expected expression"s);
+        return unexpected<Error>(Error::InvalidExpression, "Expected expression");
 
     if constexpr (sizeof...(types) >= 1) {
         Expr::Type list[] = {types...};
         for (auto i = 0; i < sizeof...(types); ++i) {
             if (e->type() == list[i])
-                return;
+                return {};
         }
 
         std::string typeNames;
@@ -96,7 +98,7 @@ static auto expect(const ExprPtr& e, Type... types)
             typeNames += type2str(list[i]);
         }
 
-        raise<std::runtime_error>("Expected "s + typeNames + " got "s + type2str(e->type()));
+        return unexpected<Error>(Error::InvalidExpression, fmt::format("Expected {} got {}", typeNames, type2str(e->type())));
     }
 }
 
@@ -147,14 +149,16 @@ static auto scopedNotInPath(Parser& p) {
  * Tries to evaluate the input expression on a stub context.
  * Returns the evaluated result on success, otherwise the original expression is returned.
  */
-static auto simplifyOrForward(Environment* env, ExprPtr expr) -> ExprPtr
+static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -> expected<ExprPtr, Error>
 {
     if (!expr)
+        return expr;
+    if (!*expr)
         return nullptr;
 
     std::deque<Value> values;
     auto stub = Context(env, Context::Phase::Compilation);
-    (void)expr->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value vv) mutable {
+    (void)(*expr)->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value vv) mutable {
         n += 1;
         if ((n <= MultiConstExpr::Limit) && (!vv.isa(ValueType::Undef) || vv.node)) {
             values.push_back(std::move(vv));
@@ -169,12 +173,12 @@ static auto simplifyOrForward(Environment* env, ExprPtr expr) -> ExprPtr
     if (!values.empty() && std::ranges::all_of(values.begin(), values.end(), [](const Value& v) {
         return v.isa(ValueType::Null);
     }))
-        env->warn("Expression is alway null"s, expr->toString());
+        env->warn("Expression is alway null"s, (*expr)->toString());
 
     if (!values.empty() && values[0].isa(ValueType::Bool) && std::ranges::all_of(values.begin(), values.end(), [&](const Value& v) {
         return v.isBool(values[0].as<ValueType::Bool>());
     }))
-        env->warn("Expression is always "s + values[0].toString(), expr->toString());
+        env->warn("Expression is always "s + values[0].toString(), (*expr)->toString());
 
     if (values.size() == 1)
         return std::make_unique<ConstExpr>(std::move(values[0]));
@@ -195,16 +199,18 @@ AST::~AST() = default;
 class AndOrParser : public InfixParselet
 {
 public:
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto right = p.parsePrecedence(precedence());
+        if (!right)
+            return right;
 
         if (t.type == Token::OP_AND)
           return simplifyOrForward(p.env, std::make_unique<AndExpr>(std::move(left),
-                                                                    std::move(right)));
+                                                                    std::move(*right)));
         else if (t.type == Token::OP_OR)
           return simplifyOrForward(p.env, std::make_unique<OrExpr>(std::move(left),
-                                                                   std::move(right)));
+                                                                   std::move(*right)));
         assert(0);
         return nullptr;
     }
@@ -222,16 +228,18 @@ public:
         : comp_(comp)
     {}
 
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto right = p.parsePrecedence(precedence());
+        if (!right)
+            return right;
 
         if (t.type == Token::OP_AND)
           return simplifyOrForward(p.env, std::make_unique<CompletionAndExpr>(std::move(left),
-                                                                              std::move(right), comp_));
+                                                                              std::move(*right), comp_));
         else if (t.type == Token::OP_OR)
           return simplifyOrForward(p.env, std::make_unique<CompletionOrExpr>(std::move(left),
-                                                                             std::move(right), comp_));
+                                                                             std::move(*right), comp_));
         assert(0);
         return nullptr;
     }
@@ -247,17 +255,17 @@ public:
 class CastParser : public InfixParselet
 {
 public:
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto type = p.consume();
         if (type.type == Token::C_NULL)
             return std::make_unique<ConstExpr>(Value::null());
 
         if (type.type != Token::Type::WORD)
-            raise<std::runtime_error>("'as' expected typename got "s + type.toString());
+            return unexpected<Error>(Error::InvalidType, fmt::format("'as' expected typename got {}", type.toString()));
 
         auto name = std::get<std::string>(type.value);
-        return simplifyOrForward(p.env, [&]() -> ExprPtr {
+        return simplifyOrForward(p.env, [&]() -> expected<ExprPtr, Error> {
             if (name == strings::TypenameNull)
                 return std::make_unique<ConstExpr>(Value::null());
             if (name == strings::TypenameBool)
@@ -269,7 +277,7 @@ public:
             if (name == strings::TypenameString)
                 return std::make_unique<UnaryExpr<OperatorAsString>>(std::move(left));
 
-            raise<std::runtime_error>("Invalid type name for cast '"s + name + "'"s);
+            return unexpected<Error>(Error::InvalidType, fmt::format("Invalid type name for cast '{}'", name));
         }());
     }
 
@@ -289,12 +297,15 @@ template <class Operator,
 class BinaryOpParser : public InfixParselet
 {
 public:
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto right = p.parsePrecedence(precedence());
+        if (!right)
+            return right;
+
         return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(t,
                                                                                std::move(left),
-                                                                               std::move(right)));
+                                                                               std::move(*right)));
     }
 
     int precedence() const override
@@ -311,10 +322,13 @@ public:
 template <class Operator>
 class UnaryOpParser : public PrefixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto sub = p.parsePrecedence(Precedence::UNARY);
-        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(sub)));
+        if (!sub)
+            return sub;
+
+        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(*sub)));
     }
 };
 
@@ -324,7 +338,7 @@ class UnaryOpParser : public PrefixParselet
 template <class Operator>
 class UnaryPostOpParser : public InfixParselet
 {
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(left))), 0);
     }
@@ -340,7 +354,7 @@ class UnaryPostOpParser : public InfixParselet
  */
 class UnpackOpParser : public InfixParselet
 {
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnpackExpr>(std::move(left))), 0);
     }
@@ -356,13 +370,18 @@ class UnpackOpParser : public InfixParselet
  */
 class WordOpParser : public InfixParselet
 {
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         /* Try parse as binary operator */
-        if (auto right = p.parsePrecedence(precedence(), true); right)
+        auto right = p.parsePrecedence(precedence(), true);
+        if (!right)
+            return right;
+
+        if (*right)
             return simplifyOrForward(p.env, std::make_unique<BinaryWordOpExpr>(std::get<std::string>(t.value),
                                                                                std::move(left),
-                                                                               std::move(right)));
+                                                                               std::move(*right)));
+
         /* Parse as unary operator */
         return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryWordOpExpr>(std::get<std::string>(t.value),
                                                                                        std::move(left))), 0);
@@ -382,7 +401,7 @@ class WordOpParser : public InfixParselet
 template <class Type>
 class ScalarParser : public PrefixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         return std::make_unique<ConstExpr>(std::get<Type>(t.value));
     }
@@ -395,7 +414,7 @@ class ScalarParser : public PrefixParselet
  */
 class RegExpParser : public PrefixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto value = ReType::Type.make(std::get<std::string>(t.value));
         return std::make_unique<ConstExpr>(std::move(value));
@@ -417,7 +436,7 @@ public:
         : value_(std::move(value))
     {}
 
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         return std::make_unique<ConstExpr>(value_);
     }
@@ -432,7 +451,7 @@ public:
  */
 class ParenParser : public PrefixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto _ = scopedNotInPath(p);
         return p.parseTo(Token::RPAREN);
@@ -447,23 +466,29 @@ class ParenParser : public PrefixParselet
  */
 class SubscriptParser : public PrefixParselet, public InfixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto _ = scopedNotInPath(p);
+        auto body = p.parseTo(Token::RBRACK);
+        if (!body)
+            return body;
+
         return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::make_unique<FieldExpr>("_"),
-                                                                        p.parseTo(Token::RBRACK)));
+                                                                        std::move(*body)));
     }
 
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        expect(left,
-               Expr::Type::PATH,
-               Expr::Type::VALUE,
-               Expr::Type::SUBEXPR,
-               Expr::Type::SUBSCRIPT);
+        if (auto err = expect(left, Expr::Type::PATH, Expr::Type::VALUE, Expr::Type::SUBEXPR, Expr::Type::SUBSCRIPT))
+            return *err;
+
         auto _ = scopedNotInPath(p);
+        auto body = p.parseTo(Token::RBRACK);
+        if (!body)
+            return body;
+
         return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::move(left),
-                                                                        p.parseTo(Token::RBRACK)));
+                                                                        std::move(*body)));
     }
 
     auto precedence() const -> int override
@@ -480,25 +505,25 @@ class SubscriptParser : public PrefixParselet, public InfixParselet
  */
 class SubSelectParser : public PrefixParselet, public InfixParselet
 {
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto _ = scopedNotInPath(p);
         /* Prefix sub-selects are transformed to a right side path expression,
          * with the current node on the left. As "standalone" sub-selects are not useful. */
+        auto body = p.parseTo(Token::RBRACE);
         return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::make_unique<FieldExpr>("_"),
-                                                                  p.parseTo(Token::RBRACE)));
+                                                                  std::move(*body)));
     }
 
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        expect(left,
-               Expr::Type::PATH,
-               Expr::Type::VALUE,
-               Expr::Type::SUBEXPR,
-               Expr::Type::SUBSCRIPT);
+        if (auto err = expect(left, Expr::Type::PATH, Expr::Type::VALUE, Expr::Type::SUBEXPR, Expr::Type::SUBSCRIPT))
+            return *err;
+
         auto _ = scopedNotInPath(p);
+        auto body = p.parseTo(Token::RBRACE);
         return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::move(left),
-                                                                  p.parseTo(Token::RBRACE)));
+                                                                  std::move(*body)));
     }
 
     auto precedence() const -> int override
@@ -515,7 +540,7 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
 class WordParser : public PrefixParselet
 {
 public:
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         /* Self */
         if (t.type == Token::SELF)
@@ -537,12 +562,14 @@ public:
             p.consume();
 
             auto arguments = p.parseList(Token::RPAREN);
+            TRY_EXPECTED(arguments);
+
             if (word == "any") {
-                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(arguments)));
+                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(*arguments)));
             } else if (word == "each" || word == "all") {
-                return simplifyOrForward(p.env, std::make_unique<EachExpr>(std::move(arguments)));
+                return simplifyOrForward(p.env, std::make_unique<EachExpr>(std::move(*arguments)));
             } else {
-                return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
+                return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
             }
         } else if (!p.ctx.inPath) {
             /* Parse Symbols (words in upper-case) */
@@ -570,7 +597,7 @@ public:
         : comp_(comp)
     {}
 
-    auto parse(Parser& p, Token t) const -> ExprPtr override
+    auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         /* Self */
         if (t.type == Token::SELF)
@@ -596,7 +623,9 @@ public:
             });
 
             auto arguments = p.parseList(Token::RPAREN);
-            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(arguments)));
+            TRY_EXPECTED(arguments);
+
+            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
         }
 
         /* Single field name */
@@ -618,7 +647,7 @@ public:
 class PathParser : public InfixParselet
 {
 public:
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto inPath = true;
         std::swap(p.ctx.inPath, inPath);
@@ -628,7 +657,9 @@ public:
         });
 
         auto right = p.parsePrecedence(precedence());
-        return std::make_unique<PathExpr>(std::move(left), std::move(right));
+        TRY_EXPECTED(right);
+
+        return std::make_unique<PathExpr>(std::move(left), std::move(*right));
     }
 
     auto precedence() const -> int override
@@ -644,7 +675,7 @@ public:
         : comp_(comp)
     {}
 
-    auto parse(Parser& p, ExprPtr left, Token t) const -> ExprPtr override
+    auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
         auto inPath = true;
         std::swap(p.ctx.inPath, inPath);
@@ -654,12 +685,15 @@ public:
         });
 
         auto right = p.parsePrecedence(precedence(), t.containsPoint(comp_->point));
-        if (!right) {
+        if (!right)
+            return right;
+
+        if (!*right) {
             Token expectedWord(Token::WORD, "", t.end, t.end);
             right = std::make_unique<CompletionFieldExpr>("", comp_, expectedWord);
         }
 
-        return std::make_unique<PathExpr>(std::move(left), std::move(right));
+        return std::make_unique<PathExpr>(std::move(left), std::move(*right));
     }
 
     Completion* comp_;
@@ -732,23 +766,30 @@ static auto setupParser(Parser& p)
     p.infixParsers[Token::DOT]  = std::make_unique<PathParser>();
 }
 
-auto compile(Environment& env, std::string_view query, bool any, bool autoWildcard) -> ASTPtr
+auto compile(Environment& env, std::string_view query, bool any, bool autoWildcard) -> expected<ASTPtr, Error>
 {
-    Parser p(&env, query, Parser::Mode::Strict);
+    auto tokens = tokenize(query);
+    TRY_EXPECTED(tokens);
+
+    Parser p(&env, *tokens, Parser::Mode::Strict);
     setupParser(p);
 
-    auto expr = [&](){
+    auto expr = [&]() -> expected<ExprPtr, Error> {
         auto root = p.parse();
+        TRY_EXPECTED(root);
 
         /* Expand a single value to `** == <value>` */
-        if (autoWildcard && root && root->constant()) {
+        if (autoWildcard && *root && (*root)->constant()) {
             root = std::make_unique<BinaryExpr<OperatorEq>>(
-                std::make_unique<WildcardExpr>(), std::move(root));
+                std::make_unique<WildcardExpr>(), std::move(*root));
         }
+
+        if (!*root)
+            return unexpected<Error>(Error::ParserError, "Expression is null");
 
         if (any) {
             std::vector<ExprPtr> args;
-            args.emplace_back(std::move(root));
+            args.emplace_back(std::move(*root));
             return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(args)));
         } else {
             return root;
@@ -756,14 +797,17 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
     }();
 
     if (!p.match(Token::Type::NIL))
-        raise<std::runtime_error>("Expected end-of-input; got "s + p.current().toString());
+        return unexpected<Error>(Error::ExpectedEOF, "Expected end-of-input; got "s + p.current().toString());
 
-    return std::make_unique<AST>(std::string(query), std::move(expr));
+    return std::make_unique<AST>(std::string(query), std::move(*expr));
 }
 
-auto complete(Environment& env, std::string_view query, size_t point, const ModelNode& node, const CompletionOptions& options) -> std::vector<CompletionCandidate>
+auto complete(Environment& env, std::string_view query, size_t point, const ModelNode& node, const CompletionOptions& options) -> expected<std::vector<CompletionCandidate>, Error>
 {
-    Parser p(&env, query, Parser::Mode::Relaxed);
+    auto tokens = tokenize(query);
+    TRY_EXPECTED(tokens);
+
+    Parser p(&env, *tokens, Parser::Mode::Relaxed);
     setupParser(p);
 
     Completion comp(point);
@@ -775,34 +819,31 @@ auto complete(Environment& env, std::string_view query, size_t point, const Mode
     p.infixParsers[Token::OP_AND] = std::make_unique<CompletionAndOrParser>(&comp);
     p.infixParsers[Token::OP_OR]  = std::make_unique<CompletionAndOrParser>(&comp);
 
-    try {
-        auto ast = p.parse();
+    auto astResult = p.parse();
+    TRY_EXPECTED(astResult);
+    auto ast = std::move(*astResult);
 
-        /* Expand a single value to `** == <value>` */
-        if (options.autoWildcard && ast && ast->constant()) {
-            ast = std::make_unique<BinaryExpr<OperatorEq>>(
-                std::make_unique<WildcardExpr>(), std::move(ast));
-        }
-
-        Context ctx(&env);
-        if (options.timeoutMs > 0)
-            ctx.timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(options.timeoutMs);
-
-        ast->eval(ctx, Value::field(node), LambdaResultFn([](Context, const Value&) {
-            return Result::Continue;
-        }));
-    } catch (const std::runtime_error& exc) {
-        /* Silently ignore errors */
-        (void)exc;
+    /* Expand a single value to `** == <value>` */
+    if (options.autoWildcard && ast && ast->constant()) {
+        ast = std::make_unique<BinaryExpr<OperatorEq>>(
+            std::make_unique<WildcardExpr>(), std::move(ast));
     }
+
+    Context ctx(&env);
+    if (options.timeoutMs > 0)
+        ctx.timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(options.timeoutMs);
+
+    ast->eval(ctx, Value::field(node), LambdaResultFn([](Context, const Value&) {
+        return Result::Continue;
+    }));
 
     return std::vector<CompletionCandidate>(comp.candidates.begin(), comp.candidates.end());
 }
 
-auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* diag) -> std::vector<Value>
+auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* diag) -> expected<std::vector<Value>, Error>
 {
     if (!node.model_)
-        raise<std::runtime_error>("ModelNode must have a model!");
+        return unexpected<Error>(Error::NullModel, "ModelNode must have a model!");
 
     Context ctx(&env);
 
@@ -821,7 +862,7 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     return res;
 }
 
-auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> std::vector<Diagnostics::Message>
+auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> expected<std::vector<Diagnostics::Message>, Error>
 {
     return diag.buildMessages(env, ast);
 }

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -18,9 +18,9 @@ auto Compile(std::string_view query, bool autoWildcard) -> ASTPtr
     return std::move(*ast);
 }
 
-auto JoinedResult(std::string_view query) -> std::string
+auto JoinedResult(std::string_view query, std::optional<std::string> json) -> std::string
 {
-    auto model = simfil::json::parse(TestModel);
+    auto model = simfil::json::parse(std::string(json.value_or(TestModel)));
     Environment env(model->strings());
 
     env.functions["panic"] = &panicFn;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -78,9 +78,6 @@ public:
 };
 
 auto Compile(std::string_view query, bool autoWildcard = false) -> ASTPtr;
-auto JoinedResult(std::string_view query) -> std::string;
+auto JoinedResult(std::string_view query, std::optional<std::string> json = {}) -> std::string;
 auto CompleteQuery(std::string_view query, size_t point) -> std::vector<CompletionCandidate>;
 auto GetDiagnosticMessages(std::string_view query) -> std::vector<Diagnostics::Message>;
-
-#define REQUIRE_RESULT(query, result) \
-    REQUIRE(JoinedResult((query)) == (result))

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -77,6 +77,7 @@ public:
     }
 };
 
+auto Compile(std::string_view query, bool autoWildcard = false) -> ASTPtr;
 auto JoinedResult(std::string_view query) -> std::string;
 auto CompleteQuery(std::string_view query, size_t point) -> std::vector<CompletionCandidate>;
 auto GetDiagnosticMessages(std::string_view query) -> std::vector<Diagnostics::Message>;

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -58,12 +58,18 @@ static auto joined_result(std::string_view query)
     auto model = json::parse(invoice);
     Environment env(model->strings());
     auto ast = compile(env, query, false);
-    INFO("AST: " << ast->expr().toString());
+    if (!ast)
+        INFO(ast.error().message);
+    REQUIRE(ast.has_value());
+    INFO("AST: " << (*ast)->expr().toString());
 
-    auto res = eval(env, *ast, *model->root(0), nullptr);
+    auto res = eval(env, **ast, *model->root(0), nullptr);
+    if (!res)
+        INFO(res.error().message);
+    REQUIRE(res);
 
     std::string vals;
-    for (const auto& vv : res) {
+    for (const auto& vv : *res) {
         if (!vals.empty())
             vals.push_back('|');
         vals += vv.toString();

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -114,14 +114,17 @@ static auto result(const ModelPoolPtr& model, std::string_view query)
 {
     Environment env(model->strings());
     auto ast = compile(env, query, false);
-    INFO("AST: " << ast->expr().toString());
+    if (!ast)
+        INFO(ast.error().message);
+    REQUIRE(ast.has_value());
+    INFO("AST: " << (*ast)->expr().toString());
 
-    return eval(env, *ast, *model->root(0), nullptr);
+    return eval(env, **ast, *model->root(0), nullptr);
 }
 
 static auto joined_result(const ModelPoolPtr& model, std::string_view query)
 {
-    auto res = result(model, query);
+    auto res = result(model, query).value();
 
     std::string vals;
     for (const auto& vv : res) {

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -15,6 +15,9 @@ using namespace simfil;
 
 static constexpr auto StaticTestKey = StringPool::NextStaticId;
 
+#define REQUIRE_RESULT(query, result) \
+    REQUIRE(JoinedResult((query)) == (result))
+
 #define REQUIRE_AST(input, output) \
     REQUIRE(Compile(input, false)->expr().toString() == (output));
 

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -1,9 +1,7 @@
 #include "simfil/simfil.h"
 #include "simfil/environment.h"
 #include "simfil/exception-handler.h"
-#include "simfil/function.h"
 #include "simfil/model/json.h"
-#include "simfil/result.h"
 #include "simfil/value.h"
 #include "src/expressions.h"
 
@@ -17,19 +15,11 @@ using namespace simfil;
 
 static constexpr auto StaticTestKey = StringPool::NextStaticId;
 
-
-static auto getASTString(std::string_view input, bool autoWildcard = false)
-{
-    Environment env(Environment::WithNewStringCache);
-    env.constants.emplace("a_number", simfil::Value::make((int64_t)123));
-    return compile(env, input, false, autoWildcard);
-}
-
 #define REQUIRE_AST(input, output) \
-    REQUIRE(getASTString(input, false)->expr().toString() == output);
+    REQUIRE(Compile(input, false)->expr().toString() == (output));
 
 #define REQUIRE_AST_AUTOWILDCARD(input, output) \
-    REQUIRE(getASTString(input, true)->expr().toString() == output);
+    REQUIRE(Compile(input, true)->expr().toString() == (output));
 
 TEST_CASE("Path", "[ast.path]") {
     REQUIRE_AST("a", "a");
@@ -68,9 +58,17 @@ TEST_CASE("OperatorConst", "[ast.operator]") {
     REQUIRE_AST("1/null", "null");
     REQUIRE_AST("null/1", "null");
 
+    auto GetError = [&](std::string_view query) {
+        Environment env(Environment::WithNewStringCache);
+        auto ast = compile(env, query);
+
+        REQUIRE(!ast);
+        return ast.error().message;
+    };
+
     /* Division by zero */
-    CHECK_THROWS(getASTString("1/0"));
-    CHECK_THROWS(getASTString("1%0"));
+    CHECK_THROWS(GetError("1/0"));
+    CHECK_THROWS(GetError("1%0"));
 
     /* String */
     REQUIRE_AST("'a'+null", "\"anull\"");
@@ -190,9 +188,14 @@ TEST_CASE("CompareIncompatibleTypesFields", "[ast.compare-incompatible-types-fie
         Environment env(model->strings());
 
         auto ast = compile(env, query, false);
-        INFO("AST: " << ast->expr().toString());
+        if (!ast)
+            INFO(ast.error().message);
+        REQUIRE(ast.has_value());
+        REQUIRE(*ast);
 
-        return eval(env, *ast, *model->root(0), nullptr).front().template as<ValueType::Bool>();
+        INFO("AST: " << (*ast)->expr().toString());
+
+        return eval(env, **ast, *model->root(0), nullptr).value().front().template as<ValueType::Bool>();
     };
 
     /* Test some field with different value types for different objects */
@@ -566,7 +569,10 @@ TEST_CASE("Visit AST", "[visit.ast]")
     Environment env(Environment::WithNewStringCache);
 
     auto ast = compile(env, "**.field = 123", false, false);
-    REQUIRE(ast.get() != nullptr);
+    if (!ast)
+        INFO(ast.error().message);
+    REQUIRE(ast.has_value());
+    REQUIRE(*ast);
 
     struct Visitor : ExprVisitor
     {
@@ -581,7 +587,7 @@ TEST_CASE("Visit AST", "[visit.ast]")
     };
 
     Visitor visitor;
-    ast->expr().accept(visitor);
+    (*ast)->expr().accept(visitor);
 
     REQUIRE(visitor.visitedFieldName == "field");
 }

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -61,19 +61,18 @@ TEST_CASE("OperatorConst", "[ast.operator]") {
     REQUIRE_AST("1/null", "null");
     REQUIRE_AST("null/1", "null");
 
-    auto GetError = [&](std::string_view query) -> std::optional<simfil::Error> {
+    auto GetError = [&](std::string_view query) {
         Environment env(Environment::WithNewStringCache);
         auto ast = compile(env, query);
 
         REQUIRE(!ast);
         if (!ast)
-            return ast.error();
-        return {};
+            throw ast.error();
     };
 
     /* Division by zero */
-    REQUIRE(GetError("1/0").has_value());
-    REQUIRE(GetError("1%0").has_value());
+    CHECK_THROWS(GetError("1/0"));
+    CHECK_THROWS(GetError("1%0"));
 
     /* String */
     REQUIRE_AST("'a'+null", "\"anull\"");

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -61,17 +61,19 @@ TEST_CASE("OperatorConst", "[ast.operator]") {
     REQUIRE_AST("1/null", "null");
     REQUIRE_AST("null/1", "null");
 
-    auto GetError = [&](std::string_view query) {
+    auto GetError = [&](std::string_view query) -> std::optional<simfil::Error> {
         Environment env(Environment::WithNewStringCache);
         auto ast = compile(env, query);
 
         REQUIRE(!ast);
-        return ast.error().message;
+        if (!ast)
+            return ast.error();
+        return {};
     };
 
     /* Division by zero */
-    CHECK_THROWS(GetError("1/0"));
-    CHECK_THROWS(GetError("1%0"));
+    REQUIRE(GetError("1/0").has_value());
+    REQUIRE(GetError("1%0").has_value());
 
     /* String */
     REQUIRE_AST("'a'+null", "\"anull\"");


### PR DESCRIPTION
Removes exceptions from all the _parser_ code.

At query-time exceptions can still occur. Changing this should be part of a second PR.

We are using `tl::expected`, which can be changed to `std::expected` with C++23 support.
The `TRY_EXPECTED(...)` macro is a fill-in for C++'s ugly way of how you have to move out the
error off an `std::expected` value: `if (!res) return std::unexpected<Type>(std::move(res.error()));`

Division by zero can still lead to an exception during compile time, if the compiler tries to simplify expressions.