### PR TITLE
Introduce generic Model::resolve<Target>

### DIFF
--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -31,20 +31,11 @@ struct tag {};
 
 namespace detail
 {
-template<typename T, typename = void>
-struct node_model_type
-{
-    static_assert(sizeof(T) == 0, "Target must provide a ModelType alias.");
-};
+template<class T>
+concept HasModelType = requires { typename T::ModelType; };
 
-template<typename T>
-struct node_model_type<T, std::void_t<typename T::ModelType>>
-{
-    using type = typename T::ModelType;
-};
-
-template<typename T>
-using node_model_type_t = typename node_model_type<T>::type;
+template<HasModelType T>
+using ModelTypeOf = typename T::ModelType;
 }
 
 /**
@@ -137,16 +128,22 @@ public:
             return model_ptr<ModelNode>(node);
         }
         else {
-            using ModelType = detail::node_model_type_t<Target>;
+            if constexpr (!detail::HasModelType<Target>) {
+                static_assert(detail::HasModelType<Target>, "Target must provide a ModelType alias.");
+                return {};
+            }
+            else {
+                using ModelType = detail::ModelTypeOf<Target>;
 #if !defined(NDEBUG)
-            // In debug builds, validate the model type to catch misuse early.
-            auto typedModel = dynamic_cast<ModelType const*>(this);
-            assert(typedModel && "resolve<T> called on incompatible model type.");
-            return resolveInternal(res::tag<Target>{}, *typedModel, node);
+                // In debug builds, validate the model type to catch misuse early.
+                auto typedModel = dynamic_cast<ModelType const*>(this);
+                assert(typedModel && "resolve<T> called on incompatible model type.");
+                return resolveInternal(res::tag<Target>{}, *typedModel, node);
 #else
-            // In release builds, avoid RTTI overhead on this hot path.
-            return resolveInternal(res::tag<Target>{}, *static_cast<ModelType const*>(this), node);
+                // In release builds, avoid RTTI overhead on this hot path.
+                return resolveInternal(res::tag<Target>{}, *static_cast<ModelType const*>(this), node);
 #endif
+            }
         }
     }
 

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -9,7 +9,10 @@
 
 #include <memory>
 #include <string_view>
+#include <type_traits>
 #include <vector>
+#include <utility>
+#include <cassert>
 #include <istream>
 #include <ostream>
 
@@ -18,6 +21,47 @@
 
 namespace simfil
 {
+
+namespace res
+{
+// Tag type for ADL-based resolve hooks implemented by model libraries.
+template<typename Target>
+struct tag {};
+}
+
+namespace detail
+{
+template<typename T, typename = void>
+struct node_model_type
+{
+    static_assert(sizeof(T) == 0, "Target must provide a ModelType alias.");
+};
+
+template<typename T>
+struct node_model_type<T, std::void_t<typename T::ModelType>>
+{
+    using type = typename T::ModelType;
+};
+
+template<typename T>
+using node_model_type_t = typename node_model_type<T>::type;
+}
+
+/**
+ * ADL customization point for typed node resolution.
+ * Libraries define resolveInternal(tag, model, node) in their namespace.
+ */
+template<typename Target, typename ModelType>
+model_ptr<Target> resolveInternal(res::tag<Target>, ModelType const&, ModelNode const&) = delete;
+
+class ModelPool;
+
+// Built-in resolve hooks for core node types. Declared here so ADL sees them
+// across translation units without relying on friend injection.
+template<>
+model_ptr<Object> resolveInternal(res::tag<Object>, ModelPool const&, ModelNode const&);
+template<>
+model_ptr<Array> resolveInternal(res::tag<Array>, ModelPool const&, ModelNode const&);
 
 /**
  * Basic node model which only resolves trivial node types.
@@ -58,6 +102,54 @@ public:
      */
     virtual tl::expected<void, Error> resolve(ModelNode const& n, ResolveFn const& cb) const;
 
+    /**
+     * Resolve a node to a specific ModelNode subtype using ADL hooks.
+     * This provides a clean cast API without exposing model internals.
+     */
+    template<typename Target = ModelNode>
+    model_ptr<Target> resolve(ModelNodeAddress const& address) const
+    {
+        if constexpr (std::is_same_v<Target, ModelNode>) {
+            return ModelNode::Ptr::make(shared_from_this(), address);
+        }
+        return resolve<Target>(*ModelNode::Ptr::make(shared_from_this(), address));
+    }
+
+    template<typename Target = ModelNode>
+    model_ptr<Target> resolve(ModelNodeAddress const& address, ScalarValueType data) const
+    {
+        if constexpr (std::is_same_v<Target, ModelNode>) {
+            return ModelNode::Ptr::make(shared_from_this(), address, std::move(data));
+        }
+        return resolve<Target>(*ModelNode::Ptr::make(shared_from_this(), address, std::move(data)));
+    }
+
+    template<typename Target>
+    model_ptr<Target> resolve(ModelNode::Ptr const& node) const
+    {
+        return resolve<Target>(*node);
+    }
+
+    template<typename Target>
+    model_ptr<Target> resolve(ModelNode const& node) const
+    {
+        if constexpr (std::is_same_v<Target, ModelNode>) {
+            return model_ptr<ModelNode>(node);
+        }
+        else {
+            using ModelType = detail::node_model_type_t<Target>;
+#if !defined(NDEBUG)
+            // In debug builds, validate the model type to catch misuse early.
+            auto typedModel = dynamic_cast<ModelType const*>(this);
+            assert(typedModel && "resolve<T> called on incompatible model type.");
+            return resolveInternal(res::tag<Target>{}, *typedModel, node);
+#else
+            // In release builds, avoid RTTI overhead on this hot path.
+            return resolveInternal(res::tag<Target>{}, *static_cast<ModelType const*>(this), node);
+#endif
+        }
+    }
+
     /** Add a small scalar value and get its model node view */
     ModelNode::Ptr newSmallValue(bool value);
     ModelNode::Ptr newSmallValue(int16_t value);
@@ -88,6 +180,8 @@ class ModelPool : public Model
     template<typename, typename> friend struct BaseArray;
 
 public:
+    // Keep Model::resolve<T> overloads visible alongside the virtual resolve override.
+    using Model::resolve;
     /**
      * The pool consists of multiple ModelNode columns,
      * each for a different data type. Each column
@@ -155,12 +249,6 @@ public:
     ModelNode::Ptr newValue(double const& value);
     ModelNode::Ptr newValue(std::string_view const& value);
     ModelNode::Ptr newValue(StringId handle);
-
-    /** Node-type-specific resolve-functions */
-    [[nodiscard]]
-    model_ptr<Object> resolveObject(ModelNode::Ptr const& n) const;
-    [[nodiscard]]
-    model_ptr<Array> resolveArray(ModelNode::Ptr const& n) const;
 
     /** Access the field name storage */
     [[nodiscard]]

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -67,18 +67,18 @@ using ScalarValueType = std::variant<
 
 namespace detail
 {
-    // Passkey for ModelNode construction: ModelNode types take this in their constructors so only
-    // model_ptr (and ModelPool via a shared key instance) can default/in-place construct them.
-    // This avoids per-node friendship and keeps IDEs happy across library boundaries.
-    struct mp_key
-    {
-        mp_key() = delete;
-    private:
-        explicit mp_key(int) {}
-        template<typename> friend struct ::simfil::model_ptr;
-        friend class ::simfil::Model;
-        friend class ::simfil::ModelPool;
-    };
+// Passkey for ModelNode construction: ModelNode types take this in their constructors so only
+// model_ptr (and ModelPool via a shared key instance) can default/in-place construct them.
+// This avoids per-node friendship and keeps IDEs happy across library boundaries.
+struct mp_key
+{
+    mp_key() = delete;
+private:
+    explicit mp_key(int) {}
+    template<typename> friend struct ::simfil::model_ptr;
+    friend class ::simfil::Model;
+    friend class ::simfil::ModelPool;
+};
 }
 
 /**
@@ -208,21 +208,21 @@ struct ModelNodeAddress
 
 namespace detail
 {
-    // Shared storage entry for object fields across all BaseObject instantiations.
-    // Keeps the underlying ArrayArena type identical regardless of ModelType.
-    struct ObjectField
-    {
-        ObjectField() = default;
-        ObjectField(StringId name, ModelNodeAddress a) : name_(name), node_(a) {}
-        StringId name_ = StringPool::Empty;
-        ModelNodeAddress node_;
+// Shared storage entry for object fields across all BaseObject instantiations.
+// Keeps the underlying ArrayArena type identical regardless of ModelType.
+struct ObjectField
+{
+    ObjectField() = default;
+    ObjectField(StringId name, ModelNodeAddress a) : name_(name), node_(a) {}
+    StringId name_ = StringPool::Empty;
+    ModelNodeAddress node_;
 
-        template<typename S>
-        void serialize(S& s) {
-            s.value2b(name_);
-            s.object(node_);
-        }
-    };
+    template<typename S>
+    void serialize(S& s) {
+        s.value2b(name_);
+        s.object(node_);
+    }
+};
 }
 
 /** Semantic view onto a particular node in a ModelPool. */

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -206,6 +206,25 @@ struct ModelNodeAddress
     }
 };
 
+namespace detail
+{
+    // Shared storage entry for object fields across all BaseObject instantiations.
+    // Keeps the underlying ArrayArena type identical regardless of ModelType.
+    struct ObjectField
+    {
+        ObjectField() = default;
+        ObjectField(StringId name, ModelNodeAddress a) : name_(name), node_(a) {}
+        StringId name_ = StringPool::Empty;
+        ModelNodeAddress node_;
+
+        template<typename S>
+        void serialize(S& s) {
+            s.value2b(name_);
+            s.object(node_);
+        }
+    };
+}
+
 /** Semantic view onto a particular node in a ModelPool. */
 struct ModelNode
 {
@@ -413,13 +432,15 @@ struct ValueNode final : public ModelNodeBase
  * a reference to a Model-derived pool type.
  * @tparam ModelType Model-derived type.
  */
-template<class ModelType>
+template<class ModelTypeT>
 struct MandatoryDerivedModelNodeBase : public ModelNodeBase
 {
-    inline ModelType& model() const {return *modelPtr<ModelType>();}  // NOLINT
+    using ModelType = ModelTypeT;
+
+    inline ModelTypeT& model() const {return *modelPtr<ModelTypeT>();}  // NOLINT
 
 protected:
-    template<class ModelType_ = ModelType>
+    template<class ModelType_ = ModelTypeT>
     inline ModelType_* modelPtr() const {
         return static_cast<ModelType_*>(const_cast<Model*>(model_.get()));
     }
@@ -570,24 +591,9 @@ public:
 
 protected:
     /**
-     * Object field - a name and a tree node address.
-     * These are stored in the ModelPools Field array arena.
+     * Object fields are stored in the model's shared object-field arena.
      */
-    struct Field
-    {
-        Field() = default;
-        Field(StringId name, ModelNodeAddress a) : name_(name), node_(a) {}
-        StringId name_ = StringPool::Empty;
-        ModelNodeAddress node_;
-
-        template<typename S>
-        void serialize(S& s) {
-            s.value2b(name_);
-            s.object(node_);
-        }
-    };
-
-    using Storage = ArrayArena<Field, detail::ColumnPageSize*2>;
+    using Storage = ArrayArena<detail::ObjectField, detail::ColumnPageSize*2>;
     using ModelNode::model_;
     using MandatoryDerivedModelNodeBase<ModelType>::model;
 
@@ -637,6 +643,8 @@ template<uint16_t MaxProceduralFields, class LambdaThisType=Object, class ModelP
 class ProceduralObject : public Object
 {
 public:
+    using ModelType = ModelPoolDerivedModel;
+
     [[nodiscard]] ModelNode::Ptr at(int64_t i) const override {
         if (i < fields_.size())
             return fields_[i].second(static_cast<LambdaThisType const&>(*this));

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -394,17 +394,21 @@ ModelNode::Ptr ModelPool::newValue(StringId handle) {
         ModelNodeAddress{PooledString, static_cast<uint32_t>(handle)});
 }
 
-model_ptr<Object> ModelPool::resolveObject(const ModelNode::Ptr& n) const {
-    if (n->addr_.column() != Objects)
+// Core ADL resolve hooks for base Object/Array nodes.
+template<>
+model_ptr<Object> resolveInternal(res::tag<Object>, ModelPool const& model, ModelNode const& node)
+{
+    if (node.addr().column() != ModelPool::Objects)
         raise<std::runtime_error>("Cannot cast this node to an object.");
-    return model_ptr<Object>::make(shared_from_this(), n->addr_);
+    return model_ptr<Object>::make(model.shared_from_this(), node.addr());
 }
 
-model_ptr<Array> ModelPool::resolveArray(ModelNode::Ptr const& n) const
+template<>
+model_ptr<Array> resolveInternal(res::tag<Array>, ModelPool const& model, ModelNode const& node)
 {
-    if (n->addr_.column() != Arrays)
+    if (node.addr().column() != ModelPool::Arrays)
         raise<std::runtime_error>("Cannot cast this node to an array.");
-    return model_ptr<Array>::make(shared_from_this(), n->addr_);
+    return model_ptr<Array>::make(model.shared_from_this(), node.addr());
 }
 
 std::shared_ptr<StringPool> ModelPool::strings() const


### PR DESCRIPTION
This PR fixes #99 by introducing and ADL-based `Model::resolve(ModelNode|model_ptr|ModelNodeAddress)` interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core node-resolution and casting pathways and introduces template/ADL-based dispatch, which could cause subtle compile/link or runtime type-mismatch issues if downstream models don’t provide the expected `resolveInternal` hooks.
> 
> **Overview**
> Introduces a generic `Model::resolve<Target>` overload set that can resolve from `ModelNodeAddress`, `ModelNode`, or `model_ptr`, delegating typed casts to an ADL customization point `resolveInternal(tag, model, node)`; debug builds assert model/type compatibility while release builds avoid RTTI.
> 
> Reworks core typed resolution by deleting `ModelPool::resolveObject/resolveArray` and providing built-in `resolveInternal` specializations for `Object` and `Array`, plus small supporting refactors (`ModelPool` re-exposes base overloads via `using Model::resolve`, `BaseObject` uses a shared `detail::ObjectField` storage type, and `ProceduralObject` defines `ModelType` for compatibility).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b01ea88509d1017d332fe9e90882e9c95b0f2b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->