### PR TITLE
Avoid calling very slow steady_clock::now

### DIFF
--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -149,14 +149,14 @@ struct Context
     Phase phase = Evaluation;
 
     /* Timeout after which the evaluation should be canceled. */
-    std::chrono::time_point<std::chrono::steady_clock> timeout = std::chrono::time_point<std::chrono::steady_clock>::max();
+    std::optional<std::chrono::time_point<std::chrono::steady_clock>> timeout;
 
     Context(Environment* env, Phase = Phase::Evaluation);
 
     auto canceled() const -> bool
     {
-        if (phase != Phase::Compilation)
-            return timeout < std::chrono::steady_clock::now();
+        if (phase != Phase::Compilation && timeout)
+            return *timeout < std::chrono::steady_clock::now();
         return false;
     }
 };


### PR DESCRIPTION
Unfortunately, steady_clock calls in WASM translate to native JS calls, which bottlenecks simfil in the browser in extreme ways: The steady_clock calls cause a roughly 69% slowdown, maybe more, both on Chrome and Firefox. E.g. in a heavy tile render call we spend 115ms in simfil eval; 80ms of this time are spent in the emscripten steady_clock implementation!

On the Desktop, the impact is just 10%, but still worth it.

* Query typeof Recursive: **-10.91%**
* Query field id Recursive: **-11.51%**
* Query field id: **-10.73%**

For completion (i.e. when a timeout is set), we need to consider a different implementation. For example, we could check the timeout in-between evals for individual features in the WASM workers, not for each Expr eval in simfil.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1fdbf28378642a0392acbe1bc23fd96b602f4587. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->