### PR TITLE
Simfil Perf Improvements

### DIFF
--- a/include/simfil/value.h
+++ b/include/simfil/value.h
@@ -170,6 +170,11 @@ struct ValueType4CType<ModelNode> {
     static constexpr ValueType Type = ValueType::Object;
 };
 
+template <>
+struct ValueType4CType<ModelNode::Ptr> {
+    static constexpr ValueType Type = ValueType::Object;
+};
+
 template <ValueType>
 struct ValueTypeInfo;
 
@@ -237,6 +242,30 @@ struct ValueAs<ValueType::String>
     }
 };
 
+template <>
+struct ValueAs<ValueType::Object>
+{
+    template <class VariantType>
+    static auto get(const VariantType& v) -> ModelNode::Ptr
+    {
+        if (auto nodePtr = std::get_if<ModelNode::Ptr>(&v))
+            return *nodePtr;
+        return {};
+    }
+};
+
+template <>
+struct ValueAs<ValueType::Array>
+{
+    template <class VariantType>
+    static auto get(const VariantType& v) -> ModelNode::Ptr
+    {
+        if (auto nodePtr = std::get_if<ModelNode::Ptr>(&v))
+            return *nodePtr;
+        return {};
+    }
+};
+
 class Value
 {
 public:
@@ -278,20 +307,33 @@ public:
 
     static auto field(const ModelNode& node) -> Value
     {
-        return {node.type(), node.value(), model_ptr<ModelNode>(node)};
+        const auto type = node.type();
+        if (type == ValueType::Object || type == ValueType::Array) {
+            return Value{type, model_ptr<ModelNode>(node)};
+        } else {
+            return Value{node.value()};
+        }
     }
 
     static auto field(ModelNode&& node) -> Value
     {
-        auto type = node.type();
-        auto value = node.value();
-        return {type, std::move(value), model_ptr<ModelNode>(std::move(node))};
+        const auto type = node.type();
+        if (type == ValueType::Object || type == ValueType::Array) {
+            return {type, model_ptr<ModelNode>(std::move(node))};
+        } else {
+            return Value{node.value()};
+        }
     }
 
     template <class ModelNodeT>
     static auto field(const model_ptr<ModelNodeT>& node) -> Value
     {
-        return {node->type(), node->value(), node};
+        const auto type = node->type();
+        if (type == ValueType::Object || type == ValueType::Array) {
+            return {type, model_ptr<ModelNode>(node)};
+        } else {
+            return Value{node->value()};
+        }
     }
 
     Value(ValueType type)  // NOLINT
@@ -304,17 +346,12 @@ public:
           , value(std::forward<ArgType>(value))
     {}
 
-    Value(ValueType type, ScalarValueType&& value_, ModelNode::Ptr node)
-        : type(type), node(std::move(node))
-    {
-        std::visit([this](auto&& v){value = v;}, value_);
-    }
 
     Value(ScalarValueType&& value_)  // NOLINT
     {
         std::visit([this](auto&& v){
             type = ValueType4CType<std::decay_t<decltype(v)>>::Type;
-            value = v;
+            value = std::forward<decltype(v)>(v);
         }, value_);
     }
 
@@ -363,8 +400,8 @@ public:
             return fn(this->template as<ValueType::TransientObject>());
         case ValueType::Object:
         case ValueType::Array:
-            if (node) [[likely]]
-                return fn(*node);
+            if (auto nodePtr = std::get_if<ModelNode::Ptr>(&value); nodePtr && *nodePtr) [[likely]]
+                return fn(**nodePtr);
             else
                 return fn(NullType{});
         }
@@ -400,10 +437,21 @@ public:
         return scalarVisitor.result;
     }
 
-    /// Get the string_view of this Value if it has one.
     std::string_view const* stringViewValue() noexcept
     {
         return std::get_if<std::string_view>(&value);
+    }
+
+    ModelNode::Ptr const* nodePtr() const noexcept
+    {
+        return std::get_if<ModelNode::Ptr>(&value);
+    }
+
+    ModelNode const* node() const noexcept
+    {
+        if (auto ptr = nodePtr(); ptr)
+            return &**ptr;
+        return nullptr;
     }
 
     ValueType type;
@@ -414,9 +462,8 @@ public:
         double,
         std::string,
         std::string_view,
-        TransientObject> value;
-
-    ModelNode::Ptr node;
+        TransientObject,
+        ModelNode::Ptr> value;
 };
 
 template <typename ResultT, typename ValueT>

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -147,7 +147,7 @@ auto CompletionFieldOrWordExpr::ieval(Context ctx, const Value& val, const Resul
     const auto caseSensitive = comp_->options.smartCase && containsUppercaseCharacter(prefix_);
 
     // First we try to complete fields
-    for (StringId id : val.node->fieldNames()) {
+    for (StringId id : val.node()->fieldNames()) {
         if (comp_->size() >= comp_->limit)
             return Result::Stop;
 

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -554,13 +554,13 @@ auto KeysFn::eval(Context ctx, Value val, const std::vector<ExprPtr>& args, cons
         return tl::unexpected<Error>(Error::InvalidArguments,
                                      fmt::format("'keys' expects 1 argument got {}", args.size()));
 
-    auto result = args[0]->eval(ctx, val, LambdaResultFn([&res](Context ctx, Value vv) -> tl::expected<Result, Error> {
+    auto result = args[0]->eval(ctx, val, LambdaResultFn([&res](Context ctx, const Value& vv) -> tl::expected<Result, Error> {
         if (ctx.phase == Context::Phase::Compilation)
             if (vv.isa(ValueType::Undef))
-                return res(ctx, std::move(vv));
+                return res(ctx, vv);
 
-        if (vv.node)
-            for (auto&& fieldName : vv.node->fieldNames()) {
+        if (vv.nodePtr())
+            for (auto&& fieldName : vv.node()->fieldNames()) {
                 if (auto key = ctx.env->stringPool->resolve(fieldName)) {
                     if (res(ctx, Value::strref(*key)) == Result::Stop)
                         return Result::Stop;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -38,30 +38,30 @@ auto OverlayNode::set(StringId const& key, Value const& child) -> void
 {
     auto iter = model().overlayChildren_.find(key);
     if (iter != model().overlayChildren_.end()) {
-        if (iter->second.node)
-            return iter->second.node;
+        if (iter->second.nodePtr())
+            return *iter->second.nodePtr();
         return ValueNode(iter->second.getScalar());
     }
-    return model().value_.node->get(key);
+    return model().value_.node()->get(key);
 }
 
 [[nodiscard]] ModelNode::Ptr OverlayNode::at(int64_t i) const
 {
-    return model().value_.node->at(i);
+    return model().value_.node()->at(i);
 }
 
 [[nodiscard]] StringId OverlayNode::keyAt(int64_t i) const
 {
-    return model().value_.node->keyAt(i);
+    return model().value_.node()->keyAt(i);
 }
 
 [[nodiscard]] uint32_t OverlayNode::size() const
 {
-    return model().value_.node->size();
+    return model().value_.node()->size();
 }
 
 [[nodiscard]] bool OverlayNode::iterate(IterCallback const& cb) const {
-    return model().value_.node->iterate(cb);
+    return model().value_.node()->iterate(cb);
 }
 
 }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -159,7 +159,7 @@ static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -
     auto stub = Context(env, Context::Phase::Compilation);
     auto res = (*expr)->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value vv) mutable {
         n += 1;
-        if ((n <= MultiConstExpr::Limit) && (!vv.isa(ValueType::Undef) || vv.node)) {
+        if ((n <= MultiConstExpr::Limit) && (!vv.isa(ValueType::Undef) || vv.nodePtr())) {
             values.push_back(std::move(vv));
             return Result::Continue;
         }


### PR DESCRIPTION
The `simfil::Value` type is huge because of the `ModeNode::Ptr` field.
Moving the node field into the variant saves some bytes and improves performance a lot.

This is just a test, as it removes the option to store a scalar + a node in a Value object.

Main:
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Query typeof Recursive                         100             1     1.73898 s 
                                        17.6426 ms    17.5999 ms     17.695 ms 
                                        241.428 us    204.215 us    290.245 us 
                                                                               
Query field id Recursive                       100             1     1.36372 s 
                                        13.9724 ms    13.8896 ms    14.0689 ms 
                                        456.841 us    402.926 us    551.696 us 
                                                                               
Query field id                                 100             1    28.5413 ms 
                                        286.066 us    284.083 us     289.23 us 
                                        12.5867 us     8.7692 us    17.7284 us
```

This PR:
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Query typeof Recursive                         100             1     1.69738 s 
                                        16.4374 ms    16.3952 ms    16.4813 ms 
                                        220.149 us    194.271 us    251.362 us 
                                                                               
Query field id Recursive                       100             1     1.11677 s 
                                         11.213 ms    11.1973 ms    11.2294 ms 
                                        81.8348 us    70.2954 us    97.3137 us 
                                                                               
Query field id                                 100             1    25.6478 ms 
                                        253.815 us    252.875 us    255.383 us 
                                        6.06835 us    4.06118 us    9.42665 us
```