### PR TITLE
Support Moving Eval Values

### DIFF
--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -50,17 +50,35 @@ public:
     /* Debug */
     virtual auto toString() const -> std::string = 0;
 
-    /* Evaluation wrapper */
-    auto eval(Context ctx, Value val, const ResultFn& res) -> tl::expected<Result, Error>
+    auto eval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
     {
         if (ctx.canceled())
             return Result::Stop;
 
-        auto dbg = ctx.env->debug;
-        if (dbg) dbg->evalBegin(*this, ctx, val, res);
-        auto r = ieval(ctx, val, res);
-        if (dbg) dbg->evalEnd(*this);
-        return r;
+        if (auto dbg = ctx.env->debug) [[unlikely]] {
+            auto dbgVal = Value{val};
+            dbg->evalBegin(*this, ctx, dbgVal, res);
+            auto r = ieval(ctx, std::move(dbgVal), res);
+            dbg->evalEnd(*this);
+            return r;
+        }
+
+        return ieval(ctx, val, res);
+    }
+
+    auto eval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error>
+    {
+        if (ctx.canceled())
+            return Result::Stop;
+
+        if (auto dbg = ctx.env->debug) [[unlikely]] {
+            dbg->evalBegin(*this, ctx, val, res);
+            auto r = ieval(ctx, std::move(val), res);
+            dbg->evalEnd(*this);
+            return r;
+        }
+
+        return ieval(ctx, std::move(val), res);
     }
 
     /* Recursive clone */
@@ -80,6 +98,11 @@ public:
 private:
     /* Abstract evaluation implementation */
     virtual auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> = 0;
+    
+    /* Move-optimized evaluation implementation */
+    virtual auto ieval(Context ctx, Value&& value, const ResultFn& result) -> tl::expected<Result, Error> {
+        return ieval(ctx, value, result);
+    }
 
     SourceLocation sourceLocation_;
 };

--- a/include/simfil/operator.h
+++ b/include/simfil/operator.h
@@ -663,8 +663,8 @@ struct UnaryOperatorDispatcher
         return Value::undef();
     }
 
-    template <class _Value>
-    auto operator()(const _Value& rhs) -> tl::expected<Value, Error>
+    template <class Value_>
+    auto operator()(const Value_& rhs) -> tl::expected<Value, Error>
     {
         return impl::makeOperatorResult<_Operator>(_Operator()(rhs));
     }

--- a/include/simfil/result.h
+++ b/include/simfil/result.h
@@ -19,6 +19,7 @@ struct ResultFn
     virtual ~ResultFn() = default;
 
     virtual auto operator()(Context ctx, const Value& value) const noexcept -> tl::expected<Result, Error> = 0;
+    virtual auto operator()(Context ctx, Value&& value) const noexcept -> tl::expected<Result, Error> = 0;
 };
 
 template <class Lambda>
@@ -31,6 +32,15 @@ struct LambdaResultFn final : ResultFn
     {}
 
     auto operator()(Context ctx, const Value& value) const noexcept -> tl::expected<Result, Error> override
+    {
+        if constexpr (std::is_invocable_v<Lambda, Context, const Value&>) {
+            return lambda(std::move(ctx), value);
+        } else {
+            return lambda(std::move(ctx), Value{value});
+        }
+    }
+
+    auto operator()(Context ctx, Value&& value) const noexcept -> tl::expected<Result, Error> override
     {
         return lambda(std::move(ctx), std::move(value));
     }

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -105,6 +105,7 @@ public:
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error> override;
     auto clone() const -> ExprPtr override;
     void accept(ExprVisitor& v) override;
     auto toString() const -> std::string override;
@@ -178,6 +179,7 @@ public:
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
     auto toString() const -> std::string override;
     auto clone() const -> ExprPtr override;
     void accept(ExprVisitor& v) override;
@@ -228,6 +230,7 @@ public:
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error> override;
     auto clone() const -> ExprPtr override;
     void accept(ExprVisitor& v) override;
     auto toString() const -> std::string override;
@@ -245,6 +248,7 @@ public:
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
     auto clone() const -> ExprPtr override;
     void accept(ExprVisitor& v) override;
     auto toString() const -> std::string override;

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -157,7 +157,7 @@ static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -
 
     std::deque<Value> values;
     auto stub = Context(env, Context::Phase::Compilation);
-    auto res = (*expr)->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value vv) mutable {
+    auto res = (*expr)->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value&& vv) mutable {
         n += 1;
         if ((n <= MultiConstExpr::Limit) && (!vv.isa(ValueType::Undef) || vv.nodePtr())) {
             values.push_back(std::move(vv));
@@ -875,7 +875,7 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     auto mutableAST = ast.expr().clone();
 
     std::vector<Value> values;
-    auto res = mutableAST->eval(ctx, Value::field(node), LambdaResultFn([&values](Context, Value value) {
+    auto res = mutableAST->eval(ctx, Value::field(node), LambdaResultFn([&values](Context, Value&& value) {
         values.push_back(std::move(value));
         return Result::Continue;
     }));


### PR DESCRIPTION
Another test for improving runtime performance by adding a move `ieval` overload, that takes an rvalue `Value`.

Main:
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Query typeof Recursive                         100             1     1.73898 s 
                                        17.6426 ms    17.5999 ms     17.695 ms 
                                        241.428 us    204.215 us    290.245 us 
                                                                               
Query field id Recursive                       100             1     1.36372 s 
                                        13.9724 ms    13.8896 ms    14.0689 ms 
                                        456.841 us    402.926 us    551.696 us 
                                                                               
Query field id                                 100             1    28.5413 ms 
                                        286.066 us    284.083 us     289.23 us 
                                        12.5867 us     8.7692 us    17.7284 us
```

Base:
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Query typeof Recursive                         100             1     1.96654 s 
                                        19.6814 ms     19.631 ms    19.7516 ms 
                                        300.289 us    225.327 us    432.353 us 
                                                                               
Query field id Recursive                       100             1     1.41579 s 
                                        14.1799 ms    14.1637 ms    14.2028 ms 
                                        97.8133 us    74.9947 us    133.221 us 
                                                                               
Query field id                                 100             1    29.7429 ms 
                                        298.493 us    296.618 us    301.441 us 
                                         11.782 us    8.37853 us     15.822 us
```


This pr (post rebase):
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Query typeof Recursive                         100             1     1.63423 s 
                                        16.1215 ms    16.0871 ms    16.1712 ms 
                                        208.162 us    146.815 us    310.164 us 
                                                                               
Query field id Recursive                       100             1    923.614 ms 
                                        9.20175 ms    9.18706 ms    9.22581 ms 
                                        94.4176 us    64.9266 us     137.98 us 
                                                                               
Query field id                                 100             1    23.6903 ms 
                                        238.867 us     236.91 us    242.239 us 
                                        12.7718 us    8.24217 us     18.289 us
```