### PR TITLE
Rework Diagnostics Folding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(simfil ${LIBRARY_TYPE}
   src/value.cpp
   src/overlay.cpp
   src/exception-handler.cpp
+  src/expression-visitor.cpp
   src/model/model.cpp
   src/model/nodes.cpp
   src/model/string-pool.cpp)
@@ -94,6 +95,7 @@ target_sources(simfil PUBLIC
       include/simfil/transient.h
       include/simfil/simfil.h
       include/simfil/exception-handler.h
+      include/simfil/expression-visitor.h
 
       include/simfil/model/arena.h
       include/simfil/model/column.h

--- a/include/simfil/diagnostics.h
+++ b/include/simfil/diagnostics.h
@@ -9,10 +9,9 @@
 
 #include <tl/expected.hpp>
 #include <optional>
-#include <unistd.h>
 #include <vector>
 #include <string>
-#include <memory>
+#include <cstdlib>
 
 namespace simfil
 {
@@ -76,6 +75,11 @@ public:
     auto write(std::ostream& stream) const -> tl::expected<void, Error>;
     auto read(std::istream& stream) -> tl::expected<void, Error>;
 
+    /**
+     * Build the exprIndex_ map for the AST.
+     */
+    auto prepareIndices(const Expr& ast) -> void;
+
     /** ExprId to diagnostics data index mapping. */
     std::vector<size_t> exprIndex_;
 
@@ -86,18 +90,14 @@ public:
     std::vector<ComparisonExprData> comparisonData_;
 
 private:
-    friend auto eval(Environment&, const AST&, const ModelNode&, Diagnostics*) -> tl::expected<std::vector<Value>, Error>;
     friend auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Message>, Error>;
-
-    /**
-     * Build the exprIndex_ map for the AST.
-     */
-    auto prepareIndizes(Expr& ast) -> void;
 
     /**
      * Build messages from this objecst diagnostics data.
      */
     auto buildMessages(Environment& env, const AST& ast) const -> std::vector<Message>;
+
+    mutable std::mutex mtx_;
 };
 
 namespace detail

--- a/include/simfil/diagnostics.h
+++ b/include/simfil/diagnostics.h
@@ -2,12 +2,14 @@
 
 #pragma once
 
+#include "simfil/sourcelocation.h"
 #include "simfil/value.h"
-#include "simfil/token.h"
 #include "simfil/error.h"
+#include "simfil/expression.h"
 
 #include <tl/expected.hpp>
 #include <optional>
+#include <unistd.h>
 #include <vector>
 #include <string>
 #include <memory>
@@ -16,7 +18,6 @@ namespace simfil
 {
 
 class AST;
-class Expr;
 struct Environment;
 struct ModelNode;
 
@@ -24,7 +25,23 @@ struct ModelNode;
 struct Diagnostics
 {
 public:
-    using ExprId = std::uint32_t;
+    struct FieldExprData
+    {
+        SourceLocation location;
+        std::uint32_t hits = 0;
+        std::uint32_t evaluations = 0;
+        std::string name;
+    };
+
+
+    struct ComparisonExprData
+    {
+        SourceLocation location;
+        TypeFlags leftTypes;
+        TypeFlags rightTypes;
+        std::uint32_t falseResults = 0u;
+        std::uint32_t trueResults = 0u;
+    };
 
     struct Message
     {
@@ -43,6 +60,12 @@ public:
     ~Diagnostics();
 
     /**
+     * Get diagnostics data for a single Expr.
+     */
+    template <class DiagnosticsDataType>
+    auto get(const Expr& expr) -> DiagnosticsDataType&;
+
+    /**
      * Append/merge another diagnostics object into this one.
      */
     Diagnostics& append(const Diagnostics& other);
@@ -53,22 +76,76 @@ public:
     auto write(std::ostream& stream) const -> tl::expected<void, Error>;
     auto read(std::istream& stream) -> tl::expected<void, Error>;
 
-    struct Data;
+    /** ExprId to diagnostics data index mapping. */
+    std::vector<size_t> exprIndex_;
+
+    /** FieldExpr diagnostics data. */
+    std::vector<FieldExprData> fieldData_;
+
+    /** ComparisonExpr diagnostics data. */
+    std::vector<ComparisonExprData> comparisonData_;
+
 private:
     friend auto eval(Environment&, const AST&, const ModelNode&, Diagnostics*) -> tl::expected<std::vector<Value>, Error>;
     friend auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Message>, Error>;
 
-    std::unique_ptr<Data> data;
-
     /**
-     * Collect diagnostics data from an AST.
+     * Build the exprIndex_ map for the AST.
      */
-    auto collect(Expr& ast) -> void;
+    auto prepareIndizes(Expr& ast) -> void;
 
     /**
      * Build messages from this objecst diagnostics data.
      */
     auto buildMessages(Environment& env, const AST& ast) const -> std::vector<Message>;
 };
+
+namespace detail
+{
+
+template <class T>
+struct DiagnosticsStorage;
+
+template <>
+struct DiagnosticsStorage<Diagnostics::FieldExprData>
+{
+    static auto get(Diagnostics& diag)
+    {
+        return &diag.fieldData_;
+    }
+};
+
+template <>
+struct DiagnosticsStorage<Diagnostics::ComparisonExprData>
+{
+    static auto get(Diagnostics& diag)
+    {
+        return &diag.comparisonData_;
+    }
+};
+
+}
+
+/**
+ * Get typed diagnostics data for a single Expr.
+ */
+template <class DiagnosticsDataType>
+auto Diagnostics::get(const Expr& expr) -> DiagnosticsDataType&
+{
+    auto* data = detail::DiagnosticsStorage<DiagnosticsDataType>::get(*this);
+
+    const auto id = expr.id();
+    if (exprIndex_.size() <= id) [[unlikely]] {
+        exprIndex_.resize(id + 1u);
+        exprIndex_[id] = data->size();
+    }
+
+    const auto index = exprIndex_[id];
+    if (data->size() <= index) {
+        data->resize(index + 1u);
+    }
+
+    return (*data)[index];
+}
 
 }

--- a/include/simfil/diagnostics.h
+++ b/include/simfil/diagnostics.h
@@ -7,6 +7,7 @@
 #include "simfil/error.h"
 #include "simfil/expression.h"
 
+#include <limits>
 #include <tl/expected.hpp>
 #include <optional>
 #include <vector>
@@ -23,6 +24,7 @@ struct ModelNode;
 /** Query Diagnostics. */
 struct Diagnostics
 {
+    static constexpr std::size_t InvalidIndex = std::numeric_limits<std::size_t>::max();
 public:
     struct FieldExprData
     {
@@ -38,6 +40,7 @@ public:
         SourceLocation location;
         TypeFlags leftTypes;
         TypeFlags rightTypes;
+        std::uint32_t evaluations = 0u;
         std::uint32_t falseResults = 0u;
         std::uint32_t trueResults = 0u;
     };
@@ -136,11 +139,16 @@ auto Diagnostics::get(const Expr& expr) -> DiagnosticsDataType&
 
     const auto id = expr.id();
     if (exprIndex_.size() <= id) [[unlikely]] {
-        exprIndex_.resize(id + 1u);
+        exprIndex_.resize(id + 1u, Diagnostics::InvalidIndex);
         exprIndex_[id] = data->size();
     }
 
-    const auto index = exprIndex_[id];
+    auto index = exprIndex_[id];
+    if (index == Diagnostics::InvalidIndex) {
+        exprIndex_[id] = data->size();
+        index = exprIndex_[id];
+    }
+
     if (data->size() <= index) {
         data->resize(index + 1u);
     }

--- a/include/simfil/diagnostics.h
+++ b/include/simfil/diagnostics.h
@@ -22,9 +22,9 @@ struct Environment;
 struct ModelNode;
 
 /** Query Diagnostics. */
-struct Diagnostics
+class Diagnostics
 {
-    static constexpr std::size_t InvalidIndex = std::numeric_limits<std::size_t>::max();
+    static constexpr std::uint32_t InvalidIndex = std::numeric_limits<std::uint32_t>::max();
 public:
     struct FieldExprData
     {
@@ -84,7 +84,7 @@ public:
     auto prepareIndices(const Expr& ast) -> void;
 
     /** ExprId to diagnostics data index mapping. */
-    std::vector<size_t> exprIndex_;
+    std::vector<std::uint32_t> exprIndex_;
 
     /** FieldExpr diagnostics data. */
     std::vector<FieldExprData> fieldData_;
@@ -93,12 +93,12 @@ public:
     std::vector<ComparisonExprData> comparisonData_;
 
 private:
-    friend auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Message>, Error>;
+    friend auto diagnostics(const Diagnostics& diag) -> tl::expected<std::vector<Message>, Error>;
 
     /**
      * Build messages from this objecst diagnostics data.
      */
-    auto buildMessages(Environment& env, const AST& ast) const -> std::vector<Message>;
+    auto buildMessages() const -> std::vector<Message>;
 
     mutable std::mutex mtx_;
 };

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -21,6 +21,7 @@ namespace simfil
 
 class Expr;
 class Function;
+class Diagnostics;
 struct ResultFn;
 struct Debug;
 
@@ -138,6 +139,7 @@ public:
 struct Context
 {
     Environment* const env;
+    Diagnostics* const diag;
 
     /* Current phase under which the evaluation
      * takes place. */
@@ -151,7 +153,8 @@ struct Context
     /* Timeout after which the evaluation should be canceled. */
     std::optional<std::chrono::time_point<std::chrono::steady_clock>> timeout;
 
-    Context(Environment* env, Phase = Phase::Evaluation);
+    Context() = delete;
+    Context(Environment* env, Diagnostics* diag, Phase = Phase::Evaluation);
 
     auto canceled() const -> bool
     {

--- a/include/simfil/expression-visitor.h
+++ b/include/simfil/expression-visitor.h
@@ -1,0 +1,77 @@
+// Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
+
+#pragma once
+
+#include <cstdint>
+
+namespace simfil
+{
+
+class Expr;
+class WildcardExpr;
+class AnyChildExpr;
+class MultiConstExpr;
+class ConstExpr;
+class SubscriptExpr;
+class SubExpr;
+class AnyExpr;
+class EachExpr;
+class CallExpression;
+class UnpackExpr;
+class UnaryWordOpExpr;
+class BinaryWordOpExpr;
+class FieldExpr;
+class PathExpr;
+class AndExpr;
+class OrExpr;
+struct OperatorEq;
+struct OperatorNeq;
+struct OperatorLt;
+struct OperatorLtEq;
+struct OperatorGt;
+struct OperatorGtEq;
+template <class> class UnaryExpr;
+template <class> class BinaryExpr;
+
+/**
+ * Visitor base for visiting expressions recursively.
+ */
+class ExprVisitor
+{
+public:
+    ExprVisitor();
+    virtual ~ExprVisitor();
+
+    virtual void visit(Expr& expr);
+    virtual void visit(WildcardExpr& expr);
+    virtual void visit(AnyChildExpr& expr);
+    virtual void visit(MultiConstExpr& expr);
+    virtual void visit(ConstExpr& expr);
+    virtual void visit(SubscriptExpr& expr);
+    virtual void visit(SubExpr& expr);
+    virtual void visit(AnyExpr& expr);
+    virtual void visit(EachExpr& expr);
+    virtual void visit(CallExpression& expr);
+    virtual void visit(PathExpr& expr);
+    virtual void visit(FieldExpr& expr);
+    virtual void visit(UnpackExpr& expr);
+    virtual void visit(UnaryWordOpExpr& expr);
+    virtual void visit(BinaryWordOpExpr& expr);
+    virtual void visit(AndExpr& expr);
+    virtual void visit(OrExpr& expr);
+    virtual void visit(BinaryExpr<OperatorEq>& expr);
+    virtual void visit(BinaryExpr<OperatorNeq>& expr);
+    virtual void visit(BinaryExpr<OperatorLt>& expr);
+    virtual void visit(BinaryExpr<OperatorLtEq>& expr);
+    virtual void visit(BinaryExpr<OperatorGt>& expr);
+    virtual void visit(BinaryExpr<OperatorGtEq>& expr);
+
+protected:
+    /* Returns the index of the current expression */
+    std::size_t index() const;
+
+private:
+    std::size_t index_ = 0;
+};
+
+}

--- a/include/simfil/expression-visitor.h
+++ b/include/simfil/expression-visitor.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cstdlib>
 
 namespace simfil
 {
@@ -42,29 +42,29 @@ public:
     ExprVisitor();
     virtual ~ExprVisitor();
 
-    virtual void visit(Expr& expr);
-    virtual void visit(WildcardExpr& expr);
-    virtual void visit(AnyChildExpr& expr);
-    virtual void visit(MultiConstExpr& expr);
-    virtual void visit(ConstExpr& expr);
-    virtual void visit(SubscriptExpr& expr);
-    virtual void visit(SubExpr& expr);
-    virtual void visit(AnyExpr& expr);
-    virtual void visit(EachExpr& expr);
-    virtual void visit(CallExpression& expr);
-    virtual void visit(PathExpr& expr);
-    virtual void visit(FieldExpr& expr);
-    virtual void visit(UnpackExpr& expr);
-    virtual void visit(UnaryWordOpExpr& expr);
-    virtual void visit(BinaryWordOpExpr& expr);
-    virtual void visit(AndExpr& expr);
-    virtual void visit(OrExpr& expr);
-    virtual void visit(BinaryExpr<OperatorEq>& expr);
-    virtual void visit(BinaryExpr<OperatorNeq>& expr);
-    virtual void visit(BinaryExpr<OperatorLt>& expr);
-    virtual void visit(BinaryExpr<OperatorLtEq>& expr);
-    virtual void visit(BinaryExpr<OperatorGt>& expr);
-    virtual void visit(BinaryExpr<OperatorGtEq>& expr);
+    virtual void visit(const Expr& expr);
+    virtual void visit(const WildcardExpr& expr);
+    virtual void visit(const AnyChildExpr& expr);
+    virtual void visit(const MultiConstExpr& expr);
+    virtual void visit(const ConstExpr& expr);
+    virtual void visit(const SubscriptExpr& expr);
+    virtual void visit(const SubExpr& expr);
+    virtual void visit(const AnyExpr& expr);
+    virtual void visit(const EachExpr& expr);
+    virtual void visit(const CallExpression& expr);
+    virtual void visit(const PathExpr& expr);
+    virtual void visit(const FieldExpr& expr);
+    virtual void visit(const UnpackExpr& expr);
+    virtual void visit(const UnaryWordOpExpr& expr);
+    virtual void visit(const BinaryWordOpExpr& expr);
+    virtual void visit(const AndExpr& expr);
+    virtual void visit(const OrExpr& expr);
+    virtual void visit(const BinaryExpr<OperatorEq>& expr);
+    virtual void visit(const BinaryExpr<OperatorNeq>& expr);
+    virtual void visit(const BinaryExpr<OperatorLt>& expr);
+    virtual void visit(const BinaryExpr<OperatorLtEq>& expr);
+    virtual void visit(const BinaryExpr<OperatorGt>& expr);
+    virtual void visit(const BinaryExpr<OperatorGtEq>& expr);
 
 protected:
     /* Returns the index of the current expression */

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -5,7 +5,6 @@
 #include "simfil/token.h"
 #include "simfil/value.h"
 #include "simfil/environment.h"
-#include "simfil/diagnostics.h"
 #include "simfil/result.h"
 
 #include <memory>
@@ -110,7 +109,8 @@ private:
     virtual auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> = 0;
     
     /* Move-optimized evaluation implementation */
-    virtual auto ieval(Context ctx, Value&& value, const ResultFn& result) -> tl::expected<Result, Error> {
+    virtual auto ieval(Context ctx, Value&& value, const ResultFn& result) -> tl::expected<Result, Error>
+    {
         return ieval(ctx, value, result);
     }
 

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -59,7 +59,7 @@ public:
     /* Debug */
     virtual auto toString() const -> std::string = 0;
 
-    auto eval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+    auto eval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
     {
         if (ctx.canceled())
             return Result::Stop;
@@ -75,7 +75,7 @@ public:
         return ieval(ctx, val, res);
     }
 
-    auto eval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error>
+    auto eval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error>
     {
         if (ctx.canceled())
             return Result::Stop;
@@ -90,12 +90,8 @@ public:
         return ieval(ctx, std::move(val), res);
     }
 
-    /* Recursive clone */
-    [[nodiscard]]
-    virtual auto clone() const -> std::unique_ptr<Expr> = 0;
-
     /* Accept expression visitor */
-    virtual auto accept(ExprVisitor& v) -> void = 0;
+    virtual auto accept(ExprVisitor& v) const -> void = 0;
 
     /* Source location the expression got parsed from */
     [[nodiscard]]
@@ -106,10 +102,10 @@ public:
 
 private:
     /* Abstract evaluation implementation */
-    virtual auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> = 0;
+    virtual auto ieval(Context ctx, const Value& value, const ResultFn& result) const -> tl::expected<Result, Error> = 0;
     
     /* Move-optimized evaluation implementation */
-    virtual auto ieval(Context ctx, Value&& value, const ResultFn& result) -> tl::expected<Result, Error>
+    virtual auto ieval(Context ctx, Value&& value, const ResultFn& result) const -> tl::expected<Result, Error>
     {
         return ieval(ctx, value, result);
     }
@@ -130,7 +126,7 @@ public:
 
     ~AST();
 
-    auto expr() const -> Expr&
+    auto expr() const -> const Expr&
     {
         return *expr_;
     }

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -19,6 +19,8 @@ class Expr
 {
     friend class AST;
 public:
+    using ExprId = std::uint32_t;
+
     /**
      * Type of an expression.
      */
@@ -30,8 +32,12 @@ public:
         VALUE,
     };
 
-    Expr() = default;
-    explicit Expr(const Token& token)
+    Expr() = delete;
+    explicit Expr(ExprId id)
+        : id_(id)
+    {}
+    explicit Expr(ExprId id, const Token& token)
+        : id_(id)
     {
         assert(token.end >= token.begin);
         sourceLocation_.offset = token.begin;
@@ -41,6 +47,10 @@ public:
     virtual ~Expr() = default;
 
     /* Category */
+    auto id() const -> ExprId
+    {
+        return id_;
+    }
     virtual auto type() const -> Type = 0;
     virtual auto constant() const -> bool
     {
@@ -104,6 +114,7 @@ private:
         return ieval(ctx, value, result);
     }
 
+    ExprId id_;
     SourceLocation sourceLocation_;
 };
 

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -31,7 +31,7 @@ class ModelPool;
 class Model;
 struct ModelNode;
 struct Environment;
-struct Diagnostics;
+class Diagnostics;
 class AST;
 class Expr;
 

--- a/include/simfil/parser.h
+++ b/include/simfil/parser.h
@@ -59,6 +59,7 @@ public:
     };
 
     struct Context {
+        Expr::ExprId id = 0;
         bool inPath = false;
     };
 
@@ -102,6 +103,11 @@ public:
      */
     auto mode() const -> Mode;
     auto relaxed() const -> bool;
+
+    /**
+     * Get the next expression id.
+     */
+    auto nextId() -> Expr::ExprId;
 
     Context ctx;
     Environment* const env;

--- a/include/simfil/simfil.h
+++ b/include/simfil/simfil.h
@@ -52,7 +52,7 @@ auto eval(Environment& env, const AST& ast, ModelNode const& node, Diagnostics* 
  * Param:
  *   diag   Diagnostics data filled by eval.
  */
-auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> tl::expected<std::vector<Diagnostics::Message>, Error>;
+auto diagnostics(const Diagnostics& diag) -> tl::expected<std::vector<Diagnostics::Message>, Error>;
 
 /**
  * Find completion candidates for an expression.

--- a/include/simfil/sourcelocation.h
+++ b/include/simfil/sourcelocation.h
@@ -19,7 +19,6 @@ struct SourceLocation
     SourceLocation(const SourceLocation&) = default;
 
     auto operator==(const SourceLocation& o) const -> bool = default;
-    auto operator!=(const SourceLocation& o) const -> bool = default;
 };
 
 }

--- a/include/simfil/sourcelocation.h
+++ b/include/simfil/sourcelocation.h
@@ -1,26 +1,25 @@
 #pragma once
 
-#include <cstddef>
+#include <cstdint>
 
 namespace simfil
 {
 
 struct SourceLocation
 {
-    size_t offset = 0;
-    size_t size = 0;
+    std::uint32_t offset = 0u;
+    std::uint32_t size = 0u;
 
-    SourceLocation()
-        : offset(0), size(0)
-    {}
+    SourceLocation() = default;
 
-    SourceLocation(size_t offset, size_t size)
+    SourceLocation(std::uint32_t offset, std::uint32_t size)
         : offset(offset), size(size)
     {}
 
     SourceLocation(const SourceLocation&) = default;
 
     auto operator==(const SourceLocation& o) const -> bool = default;
+    auto operator!=(const SourceLocation& o) const -> bool = default;
 };
 
 }

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -323,7 +323,7 @@ int main(int argc, char *argv[])
             std::cout << "  " << v.toString() << "\n";
         }
 
-        auto messages = simfil::diagnostics(env, **ast, diag);
+        auto messages = simfil::diagnostics(diag);
         if (!messages) {
             std::cerr << "Error: " << messages.error().message << "\n";
             continue;

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -137,7 +137,7 @@ auto CompletionFieldOrWordExpr::type() const -> Type
     return Type::FIELD;
 }
 
-auto CompletionFieldOrWordExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CompletionFieldOrWordExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (ctx.phase == Context::Phase::Compilation)
         return res(ctx, Value::undef());
@@ -191,12 +191,7 @@ auto CompletionFieldOrWordExpr::toString() const -> std::string
     return prefix_;
 }
 
-auto CompletionFieldOrWordExpr::clone() const -> std::unique_ptr<Expr>
-{
-    throw std::runtime_error("Cannot clone CompletionFieldOrWordExpr");
-}
-
-auto CompletionFieldOrWordExpr::accept(ExprVisitor& v) -> void
+auto CompletionFieldOrWordExpr::accept(ExprVisitor& v) const -> void
 {
     v.visit(*this);
 }
@@ -216,7 +211,7 @@ struct FindExpressionRange : ExprVisitor
 
     using ExprVisitor::visit;
 
-    void visit(Expr& expr) override
+    void visit(const Expr& expr) override
     {
         ExprVisitor::visit(expr);
 
@@ -255,7 +250,7 @@ auto CompletionAndExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto CompletionAndExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CompletionAndExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (left_)
         (void)left_->eval(ctx, val, LambdaResultFn([](const Context&, const Value&) {
@@ -270,14 +265,9 @@ auto CompletionAndExpr::ieval(Context ctx, const Value& val, const ResultFn& res
     return Result::Continue;
 }
 
-void CompletionAndExpr::accept(ExprVisitor& v)
+void CompletionAndExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto CompletionAndExpr::clone() const -> ExprPtr
-{
-    throw std::runtime_error("Cannot clone CompletionAndExpr");
 }
 
 auto CompletionAndExpr::toString() const -> std::string
@@ -316,7 +306,7 @@ auto CompletionOrExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto CompletionOrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CompletionOrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (left_)
         (void)left_->eval(ctx, val, LambdaResultFn([](const Context&, const Value&) {
@@ -331,14 +321,9 @@ auto CompletionOrExpr::ieval(Context ctx, const Value& val, const ResultFn& res)
     return Result::Continue;
 }
 
-void CompletionOrExpr::accept(ExprVisitor& v)
+void CompletionOrExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto CompletionOrExpr::clone() const -> ExprPtr
-{
-    throw std::runtime_error("Cannot clone CompletionOrExpr");
 }
 
 auto CompletionOrExpr::toString() const -> std::string
@@ -368,7 +353,7 @@ auto CompletionWordExpr::constant() const -> bool
     return true;
 }
 
-auto CompletionWordExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CompletionWordExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (ctx.phase == Context::Phase::Compilation)
         return res(ctx, Value::undef());
@@ -384,12 +369,7 @@ auto CompletionWordExpr::toString() const -> std::string
     return prefix_;
 }
 
-auto CompletionWordExpr::clone() const -> std::unique_ptr<Expr>
-{
-    throw std::runtime_error("Cannot clone CompletionWordExpr");
-}
-
-auto CompletionWordExpr::accept(ExprVisitor& v) -> void
+auto CompletionWordExpr::accept(ExprVisitor& v) const -> void
 {
     v.visit(*this);
 }
@@ -399,12 +379,7 @@ auto CompletionConstExpr::constant() const -> bool
     return false;
 }
 
-auto CompletionConstExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<CompletionConstExpr>(id(), value_);
-}
-
-auto CompletionConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error>
+auto CompletionConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (ctx.phase == Context::Compilation)
         return res(ctx, Value::undef());

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -125,8 +125,8 @@ auto completeWords(const simfil::Context& ctx, std::string_view prefix, simfil::
 namespace simfil
 {
 
-CompletionFieldOrWordExpr::CompletionFieldOrWordExpr(std::string prefix, Completion* comp, const Token& token, bool inPath)
-    : Expr(token)
+CompletionFieldOrWordExpr::CompletionFieldOrWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token, bool inPath)
+    : Expr(id, token)
     , prefix_(std::move(prefix))
     , comp_(comp)
     , inPath_(inPath)
@@ -230,8 +230,9 @@ struct FindExpressionRange : ExprVisitor
 
 }
 
-CompletionAndExpr::CompletionAndExpr(ExprPtr left, ExprPtr right, const Completion* comp)
-    : left_(std::move(left))
+CompletionAndExpr::CompletionAndExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp)
+    : Expr(id)
+    , left_(std::move(left))
     , right_(std::move(right))
 {
     FindExpressionRange leftRange;
@@ -290,8 +291,9 @@ auto CompletionAndExpr::toString() const -> std::string
     return "(and ? ?)";
 }
 
-CompletionOrExpr::CompletionOrExpr(ExprPtr left, ExprPtr right, const Completion* comp)
-    : left_(std::move(left))
+CompletionOrExpr::CompletionOrExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp)
+    : Expr(id)
+    , left_(std::move(left))
     , right_(std::move(right))
 {
     FindExpressionRange leftRange;
@@ -350,8 +352,8 @@ auto CompletionOrExpr::toString() const -> std::string
     return "(or ? ?)";
 }
 
-CompletionWordExpr::CompletionWordExpr(std::string prefix, Completion* comp, const Token& token)
-    : Expr(token)
+CompletionWordExpr::CompletionWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token)
+    : Expr(id, token)
     , prefix_(std::move(prefix))
     , comp_(comp)
 {}
@@ -399,7 +401,7 @@ auto CompletionConstExpr::constant() const -> bool
 
 auto CompletionConstExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<CompletionConstExpr>(value_);
+    return std::make_unique<CompletionConstExpr>(id(), value_);
 }
 
 auto CompletionConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error>

--- a/src/completion.h
+++ b/src/completion.h
@@ -45,7 +45,7 @@ struct Completion
 class CompletionFieldOrWordExpr : public Expr
 {
 public:
-    CompletionFieldOrWordExpr(std::string prefix, Completion* comp, const Token& token, bool inPath);
+    CompletionFieldOrWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token, bool inPath);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> override;
@@ -61,7 +61,7 @@ public:
 class CompletionAndExpr : public Expr
 {
 public:
-    CompletionAndExpr(ExprPtr left, ExprPtr right, const Completion* comp);
+    CompletionAndExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -75,7 +75,7 @@ public:
 class CompletionOrExpr : public Expr
 {
 public:
-    CompletionOrExpr(ExprPtr left, ExprPtr right, const Completion* comp);
+    CompletionOrExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -89,7 +89,7 @@ public:
 class CompletionWordExpr : public Expr
 {
 public:
-    CompletionWordExpr(std::string prefix, Completion* comp, const Token& token);
+    CompletionWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;

--- a/src/completion.h
+++ b/src/completion.h
@@ -48,9 +48,8 @@ public:
     CompletionFieldOrWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token, bool inPath);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> override;
-    auto clone() const -> std::unique_ptr<Expr> override;
-    auto accept(ExprVisitor& v) -> void override;
+    auto ieval(Context ctx, const Value& value, const ResultFn& result) const -> tl::expected<Result, Error> override;
+    auto accept(ExprVisitor& v) const -> void override;
     auto toString() const -> std::string override;
 
     std::string prefix_;
@@ -64,9 +63,8 @@ public:
     CompletionAndExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -78,9 +76,8 @@ public:
     CompletionOrExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -93,9 +90,8 @@ public:
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
-    auto ieval(Context ctx, const Value& value, const ResultFn& result) -> tl::expected<Result, Error> override;
-    auto clone() const -> std::unique_ptr<Expr> override;
-    auto accept(ExprVisitor& v) -> void override;
+    auto ieval(Context ctx, const Value& value, const ResultFn& result) const -> tl::expected<Result, Error> override;
+    auto accept(ExprVisitor& v) const -> void override;
     auto toString() const -> std::string override;
 
     std::string prefix_;
@@ -112,8 +108,7 @@ public:
     using ConstExpr::ConstExpr;
 
     auto constant() const -> bool override;
-    auto clone() const -> ExprPtr override;
-    auto ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error> override;
 };
 
 }

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -28,8 +28,8 @@ void serialize(S& s, TypeFlags& flags)
 template<typename S>
 void serialize(S& s, Diagnostics& data)
 {
-    s.container(data.exprIndex_, std::numeric_limits<uint16_t>::max(), [](auto& s2, std::size_t& v) {
-        s2.value8b(v);
+    s.container(data.exprIndex_, std::numeric_limits<uint16_t>::max(), [](auto& s2, std::uint32_t& v) {
+        s2.value4b(v);
     });
     s.container(data.fieldData_, std::numeric_limits<uint16_t>::max(), [](auto& s2, Diagnostics::FieldExprData& data) {
         s2.value4b(data.location.offset);
@@ -143,7 +143,7 @@ auto Diagnostics::read(std::istream& stream) -> tl::expected<void, Error>
     return {};
 }
 
-auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::vector<Diagnostics::Message>
+auto Diagnostics::buildMessages() const -> std::vector<Diagnostics::Message>
 {
     std::vector<Diagnostics::Message> messages;
 
@@ -196,9 +196,9 @@ auto Diagnostics::prepareIndices(const Expr& ast) -> void
 {
     struct Visitor : ExprVisitor
     {
-        std::size_t fieldIndex_ = 0u;
-        std::size_t comparisonIndex_ = 0u;
-        std::vector<std::size_t> indices_;
+        std::uint32_t fieldIndex_ = 0u;
+        std::uint32_t comparisonIndex_ = 0u;
+        std::vector<std::uint32_t> indices_;
 
         Visitor()
         {

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -43,6 +43,7 @@ void serialize(S& s, Diagnostics& data)
         s2.value4b(data.location.size);
         s2.object(data.leftTypes);
         s2.object(data.rightTypes);
+        s2.value4b(data.evaluations);
         s2.value4b(data.trueResults);
         s2.value4b(data.falseResults);
     });
@@ -60,6 +61,9 @@ Diagnostics::~Diagnostics() = default;
 
 Diagnostics& Diagnostics::append(const Diagnostics& other)
 {
+    std::unique_lock lock1(mtx_);
+    std::unique_lock lock2(other.mtx_);
+
 #if !defined(NDEBUG)
     if (!exprIndex_.empty())
         assert(std::ranges::equal(exprIndex_, other.exprIndex_));
@@ -74,7 +78,10 @@ Diagnostics& Diagnostics::append(const Diagnostics& other)
         auto* theirs = i < other.fieldData_.size() ? &other.fieldData_[i] : nullptr;
 
         if (ours && theirs) {
-            assert(ours->name == theirs->name);
+            if (ours->name.empty())
+                ours->name = theirs->name;
+            if (ours->location == SourceLocation{0, 0})
+                ours->location = theirs->location;
             ours->hits += theirs->hits;
             ours->evaluations += theirs->evaluations;
         }
@@ -89,8 +96,11 @@ Diagnostics& Diagnostics::append(const Diagnostics& other)
         auto* theirs = i < other.comparisonData_.size() ? &other.comparisonData_[i] : nullptr;
 
         if (ours && theirs) {
+            if (ours->location == SourceLocation{0, 0})
+                ours->location = theirs->location;
             ours->leftTypes.set(theirs->leftTypes);
             ours->rightTypes.set(theirs->rightTypes);
+            ours->evaluations += theirs->evaluations;
             ours->trueResults += theirs->trueResults;
             ours->falseResults += theirs->falseResults;
         }
@@ -147,7 +157,7 @@ auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::
     };
 
     for (const auto& data : fieldData_) {
-        if (data.hits == 0u)
+        if (data.hits == 0 && data.evaluations > 0)
             addMessage(data.location, fmt::format("No matches for field '{}'", data.name));
     }
 
@@ -165,7 +175,7 @@ auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::
         }
 
         const auto intersection = leftTypes.flags & rightTypes.flags;
-        if (intersection.none()) {
+        if (intersection.none() && data.evaluations > 0) {
             const auto allTrue = data.trueResults > 0 && data.falseResults == 0;
             const auto allFalse = data.falseResults > 0 && data.trueResults == 0;
             const auto prefix =
@@ -200,14 +210,14 @@ auto Diagnostics::prepareIndices(const Expr& ast) -> void
         auto visit(const FieldExpr& e) -> void override {
             ExprVisitor::visit(e);
             if (e.id() >= indices_.size())
-                indices_.resize(e.id() + 1);
+                indices_.resize(e.id() + 1, Diagnostics::InvalidIndex);
             indices_[e.id()] = fieldIndex_++;
         }
 
         auto visitComparisonOperator(const ComparisonExprBase& e) -> void
         {
             if (e.id() >= indices_.size())
-                indices_.resize(e.id() + 1);
+                indices_.resize(e.id() + 1, Diagnostics::InvalidIndex);
             indices_[e.id()] = comparisonIndex_++;
         }
 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -108,7 +108,7 @@ auto Diagnostics::write(std::ostream& stream) const -> tl::expected<void, Error>
     using OutputAdapter = bitsery::OutputStreamAdapter;
     
     bitsery::Serializer<OutputAdapter> serializer{stream};
-    //auto lock = data->lock();
+    std::unique_lock lock(mtx_);
     serializer.object(*this);
     
     if (!stream.good()) {
@@ -123,7 +123,7 @@ auto Diagnostics::read(std::istream& stream) -> tl::expected<void, Error>
     using InputAdapter = bitsery::InputStreamAdapter;
     
     bitsery::Deserializer<InputAdapter> deserializer{stream};
-    //auto lock = data->lock();
+    std::unique_lock lock(mtx_);
     deserializer.object(*this);
     
     if (!stream.good()) {
@@ -165,7 +165,7 @@ auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::
         }
 
         const auto intersection = leftTypes.flags & rightTypes.flags;
-        if (true || intersection.none()) {
+        if (intersection.none()) {
             const auto allTrue = data.trueResults > 0 && data.falseResults == 0;
             const auto allFalse = data.falseResults > 0 && data.trueResults == 0;
             const auto prefix =
@@ -182,7 +182,7 @@ auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::
     return messages;
 }
 
-auto Diagnostics::prepareIndizes(Expr& ast) -> void
+auto Diagnostics::prepareIndices(const Expr& ast) -> void
 {
     struct Visitor : ExprVisitor
     {
@@ -197,7 +197,7 @@ auto Diagnostics::prepareIndizes(Expr& ast) -> void
 
         using ExprVisitor::visit;
 
-        auto visit(FieldExpr& e) -> void override {
+        auto visit(const FieldExpr& e) -> void override {
             ExprVisitor::visit(e);
             if (e.id() >= indices_.size())
                 indices_.resize(e.id() + 1);
@@ -211,32 +211,32 @@ auto Diagnostics::prepareIndizes(Expr& ast) -> void
             indices_[e.id()] = comparisonIndex_++;
         }
 
-        auto visit(BinaryExpr<OperatorEq>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorEq>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }
 
-        auto visit(BinaryExpr<OperatorNeq>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorNeq>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }
 
-        auto visit(BinaryExpr<OperatorLt>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorLt>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }
 
-        auto visit(BinaryExpr<OperatorLtEq>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorLtEq>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }
 
-        auto visit(BinaryExpr<OperatorGt>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorGt>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }
 
-        auto visit(BinaryExpr<OperatorGtEq>& e) -> void override {
+        auto visit(const BinaryExpr<OperatorGtEq>& e) -> void override {
             ExprVisitor::visit(e);
             visitComparisonOperator(e);
         }

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -1,36 +1,23 @@
 // Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
 
 #include "simfil/diagnostics.h"
+#include "simfil/expression-visitor.h"
 
 #include "expressions.h"
+#include "simfil/sourcelocation.h"
 
-#include <cctype>
+#include <algorithm>
+#include <ranges>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <bitsery/bitsery.h>
 #include <bitsery/adapter/stream.h>
-#include <bitsery/ext/std_map.h>
 #include <bitsery/ext/std_bitset.h>
+#include <bitsery/traits/string.h>
+#include <bitsery/traits/vector.h>
 
 namespace simfil
 {
-
-struct Diagnostics::Data
-{
-    std::mutex mtx;
-
-    // Number a FieldExpr field was found in the model
-    std::unordered_map<ExprId, uint32_t> fieldHits;
-
-    // Comparison operator operand types
-    std::unordered_map<ExprId, std::tuple<TypeFlags, TypeFlags>> comparisonOperandTypes;
-
-    [[nodiscard]]
-    auto lock()
-    {
-        return std::unique_lock(mtx);
-    }
-};
 
 template<typename S>
 void serialize(S& s, TypeFlags& flags)
@@ -39,44 +26,78 @@ void serialize(S& s, TypeFlags& flags)
 }
 
 template<typename S>
-void serialize(S& s, Diagnostics::Data& data)
+void serialize(S& s, Diagnostics& data)
 {
-    s.ext(data.fieldHits, bitsery::ext::StdMap{std::numeric_limits<uint32_t>::max()},
-        [](S& s, Diagnostics::ExprId& key, uint32_t& value) {
-            s.value4b(key);
-            s.value4b(value);
-        });
-    s.ext(data.comparisonOperandTypes, bitsery::ext::StdMap{std::numeric_limits<uint32_t>::max()},
-        [](S& s, Diagnostics::ExprId& key, std::tuple<TypeFlags, TypeFlags>& value) {
-            s.value4b(key);
-            s.object(std::get<0>(value));
-            s.object(std::get<1>(value));
-        });
+    s.container(data.exprIndex_, std::numeric_limits<uint16_t>::max(), [](auto& s2, std::size_t& v) {
+        s2.value8b(v);
+    });
+    s.container(data.fieldData_, std::numeric_limits<uint16_t>::max(), [](auto& s2, Diagnostics::FieldExprData& data) {
+        s2.value4b(data.location.offset);
+        s2.value4b(data.location.size);
+        s2.value4b(data.hits);
+        s2.value4b(data.evaluations);
+        s2.text1b(data.name, 0xff);
+    });
+    s.container(data.comparisonData_, std::numeric_limits<uint16_t>::max(), [](auto& s2, Diagnostics::ComparisonExprData& data) {
+        s2.value4b(data.location.offset);
+        s2.value4b(data.location.size);
+        s2.object(data.leftTypes);
+        s2.object(data.rightTypes);
+        s2.value4b(data.trueResults);
+        s2.value4b(data.falseResults);
+    });
 }
 
-Diagnostics::Diagnostics()
-    : data(std::make_unique<Diagnostics::Data>())
-{}
+Diagnostics::Diagnostics() = default;
 
 Diagnostics::Diagnostics(Diagnostics&& other) noexcept
-    : data(std::move(other.data))
+    : exprIndex_(std::move(other.exprIndex_))
+    , fieldData_(std::move(other.fieldData_))
+    , comparisonData_(std::move(other.comparisonData_))
 {}
 
 Diagnostics::~Diagnostics() = default;
 
 Diagnostics& Diagnostics::append(const Diagnostics& other)
 {
-    auto otherLock = other.data->lock();
-    auto lock = data->lock();
+#if !defined(NDEBUG)
+    if (!exprIndex_.empty())
+        assert(std::ranges::equal(exprIndex_, other.exprIndex_));
+#endif
 
-    for (const auto& [key, value] : other.data->fieldHits) {
-        data->fieldHits[key] += value;
+    // Either our indices are empty or equal to the rhs, so
+    // we can just copy them every time.
+    exprIndex_ = other.exprIndex_;
+
+    for (auto i = 0u; i < std::max<std::size_t>(fieldData_.size(), other.fieldData_.size()); ++i) {
+        auto* ours = i < fieldData_.size() ? &fieldData_[i] : nullptr;
+        auto* theirs = i < other.fieldData_.size() ? &other.fieldData_[i] : nullptr;
+
+        if (ours && theirs) {
+            assert(ours->name == theirs->name);
+            ours->hits += theirs->hits;
+            ours->evaluations += theirs->evaluations;
+        }
+
+        if (!ours && theirs) {
+            fieldData_.emplace_back(*theirs);
+        }
     }
 
-    for (const auto& [key, value] : other.data->comparisonOperandTypes) {
-        auto& [left, right] = data->comparisonOperandTypes[key];
-        left.set(std::get<0>(value));
-        right.set(std::get<1>(value));
+    for (auto i = 0u; i < std::max<std::size_t>(comparisonData_.size(), other.comparisonData_.size()); ++i) {
+        auto* ours = i < comparisonData_.size() ? &comparisonData_[i] : nullptr;
+        auto* theirs = i < other.comparisonData_.size() ? &other.comparisonData_[i] : nullptr;
+
+        if (ours && theirs) {
+            ours->leftTypes.set(theirs->leftTypes);
+            ours->rightTypes.set(theirs->rightTypes);
+            ours->trueResults += theirs->trueResults;
+            ours->falseResults += theirs->falseResults;
+        }
+
+        if (!ours && theirs) {
+            comparisonData_.emplace_back(*theirs);
+        }
     }
 
     return *this;
@@ -87,8 +108,8 @@ auto Diagnostics::write(std::ostream& stream) const -> tl::expected<void, Error>
     using OutputAdapter = bitsery::OutputStreamAdapter;
     
     bitsery::Serializer<OutputAdapter> serializer{stream};
-    auto lock = data->lock();
-    serializer.object(*data);
+    //auto lock = data->lock();
+    serializer.object(*this);
     
     if (!stream.good()) {
         return tl::unexpected(Error(Error::IOError, "Failed to write diagnostics data to stream"));
@@ -102,8 +123,8 @@ auto Diagnostics::read(std::istream& stream) -> tl::expected<void, Error>
     using InputAdapter = bitsery::InputStreamAdapter;
     
     bitsery::Deserializer<InputAdapter> deserializer{stream};
-    auto lock = data->lock();
-    deserializer.object(*data);
+    //auto lock = data->lock();
+    deserializer.object(*this);
     
     if (!stream.good()) {
         return tl::unexpected(Error(Error::IOError, "Failed to read diagnostics data from stream"));
@@ -114,172 +135,80 @@ auto Diagnostics::read(std::istream& stream) -> tl::expected<void, Error>
 
 auto Diagnostics::buildMessages(Environment& env, const AST& ast) const -> std::vector<Diagnostics::Message>
 {
-    struct Visitor : ExprVisitor
-    {
-        const AST& ast;
-        const Environment& env;
-        const Diagnostics::Data& diagnostics;
-        std::vector<Diagnostics::Message> messages;
+    std::vector<Diagnostics::Message> messages;
 
-        Visitor(const AST& ast, const Environment& env, const Diagnostics::Data& diagnostics)
-            : ast(ast)
-            , env(env)
-            , diagnostics(diagnostics)
-        {}
+    auto addMessage = [&](SourceLocation loc, std::string text) {
+        Diagnostics::Message msg;
+        msg.message = std::move(text);
+        //msg.fix = std::move(fix);
+        msg.location = loc;
 
-        using ExprVisitor::visit;
-
-        void visit(FieldExpr& e) override
-        {
-            ExprVisitor::visit(e);
-
-            auto iter = diagnostics.fieldHits.find(index());
-            if (iter == diagnostics.fieldHits.end())
-                return;
-
-            if (iter->second > 0)
-                return;
-
-            addMessage(fmt::format("No matches for field '{}'.", e.name_), e, {});
-        }
-
-        void visitComparisonOperator(ComparisonExprBase& e, bool expectedResult)
-        {
-            const auto [falseResults, trueResults] = e.resultCounts();
-            if ((expectedResult && trueResults > 0) || (!expectedResult && falseResults > 0))
-                return;
-
-            auto iter = diagnostics.comparisonOperandTypes.find(index());
-            if (iter == diagnostics.comparisonOperandTypes.end())
-                return;
-
-            auto [leftTypes, rightTypes] = iter->second;
-            if (leftTypes.test(ValueType::Int) || leftTypes.test(ValueType::Float)) {
-                leftTypes.set(ValueType::Int);
-                leftTypes.set(ValueType::Float);
-            }
-            if (rightTypes.test(ValueType::Int) || rightTypes.test(ValueType::Float)) {
-                rightTypes.set(ValueType::Int);
-                rightTypes.set(ValueType::Float);
-            }
-
-            const auto intersection = leftTypes.flags & rightTypes.flags;
-            if (intersection.any())
-                return;
-
-            addMessage(fmt::format("All values compared to {}. Left hand types are {}, right hand types are {}.",
-                                   expectedResult ? "false" : "true",
-                                   fmt::join(leftTypes.typeNames(), "|"),
-                                   fmt::join(rightTypes.typeNames(), "|")),
-                       e, {});
-        }
-
-        void visit(BinaryExpr<OperatorEq>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, true);
-        }
-
-        void visit(BinaryExpr<OperatorNeq>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, false);
-        }
-
-        void visit(BinaryExpr<OperatorLt>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, true);
-        }
-
-        void visit(BinaryExpr<OperatorLtEq>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, true);
-        }
-
-        void visit(BinaryExpr<OperatorGt>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, false);
-        }
-
-        void visit(BinaryExpr<OperatorGtEq>& e) override
-        {
-            ExprVisitor::visit(e);
-            visitComparisonOperator(e, false);
-        }
-
-        void addMessage(std::string text, const Expr& expr, std::optional<std::string> fix)
-        {
-            Diagnostics::Message msg;
-            msg.message = std::move(text);
-            msg.location = expr.sourceLocation();
-            msg.fix = std::move(fix);
-
-            messages.push_back(std::move(msg));
-        }
+        messages.push_back(std::move(msg));
     };
 
-    Visitor visitor(ast, env, *data);
+    for (const auto& data : fieldData_) {
+        if (data.hits == 0u)
+            addMessage(data.location, fmt::format("No matches for field '{}'", data.name));
+    }
 
-    auto lock = data->lock();
-    ast.expr().accept(visitor);
+    for (const auto& data : comparisonData_) {
+        auto leftTypes = data.leftTypes;
+        if (leftTypes.test(ValueType::Int) || leftTypes.test(ValueType::Float)) {
+            leftTypes.set(ValueType::Int);
+            leftTypes.set(ValueType::Float);
+        }
 
-    return visitor.messages;
+        auto rightTypes = data.rightTypes;
+        if (rightTypes.test(ValueType::Int) || rightTypes.test(ValueType::Float)) {
+            rightTypes.set(ValueType::Int);
+            rightTypes.set(ValueType::Float);
+        }
+
+        const auto intersection = leftTypes.flags & rightTypes.flags;
+        if (true || intersection.none()) {
+            const auto allTrue = data.trueResults > 0 && data.falseResults == 0;
+            const auto allFalse = data.falseResults > 0 && data.trueResults == 0;
+            const auto prefix =
+                allTrue ? "All values compared to true. " :
+                allFalse ? "All values compared to false. " : "";
+
+            addMessage(data.location, fmt::format("{}Left hand types are {}, right hand types are {}.",
+                                                  prefix,
+                                                  fmt::join(leftTypes.typeNames(), "|"),
+                                                  fmt::join(rightTypes.typeNames(), "|")));
+        }
+    }
+
+    return messages;
 }
 
-auto Diagnostics::collect(Expr& ast) -> void
+auto Diagnostics::prepareIndizes(Expr& ast) -> void
 {
-    struct CollectDiagnostics : ExprVisitor
+    struct Visitor : ExprVisitor
     {
-        Diagnostics::Data& diagnostics;
-        bool suppressDiagnostics = false;
+        std::size_t fieldIndex_ = 0u;
+        std::size_t comparisonIndex_ = 0u;
+        std::vector<std::size_t> indices_;
 
-        explicit CollectDiagnostics(Diagnostics::Data& diag)
-            : diagnostics(diag)
-        {}
+        Visitor()
+        {
+            indices_.reserve(32);
+        }
 
         using ExprVisitor::visit;
 
         auto visit(FieldExpr& e) -> void override {
             ExprVisitor::visit(e);
-
-            if (e.evaluations_ > 0)
-                diagnostics.fieldHits[index()] += e.hits_;
+            if (e.id() >= indices_.size())
+                indices_.resize(e.id() + 1);
+            indices_[e.id()] = fieldIndex_++;
         }
 
         auto visitComparisonOperator(const ComparisonExprBase& e) -> void
         {
-            const auto [thisLeft, thisRight] = e.operandTypes();
-            if ((thisLeft.flags | thisRight.flags).any()) {
-                auto& [left, right] = diagnostics.comparisonOperandTypes[index()];
-                left.set(thisLeft);
-                right.set(thisRight);
-            }
-        }
-
-        auto visit(AnyExpr& e) -> void override {
-            ExprVisitor::visit(static_cast<Expr&>(e));
-
-            // Only provide diagnostic results for
-            // child expressions if none of them matched.
-            if (e.trueResults_ == 0 && e.falseResults_ > 0) {
-                for (const auto& arg : e.args_)
-                    if (arg)
-                        arg->accept(*this);
-            }
-        }
-
-        auto visit(OrExpr& e) -> void override {
-            ExprVisitor::visit(static_cast<Expr&>(e));
-
-            // Suppress diagnostics of the right hand side
-            // expression if the left hand side matched and
-            // vice versa.
-            e.left_->accept(*this);
-            if (e.rightEvaluations_ > 0)
-                e.right_->accept(*this);
+            if (e.id() >= indices_.size())
+                indices_.resize(e.id() + 1);
+            indices_[e.id()] = comparisonIndex_++;
         }
 
         auto visit(BinaryExpr<OperatorEq>& e) -> void override {
@@ -313,10 +242,11 @@ auto Diagnostics::collect(Expr& ast) -> void
         }
     };
 
-    CollectDiagnostics visitor(*data);
-
-    auto lock = data->lock();
+    Visitor visitor;
     ast.accept(visitor);
+    exprIndex_ = std::move(visitor.indices_);
+    fieldData_.reserve(visitor.fieldIndex_);
+    comparisonData_.reserve(visitor.comparisonIndex_);
 }
 
 }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1,4 +1,5 @@
 #include "simfil/environment.h"
+#include "simfil/diagnostics.h"
 #include "simfil/function.h"
 
 namespace simfil
@@ -58,8 +59,9 @@ auto Environment::strings() const -> std::shared_ptr<StringPool> {
     return stringPool;
 }
 
-Context::Context(Environment* env, Context::Phase phase)
+Context::Context(Environment* env, Diagnostics* diag, Context::Phase phase)
     : env(env)
+    , diag(diag)
     , phase(phase)
 {}
 

--- a/src/expression-visitor.cpp
+++ b/src/expression-visitor.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) Navigation Data Standard e.V. - See "LICENSE" file.
+
+#include "simfil/expression-visitor.h"
+
+#include "expressions.h"
+
+namespace simfil
+{
+
+ExprVisitor::ExprVisitor() = default;
+ExprVisitor::~ExprVisitor() = default;
+
+void ExprVisitor::visit(Expr& e)
+{
+    index_++;
+}
+
+void ExprVisitor::visit(WildcardExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+}
+
+void ExprVisitor::visit(AnyChildExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+}
+
+void ExprVisitor::visit(MultiConstExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+}
+
+void ExprVisitor::visit(ConstExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+}
+
+void ExprVisitor::visit(SubscriptExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.index_)
+        expr.index_->accept(*this);
+}
+
+void ExprVisitor::visit(SubExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.sub_)
+        expr.sub_->accept(*this);
+}
+
+void ExprVisitor::visit(AnyExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    for (const auto& arg : expr.args_)
+        if (arg)
+            arg->accept(*this);
+}
+
+void ExprVisitor::visit(EachExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    for (const auto& arg : expr.args_)
+        if (arg)
+            arg->accept(*this);
+}
+
+void ExprVisitor::visit(CallExpression& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    for (const auto& arg : expr.args_)
+        if (arg)
+            arg->accept(*this);
+}
+
+void ExprVisitor::visit(PathExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.right_)
+        expr.right_->accept(*this);
+}
+
+void ExprVisitor::visit(FieldExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+}
+
+void ExprVisitor::visit(UnpackExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.sub_)
+        expr.sub_->accept(*this);
+}
+
+void ExprVisitor::visit(UnaryWordOpExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+}
+
+void ExprVisitor::visit(BinaryWordOpExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.right_)
+        expr.right_->accept(*this);
+}
+
+void ExprVisitor::visit(AndExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.right_)
+        expr.right_->accept(*this);
+}
+
+void ExprVisitor::visit(OrExpr& expr)
+{
+    visit(static_cast<Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.right_)
+        expr.right_->accept(*this);
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorEq>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorNeq>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorLt>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorLtEq>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorGt>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+void ExprVisitor::visit(BinaryExpr<OperatorGtEq>& e)
+{
+    visit(static_cast<Expr&>(e));
+}
+
+auto ExprVisitor::index() const -> std::size_t
+{
+    return index_;
+}
+
+
+}

--- a/src/expression-visitor.cpp
+++ b/src/expression-visitor.cpp
@@ -10,34 +10,34 @@ namespace simfil
 ExprVisitor::ExprVisitor() = default;
 ExprVisitor::~ExprVisitor() = default;
 
-void ExprVisitor::visit(Expr& e)
+void ExprVisitor::visit(const Expr& e)
 {
     index_++;
 }
 
-void ExprVisitor::visit(WildcardExpr& expr)
+void ExprVisitor::visit(const WildcardExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 }
 
-void ExprVisitor::visit(AnyChildExpr& expr)
+void ExprVisitor::visit(const AnyChildExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 }
 
-void ExprVisitor::visit(MultiConstExpr& expr)
+void ExprVisitor::visit(const MultiConstExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 }
 
-void ExprVisitor::visit(ConstExpr& expr)
+void ExprVisitor::visit(const ConstExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 }
 
-void ExprVisitor::visit(SubscriptExpr& expr)
+void ExprVisitor::visit(const SubscriptExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
@@ -45,9 +45,9 @@ void ExprVisitor::visit(SubscriptExpr& expr)
         expr.index_->accept(*this);
 }
 
-void ExprVisitor::visit(SubExpr& expr)
+void ExprVisitor::visit(const SubExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
@@ -55,36 +55,36 @@ void ExprVisitor::visit(SubExpr& expr)
         expr.sub_->accept(*this);
 }
 
-void ExprVisitor::visit(AnyExpr& expr)
+void ExprVisitor::visit(const AnyExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     for (const auto& arg : expr.args_)
         if (arg)
             arg->accept(*this);
 }
 
-void ExprVisitor::visit(EachExpr& expr)
+void ExprVisitor::visit(const EachExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     for (const auto& arg : expr.args_)
         if (arg)
             arg->accept(*this);
 }
 
-void ExprVisitor::visit(CallExpression& expr)
+void ExprVisitor::visit(const CallExpression& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     for (const auto& arg : expr.args_)
         if (arg)
             arg->accept(*this);
 }
 
-void ExprVisitor::visit(PathExpr& expr)
+void ExprVisitor::visit(const PathExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
@@ -92,40 +92,30 @@ void ExprVisitor::visit(PathExpr& expr)
         expr.right_->accept(*this);
 }
 
-void ExprVisitor::visit(FieldExpr& expr)
+void ExprVisitor::visit(const FieldExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 }
 
-void ExprVisitor::visit(UnpackExpr& expr)
+void ExprVisitor::visit(const UnpackExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.sub_)
         expr.sub_->accept(*this);
 }
 
-void ExprVisitor::visit(UnaryWordOpExpr& expr)
+void ExprVisitor::visit(const UnaryWordOpExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
 }
 
-void ExprVisitor::visit(BinaryWordOpExpr& expr)
+void ExprVisitor::visit(const BinaryWordOpExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
-}
-
-void ExprVisitor::visit(AndExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
@@ -133,9 +123,9 @@ void ExprVisitor::visit(AndExpr& expr)
         expr.right_->accept(*this);
 }
 
-void ExprVisitor::visit(OrExpr& expr)
+void ExprVisitor::visit(const AndExpr& expr)
 {
-    visit(static_cast<Expr&>(expr));
+    visit(static_cast<const Expr&>(expr));
 
     if (expr.left_)
         expr.left_->accept(*this);
@@ -143,34 +133,44 @@ void ExprVisitor::visit(OrExpr& expr)
         expr.right_->accept(*this);
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorEq>& e)
+void ExprVisitor::visit(const OrExpr& expr)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(expr));
+
+    if (expr.left_)
+        expr.left_->accept(*this);
+    if (expr.right_)
+        expr.right_->accept(*this);
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorNeq>& e)
+void ExprVisitor::visit(const BinaryExpr<OperatorEq>& e)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(e));
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorLt>& e)
+void ExprVisitor::visit(const BinaryExpr<OperatorNeq>& e)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(e));
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorLtEq>& e)
+void ExprVisitor::visit(const BinaryExpr<OperatorLt>& e)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(e));
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorGt>& e)
+void ExprVisitor::visit(const BinaryExpr<OperatorLtEq>& e)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(e));
 }
 
-void ExprVisitor::visit(BinaryExpr<OperatorGtEq>& e)
+void ExprVisitor::visit(const BinaryExpr<OperatorGt>& e)
 {
-    visit(static_cast<Expr&>(e));
+    visit(static_cast<const Expr&>(e));
+}
+
+void ExprVisitor::visit(const BinaryExpr<OperatorGtEq>& e)
+{
+    visit(static_cast<const Expr&>(e));
 }
 
 auto ExprVisitor::index() const -> std::size_t

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -5,6 +5,7 @@
 #include "simfil/result.h"
 #include "simfil/value.h"
 #include "simfil/function.h"
+#include "simfil/diagnostics.h"
 
 #include "fmt/core.h"
 #include "fmt/ranges.h"
@@ -198,18 +199,12 @@ auto AnyChildExpr::toString() const -> std::string
 FieldExpr::FieldExpr(ExprId id, std::string name)
     : Expr(id)
     , name_(std::move(name))
-{
-    if (name_ == "_")
-        hits_ = 1;
-}
+{}
 
 FieldExpr::FieldExpr(ExprId id, std::string name, const Token& token)
     : Expr(id, token)
     , name_(std::move(name))
-{
-    if (name_ == "_")
-        hits_ = 1;
-}
+{}
 
 auto FieldExpr::type() const -> Type
 {
@@ -223,15 +218,26 @@ auto FieldExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl:
 
 auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error>
 {
-    if (ctx.phase != Context::Compilation)
-        evaluations_++;
+    Diagnostics::FieldExprData* diag = nullptr;
+    if (ctx.diag)
+        diag = &ctx.diag->get<Diagnostics::FieldExprData>(*this);
+
+    if (diag) {
+        diag->evaluations++;
+        diag->location = sourceLocation();
+        if (diag->name.empty())
+            diag->name = name_;
+    }
 
     if (val.isa(ValueType::Undef))
         return res(ctx, std::move(val));
 
     /* Special case: _ points to the current node */
-    if (name_ == "_")
+    if (name_ == "_") {
+        if (diag)
+            diag->hits++;
         return res(ctx, std::move(val));
+    }
 
     if (!val.node())
         return res(ctx, Value::null());
@@ -246,9 +252,8 @@ auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expe
 
     /* Enter sub-node */
     if (auto sub = val.node()->get(nameId_)) {
-        //if (ctx.diag)
-        //    ctx.diag->get<FieldExprDiagnostics>(id()).hits++;
-        hits_++;
+        if (diag)
+            diag->hits++;
         return res(ctx, Value::field(*sub));
     }
 
@@ -975,15 +980,12 @@ auto OrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::ex
         if (lval.isa(ValueType::Undef))
             return res(ctx, lval);
 
-        ++leftEvaluations_;
-
         auto v = UnaryOperatorDispatcher<OperatorBool>::dispatch(lval);
         TRY_EXPECTED(v);
         if (v->isa(ValueType::Bool))
             if (v->template as<ValueType::Bool>())
                 return res(ctx, std::move(lval));
 
-        ++rightEvaluations_;
         return right_->eval(ctx, val, LambdaResultFn([&](Context ctx, Value&& rval) {
             return res(ctx, std::move(rval));
         }));
@@ -1004,174 +1006,6 @@ auto OrExpr::clone() const -> ExprPtr
 auto OrExpr::toString() const -> std::string
 {
     return fmt::format("(or {} {})", left_->toString(), right_->toString());
-}
-
-void ExprVisitor::visit(Expr& e)
-{
-    index_++;
-}
-
-void ExprVisitor::visit(WildcardExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-}
-
-void ExprVisitor::visit(AnyChildExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-}
-
-void ExprVisitor::visit(MultiConstExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-}
-
-void ExprVisitor::visit(ConstExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-}
-
-void ExprVisitor::visit(SubscriptExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.index_)
-        expr.index_->accept(*this);
-}
-
-void ExprVisitor::visit(SubExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.sub_)
-        expr.sub_->accept(*this);
-}
-
-void ExprVisitor::visit(AnyExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
-}
-
-void ExprVisitor::visit(EachExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
-}
-
-void ExprVisitor::visit(CallExpression& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
-}
-
-void ExprVisitor::visit(PathExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
-}
-
-void ExprVisitor::visit(FieldExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-}
-
-void ExprVisitor::visit(UnpackExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.sub_)
-        expr.sub_->accept(*this);
-}
-
-void ExprVisitor::visit(UnaryWordOpExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-}
-
-void ExprVisitor::visit(BinaryWordOpExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
-}
-
-void ExprVisitor::visit(AndExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
-}
-
-void ExprVisitor::visit(OrExpr& expr)
-{
-    visit(static_cast<Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorEq>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorNeq>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorLt>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorLtEq>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorGt>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-void ExprVisitor::visit(BinaryExpr<OperatorGtEq>& e)
-{
-    visit(static_cast<Expr&>(e));
-}
-
-auto ExprVisitor::index() const -> size_t
-{
-    return index_;
 }
 
 }

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -76,7 +76,9 @@ auto boolify(const Value& v) -> bool
 
 }
 
-WildcardExpr::WildcardExpr() = default;
+WildcardExpr::WildcardExpr(ExprId id)
+    : Expr(id)
+{}
 
 auto WildcardExpr::type() const -> Type
 {
@@ -132,7 +134,7 @@ auto WildcardExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) ->
 
 auto WildcardExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<WildcardExpr>();
+    return std::make_unique<WildcardExpr>(id());
 }
 
 void WildcardExpr::accept(ExprVisitor& v)
@@ -145,7 +147,9 @@ auto WildcardExpr::toString() const -> std::string
     return "**"s;
 }
 
-AnyChildExpr::AnyChildExpr() = default;
+AnyChildExpr::AnyChildExpr(ExprId id)
+    : Expr(id)
+{}
 
 auto AnyChildExpr::type() const -> Type
 {
@@ -178,7 +182,7 @@ auto AnyChildExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> 
 
 auto AnyChildExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<AnyChildExpr>();
+    return std::make_unique<AnyChildExpr>(id());
 }
 
 void AnyChildExpr::accept(ExprVisitor& v)
@@ -191,15 +195,16 @@ auto AnyChildExpr::toString() const -> std::string
     return "*"s;
 }
 
-FieldExpr::FieldExpr(std::string name)
-    : name_(std::move(name))
+FieldExpr::FieldExpr(ExprId id, std::string name)
+    : Expr(id)
+    , name_(std::move(name))
 {
     if (name_ == "_")
         hits_ = 1;
 }
 
-FieldExpr::FieldExpr(std::string name, const Token& token)
-    : Expr(token)
+FieldExpr::FieldExpr(ExprId id, std::string name, const Token& token)
+    : Expr(id, token)
     , name_(std::move(name))
 {
     if (name_ == "_")
@@ -241,6 +246,8 @@ auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expe
 
     /* Enter sub-node */
     if (auto sub = val.node()->get(nameId_)) {
+        //if (ctx.diag)
+        //    ctx.diag->get<FieldExprDiagnostics>(id()).hits++;
         hits_++;
         return res(ctx, Value::field(*sub));
     }
@@ -252,7 +259,7 @@ auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expe
 
 auto FieldExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<FieldExpr>(name_);
+    return std::make_unique<FieldExpr>(id(), name_);
 }
 
 void FieldExpr::accept(ExprVisitor& v)
@@ -265,12 +272,14 @@ auto FieldExpr::toString() const -> std::string
     return name_;
 }
 
-MultiConstExpr::MultiConstExpr(const std::vector<Value>& vec)
-    : values_(vec)
+MultiConstExpr::MultiConstExpr(ExprId id, const std::vector<Value>& vec)
+    : Expr(id)
+    , values_(vec)
 {}
 
-MultiConstExpr::MultiConstExpr(std::vector<Value>&& vec)
-    : values_(std::move(vec))
+MultiConstExpr::MultiConstExpr(ExprId id, std::vector<Value>&& vec)
+    : Expr(id)
+    , values_(std::move(vec))
 {}
 
 auto MultiConstExpr::type() const -> Type
@@ -297,7 +306,7 @@ auto MultiConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl
 
 auto MultiConstExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<MultiConstExpr>(values_);
+    return std::make_unique<MultiConstExpr>(id(), values_);
 }
 
 void MultiConstExpr::accept(ExprVisitor& v)
@@ -314,8 +323,9 @@ auto MultiConstExpr::toString() const -> std::string
     return fmt::format("{{{}}}", fmt::join(items, " "));
 }
 
-ConstExpr::ConstExpr(Value value)
-    : value_(std::move(value))
+ConstExpr::ConstExpr(ExprId id, Value value)
+    : Expr(id)
+    , value_(std::move(value))
 {}
 
 auto ConstExpr::type() const -> Type
@@ -335,7 +345,7 @@ auto ConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl::exp
 
 auto ConstExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<ConstExpr>(value_);
+    return std::make_unique<ConstExpr>(id(), value_);
 }
 
 void ConstExpr::accept(ExprVisitor& v)
@@ -355,8 +365,9 @@ auto ConstExpr::value() const -> const Value&
     return value_;
 }
 
-SubscriptExpr::SubscriptExpr(ExprPtr left, ExprPtr index)
-    : left_(std::move(left))
+SubscriptExpr::SubscriptExpr(ExprId id, ExprPtr left, ExprPtr index)
+    : Expr(id)
+    , left_(std::move(left))
     , index_(std::move(index))
 {}
 
@@ -406,7 +417,7 @@ auto SubscriptExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -
 
 auto SubscriptExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<SubscriptExpr>(left_->clone(), index_->clone());
+    return std::make_unique<SubscriptExpr>(id(), left_->clone(), index_->clone());
 }
 
 void SubscriptExpr::accept(ExprVisitor& v)
@@ -419,13 +430,9 @@ auto SubscriptExpr::toString() const -> std::string
     return fmt::format("(index {} {})", left_->toString(), index_->toString());
 }
 
-SubExpr::SubExpr(ExprPtr sub)
-    : left_(std::make_unique<FieldExpr>("_"))
-    , sub_(std::move(sub))
-{}
-
-SubExpr::SubExpr(ExprPtr left, ExprPtr sub)
-    : left_(std::move(left))
+SubExpr::SubExpr(ExprId id, ExprPtr left, ExprPtr sub)
+    : Expr(id)
+    , left_(std::move(left))
     , sub_(std::move(sub))
 {}
 
@@ -468,7 +475,7 @@ auto SubExpr::toString() const -> std::string
 
 auto SubExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<SubExpr>(left_->clone(), sub_->clone());
+    return std::make_unique<SubExpr>(id(), left_->clone(), sub_->clone());
 }
 
 void SubExpr::accept(ExprVisitor& v)
@@ -476,8 +483,9 @@ void SubExpr::accept(ExprVisitor& v)
     v.visit(*this);
 }
 
-AnyExpr::AnyExpr(std::vector<ExprPtr> args)
-    : args_(std::move(args))
+AnyExpr::AnyExpr(ExprId id, std::vector<ExprPtr> args)
+    : Expr(id)
+    , args_(std::move(args))
 {}
 
 auto AnyExpr::type() const -> Type
@@ -526,7 +534,7 @@ auto AnyExpr::clone() const -> ExprPtr
         return exp->clone();
     });
 
-    return std::make_unique<AnyExpr>(std::move(clonedArgs));
+    return std::make_unique<AnyExpr>(id(), std::move(clonedArgs));
 }
 
 auto AnyExpr::accept(ExprVisitor& v) -> void
@@ -546,8 +554,9 @@ auto AnyExpr::toString() const -> std::string
     return fmt::format("(any {})", fmt::join(items, " "));
 }
 
-EachExpr::EachExpr(std::vector<ExprPtr> args)
-    : args_(std::move(args))
+EachExpr::EachExpr(ExprId id, std::vector<ExprPtr> args)
+    : Expr(id)
+    , args_(std::move(args))
 {}
 
 auto EachExpr::type() const -> Type
@@ -595,7 +604,7 @@ auto EachExpr::clone() const -> ExprPtr
         return exp->clone();
     });
 
-    return std::make_unique<EachExpr>(std::move(clonedArgs));
+    return std::make_unique<EachExpr>(id(), std::move(clonedArgs));
 }
 
 auto EachExpr::accept(ExprVisitor& v) -> void
@@ -615,8 +624,9 @@ auto EachExpr::toString() const -> std::string
     return fmt::format("(each {})", fmt::join(items, " "));
 }
 
-CallExpression::CallExpression(std::string name, std::vector<ExprPtr> args)
-    : name_(std::move(name))
+CallExpression::CallExpression(ExprId id, std::string name, std::vector<ExprPtr> args)
+    : Expr(id)
+    , name_(std::move(name))
     , args_(std::move(args))
 {}
 
@@ -659,7 +669,7 @@ auto CallExpression::clone() const -> ExprPtr
         return exp->clone();
     });
 
-    return std::make_unique<CallExpression>(name_, std::move(clonedArgs));
+    return std::make_unique<CallExpression>(id(), name_, std::move(clonedArgs));
 }
 
 void CallExpression::accept(ExprVisitor& v)
@@ -679,13 +689,9 @@ auto CallExpression::toString() const -> std::string
     return fmt::format("({} {})", name_, fmt::join(items, " "));
 }
 
-PathExpr::PathExpr(ExprPtr right)
-    : left_(std::make_unique<FieldExpr>("_"))
-    , right_(std::move(right))
-{}
-
-PathExpr::PathExpr(ExprPtr left, ExprPtr right)
-    : left_(std::move(left))
+PathExpr::PathExpr(ExprId id, ExprPtr left, ExprPtr right)
+    : Expr(id)
+    , left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -731,7 +737,7 @@ auto PathExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expe
 
 auto PathExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<PathExpr>(left_->clone(), right_->clone());
+    return std::make_unique<PathExpr>(id(), left_->clone(), right_->clone());
 }
 
 void PathExpr::accept(ExprVisitor& v)
@@ -744,8 +750,9 @@ auto PathExpr::toString() const -> std::string
     return fmt::format("(. {} {})", left_->toString(), right_->toString());
 }
 
-UnpackExpr::UnpackExpr(ExprPtr sub)
-    : sub_(std::move(sub))
+UnpackExpr::UnpackExpr(ExprId id, ExprPtr sub)
+    : Expr(id)
+    , sub_(std::move(sub))
 {}
 
 auto UnpackExpr::type() const -> Type
@@ -785,7 +792,7 @@ auto UnpackExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl
 
 auto UnpackExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<UnpackExpr>(sub_->clone());
+    return std::make_unique<UnpackExpr>(id(), sub_->clone());
 }
 
 void UnpackExpr::accept(ExprVisitor& v)
@@ -798,8 +805,9 @@ auto UnpackExpr::toString() const -> std::string
     return fmt::format("(... {})", sub_->toString());
 }
 
-UnaryWordOpExpr::UnaryWordOpExpr(std::string ident, ExprPtr left)
-    : ident_(std::move(ident))
+UnaryWordOpExpr::UnaryWordOpExpr(ExprId id, std::string ident, ExprPtr left)
+    : Expr(id)
+    , ident_(std::move(ident))
     , left_(std::move(left))
 {}
 
@@ -833,7 +841,7 @@ void UnaryWordOpExpr::accept(ExprVisitor& v)
 
 auto UnaryWordOpExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<UnaryWordOpExpr>(ident_, left_->clone());
+    return std::make_unique<UnaryWordOpExpr>(id(), ident_, left_->clone());
 }
 
 auto UnaryWordOpExpr::toString() const -> std::string
@@ -841,8 +849,9 @@ auto UnaryWordOpExpr::toString() const -> std::string
     return fmt::format("({} {})", ident_, left_->toString());
 }
 
-BinaryWordOpExpr::BinaryWordOpExpr(std::string ident, ExprPtr left, ExprPtr right)
-    : ident_(std::move(ident))
+BinaryWordOpExpr::BinaryWordOpExpr(ExprId id, std::string ident, ExprPtr left, ExprPtr right)
+    : Expr(id)
+    , ident_(std::move(ident))
     , left_(std::move(left))
     , right_(std::move(right))
 {}
@@ -887,7 +896,7 @@ void BinaryWordOpExpr::accept(ExprVisitor& v)
 
 auto BinaryWordOpExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<BinaryWordOpExpr>(ident_, left_->clone(), right_->clone());
+    return std::make_unique<BinaryWordOpExpr>(id(), ident_, left_->clone(), right_->clone());
 }
 
 auto BinaryWordOpExpr::toString() const -> std::string
@@ -895,8 +904,9 @@ auto BinaryWordOpExpr::toString() const -> std::string
     return fmt::format("({} {} {})", ident_, left_->toString(), right_->toString());
 }
 
-AndExpr::AndExpr(ExprPtr left, ExprPtr right)
-    : left_(std::move(left))
+AndExpr::AndExpr(ExprId id, ExprPtr left, ExprPtr right)
+    : Expr(id)
+    , left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -935,7 +945,7 @@ void AndExpr::accept(ExprVisitor& v)
 
 auto AndExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<AndExpr>(left_->clone(), right_->clone());
+    return std::make_unique<AndExpr>(id(), left_->clone(), right_->clone());
 }
 
 auto AndExpr::toString() const -> std::string
@@ -943,8 +953,9 @@ auto AndExpr::toString() const -> std::string
     return fmt::format("(and {} {})", left_->toString(), right_->toString());
 }
 
-OrExpr::OrExpr(ExprPtr left, ExprPtr right)
-    : left_(std::move(left))
+OrExpr::OrExpr(ExprId id, ExprPtr left, ExprPtr right)
+    : Expr(id)
+    , left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -987,7 +998,7 @@ void OrExpr::accept(ExprVisitor& v)
 
 auto OrExpr::clone() const -> ExprPtr
 {
-    return std::make_unique<OrExpr>(left_->clone(), right_->clone());
+    return std::make_unique<OrExpr>(id(), left_->clone(), right_->clone());
 }
 
 auto OrExpr::toString() const -> std::string

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -86,7 +86,7 @@ auto WildcardExpr::type() const -> Type
     return Type::PATH;
 }
 
-auto WildcardExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto WildcardExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     if (ctx.phase == Context::Phase::Compilation)
         return ores(ctx, Value::undef());
@@ -133,12 +133,7 @@ auto WildcardExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) ->
     return r;
 }
 
-auto WildcardExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<WildcardExpr>(id());
-}
-
-void WildcardExpr::accept(ExprVisitor& v)
+void WildcardExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -157,7 +152,7 @@ auto AnyChildExpr::type() const -> Type
     return Type::PATH;
 }
 
-auto AnyChildExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto AnyChildExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (ctx.phase == Context::Phase::Compilation)
         return res(ctx, Value::undef());
@@ -181,12 +176,7 @@ auto AnyChildExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> 
     return Result::Continue;
 }
 
-auto AnyChildExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<AnyChildExpr>(id());
-}
-
-void AnyChildExpr::accept(ExprVisitor& v)
+void AnyChildExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -211,12 +201,12 @@ auto FieldExpr::type() const -> Type
     return Type::FIELD;
 }
 
-auto FieldExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto FieldExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     return ieval(ctx, Value{val}, res);
 }
 
-auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     Diagnostics::FieldExprData* diag = nullptr;
     if (ctx.diag)
@@ -262,12 +252,7 @@ auto FieldExpr::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expe
     return res(ctx, Value::null());
 }
 
-auto FieldExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<FieldExpr>(id(), name_);
-}
-
-void FieldExpr::accept(ExprVisitor& v)
+void FieldExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -297,7 +282,7 @@ auto MultiConstExpr::constant() const -> bool
     return true;
 }
 
-auto MultiConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error>
+auto MultiConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     for (const auto& v : values_) {
         auto r = res(ctx, v);
@@ -309,12 +294,7 @@ auto MultiConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl
     return Result::Continue;
 }
 
-auto MultiConstExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<MultiConstExpr>(id(), values_);
-}
-
-void MultiConstExpr::accept(ExprVisitor& v)
+void MultiConstExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -343,17 +323,12 @@ auto ConstExpr::constant() const -> bool
     return true;
 }
 
-auto ConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error>
+auto ConstExpr::ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     return res(ctx, value_);
 }
 
-auto ConstExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<ConstExpr>(id(), value_);
-}
-
-void ConstExpr::accept(ExprVisitor& v)
+void ConstExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -381,7 +356,7 @@ auto SubscriptExpr::type() const -> Type
     return Type::SUBSCRIPT;
 }
 
-auto SubscriptExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto SubscriptExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     auto res = CountedResultFn<const ResultFn&>(ores, ctx);
     auto r = left_->eval(ctx, val, LambdaResultFn([this, &val, &res](Context ctx, const Value& lval) {
@@ -420,12 +395,7 @@ auto SubscriptExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -
     return r;
 }
 
-auto SubscriptExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<SubscriptExpr>(id(), left_->clone(), index_->clone());
-}
-
-void SubscriptExpr::accept(ExprVisitor& v)
+void SubscriptExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -446,12 +416,12 @@ auto SubExpr::type() const -> Type
     return Type::SUBEXPR;
 }
 
-auto SubExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto SubExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     return ieval(ctx, Value{val}, ores);
 }
 
-auto SubExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto SubExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     /* Do not return null unless we have _no_ matching value. */
     auto res = CountedResultFn<const ResultFn&>(ores, ctx);
@@ -478,12 +448,7 @@ auto SubExpr::toString() const -> std::string
     return fmt::format("(sub {} {})", left_->toString(), sub_->toString());
 }
 
-auto SubExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<SubExpr>(id(), left_->clone(), sub_->clone());
-}
-
-void SubExpr::accept(ExprVisitor& v)
+void SubExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -498,7 +463,7 @@ auto AnyExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto AnyExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto AnyExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     auto subctx = ctx;
     auto result = false; /* At least one value is true  */
@@ -524,25 +489,10 @@ auto AnyExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::e
     if (undef)
         return res(subctx, Value::undef());
 
-    if (result)
-        ++trueResults_;
-    else
-        ++falseResults_;
     return res(subctx, Value::make(result));
 }
 
-auto AnyExpr::clone() const -> ExprPtr
-{
-    std::vector<ExprPtr> clonedArgs;
-    clonedArgs.resize(args_.size());
-    std::transform(args_.cbegin(), args_.cend(), std::make_move_iterator(clonedArgs.begin()), [](const auto& exp) {
-        return exp->clone();
-    });
-
-    return std::make_unique<AnyExpr>(id(), std::move(clonedArgs));
-}
-
-auto AnyExpr::accept(ExprVisitor& v) -> void
+auto AnyExpr::accept(ExprVisitor& v) const -> void
 {
     v.visit(*this);
 }
@@ -569,7 +519,7 @@ auto EachExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto EachExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto EachExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     auto subctx = ctx;
     auto result = true; /* All values are true  */
@@ -594,25 +544,10 @@ auto EachExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::
     if (undef)
         return res(subctx, Value::undef());
 
-    if (result)
-        ++trueResults_;
-    else
-        ++falseResults_;
     return res(subctx, Value::make(result));
 }
 
-auto EachExpr::clone() const -> ExprPtr
-{
-    std::vector<ExprPtr> clonedArgs;
-    clonedArgs.resize(args_.size());
-    std::transform(args_.cbegin(), args_.cend(), std::make_move_iterator(clonedArgs.begin()), [](const auto& exp) {
-        return exp->clone();
-    });
-
-    return std::make_unique<EachExpr>(id(), std::move(clonedArgs));
-}
-
-auto EachExpr::accept(ExprVisitor& v) -> void
+auto EachExpr::accept(ExprVisitor& v) const -> void
 {
     v.visit(*this);
 }
@@ -640,12 +575,12 @@ auto CallExpression::type() const -> Type
     return Type::VALUE;
 }
 
-auto CallExpression::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CallExpression::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     return ieval(ctx, Value{val}, res);
 }
 
-auto CallExpression::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto CallExpression::ieval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     if (!fn_) [[unlikely]] {
         fn_ = ctx.env->findFunction(name_);
@@ -666,18 +601,7 @@ auto CallExpression::ieval(Context ctx, Value&& val, const ResultFn& res) -> tl:
     return result;
 }
 
-auto CallExpression::clone() const -> ExprPtr
-{
-    std::vector<ExprPtr> clonedArgs;
-    clonedArgs.resize(args_.size());
-    std::transform(args_.cbegin(), args_.cend(), std::make_move_iterator(clonedArgs.begin()), [](const auto& exp) {
-        return exp->clone();
-    });
-
-    return std::make_unique<CallExpression>(id(), name_, std::move(clonedArgs));
-}
-
-void CallExpression::accept(ExprVisitor& v)
+void CallExpression::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -708,12 +632,12 @@ auto PathExpr::type() const -> Type
     return Type::PATH;
 }
 
-auto PathExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto PathExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     return ieval(ctx, Value{val}, ores);
 }
 
-auto PathExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error>
+auto PathExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error>
 {
     auto res = CountedResultFn<const ResultFn&>(ores, ctx);
 
@@ -723,8 +647,6 @@ auto PathExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expe
 
         if (v.isa(ValueType::Null) && !v.node())
             return Result::Continue;
-
-        ++hits_;
 
         return right_->eval(ctx, std::move(v), LambdaResultFn([this, &res](Context ctx, Value&& vv) -> tl::expected<Result, Error> {
             if (vv.isa(ValueType::Undef))
@@ -740,12 +662,7 @@ auto PathExpr::ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expe
     return r;
 };
 
-auto PathExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<PathExpr>(id(), left_->clone(), right_->clone());
-}
-
-void PathExpr::accept(ExprVisitor& v)
+void PathExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -765,7 +682,7 @@ auto UnpackExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto UnpackExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto UnpackExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     auto anyval = false;
     auto r = sub_->eval(ctx, val, LambdaResultFn([&res, &anyval](Context ctx, Value&& v) -> tl::expected<Result, Error> {
@@ -795,12 +712,7 @@ auto UnpackExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl
     return r;
 }
 
-auto UnpackExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<UnpackExpr>(id(), sub_->clone());
-}
-
-void UnpackExpr::accept(ExprVisitor& v)
+void UnpackExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
 }
@@ -821,7 +733,7 @@ auto UnaryWordOpExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto UnaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto UnaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     return left_->eval(ctx, val, LambdaResultFn([this, &res](const Context& ctx, Value&& val) -> tl::expected<Result, Error> {
         if (val.isa(ValueType::Undef))
@@ -839,14 +751,9 @@ auto UnaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res) 
     }));
 }
 
-void UnaryWordOpExpr::accept(ExprVisitor& v)
+void UnaryWordOpExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto UnaryWordOpExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<UnaryWordOpExpr>(id(), ident_, left_->clone());
 }
 
 auto UnaryWordOpExpr::toString() const -> std::string
@@ -866,7 +773,7 @@ auto BinaryWordOpExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto BinaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto BinaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     return left_->eval(ctx, val, LambdaResultFn([this, &res, &val](const Context& ctx, const Value& lval) {
         return right_->eval(ctx, val, LambdaResultFn([this, &res, &lval](const Context& ctx, const Value& rval) -> tl::expected<Result, Error> {
@@ -894,14 +801,9 @@ auto BinaryWordOpExpr::ieval(Context ctx, const Value& val, const ResultFn& res)
     }));
 }
 
-void BinaryWordOpExpr::accept(ExprVisitor& v)
+void BinaryWordOpExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto BinaryWordOpExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<BinaryWordOpExpr>(id(), ident_, left_->clone(), right_->clone());
 }
 
 auto BinaryWordOpExpr::toString() const -> std::string
@@ -923,7 +825,7 @@ auto AndExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto AndExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto AndExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     /* Operator and behaves like in lua:
      * 'a and b' returns a if 'not a?' else b is returned */
@@ -943,14 +845,9 @@ auto AndExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::e
     }));
 }
 
-void AndExpr::accept(ExprVisitor& v)
+void AndExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto AndExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<AndExpr>(id(), left_->clone(), right_->clone());
 }
 
 auto AndExpr::toString() const -> std::string
@@ -972,7 +869,7 @@ auto OrExpr::type() const -> Type
     return Type::VALUE;
 }
 
-auto OrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error>
+auto OrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error>
 {
     /* Operator or behaves like in lua:
      * 'a or b' returns a if 'a?' else b is returned */
@@ -993,14 +890,9 @@ auto OrExpr::ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::ex
 
 }
 
-void OrExpr::accept(ExprVisitor& v)
+void OrExpr::accept(ExprVisitor& v) const
 {
     v.visit(*this);
-}
-
-auto OrExpr::clone() const -> ExprPtr
-{
-    return std::make_unique<OrExpr>(id(), left_->clone(), right_->clone());
 }
 
 auto OrExpr::toString() const -> std::string

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -3,72 +3,14 @@
 #include "simfil/expression.h"
 #include "simfil/model/nodes.h"
 #include "simfil/operator.h"
+#include "simfil/diagnostics.h"
+#include "simfil/expression-visitor.h"
 
 #include <cstdint>
 #include <string>
 
 namespace simfil
 {
-
-class WildcardExpr;
-class AnyChildExpr;
-class MultiConstExpr;
-class ConstExpr;
-class SubscriptExpr;
-class SubExpr;
-class AnyExpr;
-class EachExpr;
-class CallExpression;
-class UnpackExpr;
-class UnaryWordOpExpr;
-class BinaryWordOpExpr;
-class FieldExpr;
-class PathExpr;
-class AndExpr;
-class OrExpr;
-template <class> class UnaryExpr;
-template <class> class BinaryExpr;
-
-/**
- * Visitor base for visiting expressions recursively.
- */
-class ExprVisitor
-{
-public:
-    virtual ~ExprVisitor() = default;
-
-    virtual void visit(Expr& expr);
-    virtual void visit(WildcardExpr& expr);
-    virtual void visit(AnyChildExpr& expr);
-    virtual void visit(MultiConstExpr& expr);
-    virtual void visit(ConstExpr& expr);
-    virtual void visit(SubscriptExpr& expr);
-    virtual void visit(SubExpr& expr);
-    virtual void visit(AnyExpr& expr);
-    virtual void visit(EachExpr& expr);
-    virtual void visit(CallExpression& expr);
-    virtual void visit(PathExpr& expr);
-    virtual void visit(FieldExpr& expr);
-    virtual void visit(UnpackExpr& expr);
-    virtual void visit(UnaryWordOpExpr& expr);
-    virtual void visit(BinaryWordOpExpr& expr);
-    virtual void visit(AndExpr& expr);
-    virtual void visit(OrExpr& expr);
-    virtual void visit(BinaryExpr<OperatorEq>& expr);
-    virtual void visit(BinaryExpr<OperatorNeq>& expr);
-    virtual void visit(BinaryExpr<OperatorLt>& expr);
-    virtual void visit(BinaryExpr<OperatorLtEq>& expr);
-    virtual void visit(BinaryExpr<OperatorGt>& expr);
-    virtual void visit(BinaryExpr<OperatorGtEq>& expr);
-
-protected:
-    /* Returns the index of the current expression */
-    [[nodiscard]]
-    size_t index() const;
-
-private:
-    size_t index_ = 0;
-};
 
 class WildcardExpr : public Expr
 {
@@ -112,9 +54,6 @@ public:
 
     std::string name_;
     StringId nameId_ = {};
-
-    size_t hits_ = 0;
-    size_t evaluations_ = 0;
 };
 
 class MultiConstExpr : public Expr
@@ -389,6 +328,7 @@ public:
 class ComparisonExprBase : public Expr
 {
 public:
+
     ComparisonExprBase(ExprId id, ExprPtr left, ExprPtr right)
         : Expr(id)
         , left_(std::move(left))
@@ -406,21 +346,7 @@ public:
         return Type::VALUE;
     }
 
-    auto operandTypes() const -> std::tuple<TypeFlags, TypeFlags>
-    {
-        return {leftTypes_, rightTypes_};
-    }
-
-    auto resultCounts() const -> std::tuple<uint32_t, uint32_t>
-    {
-        return {falseResults_, trueResults_};
-    }
-
     ExprPtr left_, right_;
-    TypeFlags leftTypes_;
-    TypeFlags rightTypes_;
-    uint32_t falseResults_ = 0;
-    uint32_t trueResults_ = 0;
 };
 
 template <class Operator, class Child>
@@ -431,20 +357,30 @@ public:
 
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override
     {
-        return left_->eval(ctx, val, LambdaResultFn([this, &res, &val](Context ctx, Value lv) {
-            leftTypes_.set(lv.type);
-            return right_->eval(ctx, val, LambdaResultFn([this, &res, &lv](Context ctx, Value rv) -> tl::expected<Result, Error> {
-                rightTypes_.set(rv.type);
+        Diagnostics::ComparisonExprData* diag = nullptr;
+        if (ctx.diag)
+            diag = &ctx.diag->get<Diagnostics::ComparisonExprData>(*this);
+        if (diag) {
+            diag->location = sourceLocation();
+        }
+
+        return left_->eval(ctx, val, LambdaResultFn([this, &res, &val, &diag](Context ctx, Value lv) {
+            if (diag)
+                diag->leftTypes.set(lv.type);
+
+            return right_->eval(ctx, val, LambdaResultFn([this, &res, &lv, &diag](Context ctx, Value rv) -> tl::expected<Result, Error> {
+                if (diag)
+                    diag->rightTypes.set(rv.type);
 
                 auto operatorResult = BinaryOperatorDispatcher<Operator>::dispatch(std::move(lv), std::move(rv));
                 if (!operatorResult)
                     return tl::unexpected<Error>(std::move(operatorResult.error()));
 
-                if (operatorResult->isa(ValueType::Bool)) {
+                if (diag && operatorResult->isa(ValueType::Bool)) {
                     if (operatorResult->template as<ValueType::Bool>())
-                        ++trueResults_;
+                        diag->trueResults++;
                     else
-                        ++falseResults_;
+                        diag->falseResults++;
                 }
 
                 return res(ctx, std::move(operatorResult.value()));
@@ -562,10 +498,6 @@ public:
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
-
-    /* Runtime Data */
-    uint32_t leftEvaluations_ = 0;
-    uint32_t rightEvaluations_ = 0;
 };
 
 }

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -73,7 +73,7 @@ private:
 class WildcardExpr : public Expr
 {
 public:
-    WildcardExpr();
+    explicit WildcardExpr(ExprId);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
@@ -88,7 +88,7 @@ public:
 class AnyChildExpr : public Expr
 {
 public:
-    AnyChildExpr();
+    explicit AnyChildExpr(ExprId);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -100,8 +100,8 @@ public:
 class FieldExpr : public Expr
 {
 public:
-    explicit FieldExpr(std::string name);
-    FieldExpr(std::string name, const Token& token);
+    FieldExpr(ExprId id, std::string name);
+    FieldExpr(ExprId id, std::string name, const Token& token);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -122,8 +122,9 @@ class MultiConstExpr : public Expr
 public:
     static constexpr size_t Limit = 10000;
 
-    explicit MultiConstExpr(const std::vector<Value>& vec);
-    explicit MultiConstExpr(std::vector<Value>&& vec);
+    MultiConstExpr() = delete;
+    MultiConstExpr(ExprId id, const std::vector<Value>& vec);
+    MultiConstExpr(ExprId id, std::vector<Value>&& vec);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
@@ -138,12 +139,13 @@ public:
 class ConstExpr : public Expr
 {
 public:
+    ConstExpr() = delete;
     template <class CType_>
-    explicit ConstExpr(CType_&& value)
-        : value_(Value::make(std::forward<CType_>(value)))
+    ConstExpr(ExprId id, CType_&& value)
+        : Expr(id)
+        , value_(Value::make(std::forward<CType_>(value)))
     {}
-
-    explicit ConstExpr(Value value);
+    ConstExpr(ExprId id, Value value);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
@@ -161,7 +163,7 @@ protected:
 class SubscriptExpr : public Expr
 {
 public:
-    SubscriptExpr(ExprPtr left, ExprPtr index);
+    SubscriptExpr(ExprId id, ExprPtr left, ExprPtr index);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
@@ -176,8 +178,7 @@ public:
 class SubExpr : public Expr
 {
 public:
-    explicit SubExpr(ExprPtr sub);
-    SubExpr(ExprPtr left, ExprPtr sub);
+    SubExpr(ExprId id, ExprPtr left, ExprPtr sub);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
@@ -192,7 +193,7 @@ public:
 class AnyExpr : public Expr
 {
 public:
-    explicit AnyExpr(std::vector<ExprPtr> args);
+    AnyExpr(ExprId id, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -210,7 +211,7 @@ public:
 class EachExpr : public Expr
 {
 public:
-    explicit EachExpr(std::vector<ExprPtr> args);
+    EachExpr(ExprId id, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -228,7 +229,7 @@ public:
 class CallExpression : public Expr
 {
 public:
-    CallExpression(std::string name, std::vector<ExprPtr> args);
+    CallExpression(ExprId id, std::string name, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -245,8 +246,7 @@ public:
 class PathExpr : public Expr
 {
 public:
-    explicit PathExpr(ExprPtr right);
-    PathExpr(ExprPtr left, ExprPtr right);
+    PathExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
@@ -269,7 +269,7 @@ public:
 class UnpackExpr : public Expr
 {
 public:
-    explicit UnpackExpr(ExprPtr sub);
+    UnpackExpr(ExprId id, ExprPtr sub);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -287,8 +287,9 @@ template <class Operator>
 class UnaryExpr : public Expr
 {
 public:
-    explicit UnaryExpr(ExprPtr sub)
-        : sub_(std::move(sub))
+    UnaryExpr(ExprId id, ExprPtr sub)
+        : Expr(id)
+        , sub_(std::move(sub))
     {}
 
     auto type() const -> Type override
@@ -314,7 +315,7 @@ public:
 
     auto clone() const -> ExprPtr override
     {
-        return std::make_unique<UnaryExpr>(sub_->clone());
+        return std::make_unique<UnaryExpr>(id(), sub_->clone());
     }
 
     auto toString() const -> std::string override
@@ -332,13 +333,14 @@ template <class Operator>
 class BinaryExpr : public Expr
 {
 public:
-    BinaryExpr(ExprPtr left, ExprPtr right)
-        : left_(std::move(left))
+    BinaryExpr(ExprId id, ExprPtr left, ExprPtr right)
+        : Expr(id)
+        , left_(std::move(left))
         , right_(std::move(right))
     {}
 
-    BinaryExpr(const Token& token, ExprPtr left, ExprPtr right)
-        : Expr(token)
+    BinaryExpr(ExprId id, const Token& token, ExprPtr left, ExprPtr right)
+        : Expr(id, token)
         , left_(std::move(left))
         , right_(std::move(right))
     {}
@@ -365,7 +367,7 @@ public:
 
     auto clone() const -> ExprPtr override
     {
-        return std::make_unique<BinaryExpr>(left_->clone(), right_->clone());
+        return std::make_unique<BinaryExpr>(id(), left_->clone(), right_->clone());
     }
 
     void accept(ExprVisitor& v) override
@@ -387,13 +389,14 @@ public:
 class ComparisonExprBase : public Expr
 {
 public:
-    ComparisonExprBase(ExprPtr left, ExprPtr right)
-        : left_(std::move(left))
+    ComparisonExprBase(ExprId id, ExprPtr left, ExprPtr right)
+        : Expr(id)
+        , left_(std::move(left))
         , right_(std::move(right))
     {}
 
-    ComparisonExprBase(const Token& token, ExprPtr left, ExprPtr right)
-        : Expr(token)
+    ComparisonExprBase(ExprId id, const Token& token, ExprPtr left, ExprPtr right)
+        : Expr(id, token)
         , left_(std::move(left))
         , right_(std::move(right))
     {}
@@ -451,7 +454,7 @@ public:
 
     auto clone() const -> ExprPtr override
     {
-        return std::make_unique<Child>(left_->clone(), right_->clone());
+        return std::make_unique<Child>(id(), left_->clone(), right_->clone());
     }
 
     void accept(ExprVisitor& v) override
@@ -506,7 +509,7 @@ class BinaryExpr<OperatorGtEq> : public ComparisonExpr<OperatorGtEq, BinaryExpr<
 class UnaryWordOpExpr : public Expr
 {
 public:
-    UnaryWordOpExpr(std::string ident, ExprPtr left);
+    UnaryWordOpExpr(ExprId id, std::string ident, ExprPtr left);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -521,7 +524,7 @@ public:
 class BinaryWordOpExpr : public Expr
 {
 public:
-    BinaryWordOpExpr(std::string ident, ExprPtr left, ExprPtr right);
+    BinaryWordOpExpr(ExprId id, std::string ident, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -536,7 +539,7 @@ public:
 class AndExpr : public Expr
 {
 public:
-    AndExpr(ExprPtr left, ExprPtr right);
+    AndExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
@@ -550,7 +553,7 @@ public:
 class OrExpr : public Expr
 {
 public:
-    OrExpr(ExprPtr left, ExprPtr right);
+    OrExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -18,9 +18,8 @@ public:
     explicit WildcardExpr(ExprId);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 };
 
@@ -33,9 +32,8 @@ public:
     explicit AnyChildExpr(ExprId);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 };
 
@@ -46,14 +44,13 @@ public:
     FieldExpr(ExprId id, std::string name, const Token& token);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::string name_;
-    StringId nameId_ = {};
+    mutable StringId nameId_ = {};
 };
 
 class MultiConstExpr : public Expr
@@ -67,9 +64,8 @@ public:
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
-    auto ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     const std::vector<Value> values_;
@@ -88,9 +84,8 @@ public:
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
-    auto ieval(Context ctx, const Value&, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value&, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     auto value() const -> const Value&;
@@ -105,9 +100,8 @@ public:
     SubscriptExpr(ExprId id, ExprPtr left, ExprPtr index);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_;
@@ -120,11 +114,10 @@ public:
     SubExpr(ExprId id, ExprPtr left, ExprPtr sub);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
-    auto ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
 
     ExprPtr left_, sub_;
 };
@@ -135,16 +128,11 @@ public:
     AnyExpr(ExprId id, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
-
-    /* Runtime Data */
-    std::uint32_t trueResults_ = 0;
-    std::uint32_t falseResults_ = 0;
 };
 
 class EachExpr : public Expr
@@ -153,16 +141,11 @@ public:
     EachExpr(ExprId id, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
-
-    /* Runtime Data */
-    std::uint32_t trueResults_ = 0;
-    std::uint32_t falseResults_ = 0;
 };
 
 class CallExpression : public Expr
@@ -171,15 +154,14 @@ public:
     CallExpression(ExprId id, std::string name, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto ieval(Context ctx, Value&& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::string name_;
     std::vector<ExprPtr> args_;
-    const Function* fn_ = nullptr;
+    mutable const Function* fn_ = nullptr;
 };
 
 class PathExpr : public Expr
@@ -188,16 +170,12 @@ public:
     PathExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
-    auto ieval(Context ctx, Value&& val, const ResultFn& ores) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    auto ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
-
-    /* Evaluation data */
-    uint32_t hits_ = 0;
 };
 
 /** Calls `unpack` onto values of type Object. Forwards the value(s) otherwise.
@@ -211,9 +189,8 @@ public:
     UnpackExpr(ExprId id, ExprPtr sub);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    auto clone() const -> ExprPtr override;
-    void accept(ExprVisitor& v) override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr sub_;
@@ -236,7 +213,7 @@ public:
         return Type::VALUE;
     }
 
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override
     {
         return sub_->eval(ctx, val, LambdaResultFn([&](Context ctx, Value vv) -> tl::expected<Result, Error> {
             auto v = UnaryOperatorDispatcher<Operator>::dispatch(std::move(vv));
@@ -246,15 +223,10 @@ public:
         }));
     }
 
-    void accept(ExprVisitor& v) override
+    void accept(ExprVisitor& v) const override
     {
         v.visit(*this);
         sub_->accept(v);
-    }
-
-    auto clone() const -> ExprPtr override
-    {
-        return std::make_unique<UnaryExpr>(id(), sub_->clone());
     }
 
     auto toString() const -> std::string override
@@ -289,13 +261,10 @@ public:
         return Type::VALUE;
     }
 
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override
     {
         return left_->eval(ctx, val, LambdaResultFn([this, &res, &val](Context ctx, Value lv) {
-            leftTypes_.set(lv.type);
             return right_->eval(ctx, val, LambdaResultFn([this, &res, &lv](Context ctx, Value rv) -> tl::expected<Result, Error> {
-                rightTypes_.set(rv.type);
-
                 auto v = BinaryOperatorDispatcher<Operator>::dispatch(std::move(lv), std::move(rv));
                 if (!v)
                     return tl::unexpected<Error>(std::move(v.error()));
@@ -304,12 +273,7 @@ public:
         }));
     }
 
-    auto clone() const -> ExprPtr override
-    {
-        return std::make_unique<BinaryExpr>(id(), left_->clone(), right_->clone());
-    }
-
-    void accept(ExprVisitor& v) override
+    void accept(ExprVisitor& v) const override
     {
         v.visit(*this);
         left_->accept(v);
@@ -322,7 +286,6 @@ public:
     }
 
     ExprPtr left_, right_;
-    TypeFlags leftTypes_, rightTypes_;
 };
 
 class ComparisonExprBase : public Expr
@@ -355,7 +318,7 @@ class ComparisonExpr : public ComparisonExprBase
 public:
     using ComparisonExprBase::ComparisonExprBase;
 
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override
     {
         Diagnostics::ComparisonExprData* diag = nullptr;
         if (ctx.diag)
@@ -388,14 +351,9 @@ public:
         }));
     }
 
-    auto clone() const -> ExprPtr override
+    void accept(ExprVisitor& v) const override
     {
-        return std::make_unique<Child>(id(), left_->clone(), right_->clone());
-    }
-
-    void accept(ExprVisitor& v) override
-    {
-        v.visit(static_cast<Child&>(*this));
+        v.visit(static_cast<const Child&>(*this));
         left_->accept(v);
         right_->accept(v);
     }
@@ -448,9 +406,8 @@ public:
     UnaryWordOpExpr(ExprId id, std::string ident, ExprPtr left);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -463,9 +420,8 @@ public:
     BinaryWordOpExpr(ExprId id, std::string ident, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -478,9 +434,8 @@ public:
     AndExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -492,9 +447,8 @@ public:
     OrExpr(ExprId id, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
-    auto ieval(Context ctx, const Value& val, const ResultFn& res) -> tl::expected<Result, Error> override;
-    void accept(ExprVisitor& v) override;
-    auto clone() const -> ExprPtr override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -325,6 +325,7 @@ public:
             diag = &ctx.diag->get<Diagnostics::ComparisonExprData>(*this);
         if (diag) {
             diag->location = sourceLocation();
+            diag->evaluations++;
         }
 
         return left_->eval(ctx, val, LambdaResultFn([this, &res, &val, &diag](Context ctx, Value lv) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -26,17 +26,12 @@ public:
         return Type::FIELD;
     }
 
-    auto ieval(Context ctx, const Value& val, const ResultFn& ores) -> tl::expected<Result, Error> override
+    auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override
     {
         return Result::Stop;
     }
 
-    auto clone() const -> ExprPtr override
-    {
-        return std::make_unique<NOOPExpr>(id());
-    }
-
-    void accept(ExprVisitor& v) override
+    void accept(ExprVisitor& v) const override
     {
         v.visit(*this);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -19,6 +19,8 @@ namespace
 class NOOPExpr : public Expr
 {
 public:
+    using Expr::Expr;
+
     auto type() const -> Type override
     {
         return Type::FIELD;
@@ -31,7 +33,7 @@ public:
 
     auto clone() const -> ExprPtr override
     {
-        return std::make_unique<NOOPExpr>();
+        return std::make_unique<NOOPExpr>(id());
     }
 
     void accept(ExprVisitor& v) override
@@ -116,6 +118,11 @@ auto Parser::relaxed() const -> bool
     return mode_ == Mode::Relaxed;
 }
 
+auto Parser::nextId() -> Expr::ExprId
+{
+    return ctx.id++;
+}
+
 auto Parser::parseInfix(expected<ExprPtr, Error> left, int prec) -> expected<ExprPtr, Error>
 {
     TRY_EXPECTED(left);
@@ -125,7 +132,7 @@ auto Parser::parseInfix(expected<ExprPtr, Error> left, int prec) -> expected<Exp
         auto parser = findInfixParser(token);
         if (!parser) {
             if (relaxed())
-                return std::make_unique<NOOPExpr>();
+                return std::make_unique<NOOPExpr>(nextId());
 
             return unexpected<Error>(
                 Error::ParserError,
@@ -174,7 +181,7 @@ auto Parser::parseTo(Token::Type type) -> expected<ExprPtr, Error>
 
     if (!*expr) {
         if (relaxed())
-            return std::make_unique<NOOPExpr>();
+            return std::make_unique<NOOPExpr>(nextId());
 
         return unexpected<Error>(
             Error::ParserError,

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -149,10 +149,10 @@ static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -
         env->warn("Expression is always "s + values[0].toString(), (*expr)->toString());
 
     if (values.size() == 1)
-        return std::make_unique<ConstExpr>(std::move(values[0]));
+        return std::make_unique<ConstExpr>((*expr)->id(), std::move(values[0]));
     if (values.size() > 1)
-        return std::make_unique<MultiConstExpr>(std::vector<Value>(std::make_move_iterator(values.begin()),
-                                                                   std::make_move_iterator(values.end())));
+        return std::make_unique<MultiConstExpr>((*expr)->id(), std::vector<Value>(std::make_move_iterator(values.begin()),
+                                                                               std::make_move_iterator(values.end())));
 
     return expr;
 }
@@ -174,11 +174,13 @@ public:
             return right;
 
         if (t.type == Token::OP_AND)
-          return simplifyOrForward(p.env, std::make_unique<AndExpr>(std::move(left),
-                                                                    std::move(*right)));
+            return simplifyOrForward(p.env, std::make_unique<AndExpr>(p.nextId(),
+                                                                      std::move(left),
+                                                                      std::move(*right)));
         else if (t.type == Token::OP_OR)
-          return simplifyOrForward(p.env, std::make_unique<OrExpr>(std::move(left),
-                                                                   std::move(*right)));
+            return simplifyOrForward(p.env, std::make_unique<OrExpr>(p.nextId(),
+                                                                     std::move(left),
+                                                                     std::move(*right)));
         assert(0);
         return nullptr;
     }
@@ -203,11 +205,13 @@ public:
             return right;
 
         if (t.type == Token::OP_AND)
-          return simplifyOrForward(p.env, std::make_unique<CompletionAndExpr>(std::move(left),
-                                                                              std::move(*right), comp_));
+            return simplifyOrForward(p.env, std::make_unique<CompletionAndExpr>(p.nextId(),
+                                                                                std::move(left),
+                                                                                std::move(*right), comp_));
         else if (t.type == Token::OP_OR)
-          return simplifyOrForward(p.env, std::make_unique<CompletionOrExpr>(std::move(left),
-                                                                             std::move(*right), comp_));
+            return simplifyOrForward(p.env, std::make_unique<CompletionOrExpr>(p.nextId(),
+                                                                               std::move(left),
+                                                                               std::move(*right), comp_));
         assert(0);
         return nullptr;
     }
@@ -227,7 +231,7 @@ public:
     {
         auto type = p.consume();
         if (type.type == Token::C_NULL)
-            return std::make_unique<ConstExpr>(Value::null());
+            return std::make_unique<ConstExpr>(p.nextId(), Value::null());
 
         if (type.type != Token::Type::WORD)
             return unexpected<Error>(Error::InvalidType, fmt::format("'as' expected typename got {}", type.toString()));
@@ -235,17 +239,17 @@ public:
         auto name = std::get<std::string>(type.value);
         return simplifyOrForward(p.env, [&]() -> expected<ExprPtr, Error> {
             if (name == strings::TypenameNull)
-                return std::make_unique<ConstExpr>(Value::null());
+                return std::make_unique<ConstExpr>(p.nextId(), Value::null());
             if (name == strings::TypenameBool)
-                return std::make_unique<UnaryExpr<OperatorBool>>(std::move(left));
+                return std::make_unique<UnaryExpr<OperatorBool>>(p.nextId(), std::move(left));
             if (name == strings::TypenameInt)
-                return std::make_unique<UnaryExpr<OperatorAsInt>>(std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsInt>>(p.nextId(), std::move(left));
             if (name == strings::TypenameFloat)
-                return std::make_unique<UnaryExpr<OperatorAsFloat>>(std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsFloat>>(p.nextId(), std::move(left));
             if (name == strings::TypenameString)
-                return std::make_unique<UnaryExpr<OperatorAsString>>(std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsString>>(p.nextId(), std::move(left));
             if (name == strings::TypenameBytes)
-                return std::make_unique<UnaryExpr<OperatorAsBytes>>(std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsBytes>>(p.nextId(), std::move(left));
 
             return unexpected<Error>(Error::InvalidType, fmt::format("Invalid type name for cast '{}'", name));
         }());
@@ -273,7 +277,8 @@ public:
         if (!right)
             return right;
 
-        return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(t,
+        return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(p.nextId(),
+                                                                               t,
                                                                                std::move(left),
                                                                                std::move(*right)));
     }
@@ -298,7 +303,7 @@ class UnaryOpParser : public PrefixParselet
         if (!sub)
             return sub;
 
-        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(*sub)));
+        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(p.nextId(), std::move(*sub)));
     }
 };
 
@@ -310,7 +315,7 @@ class UnaryPostOpParser : public InfixParselet
 {
     auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(left))), 0);
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(p.nextId(), std::move(left))), 0);
     }
 
     auto precedence() const -> int override
@@ -326,7 +331,7 @@ class UnpackOpParser : public InfixParselet
 {
     auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnpackExpr>(std::move(left))), 0);
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnpackExpr>(p.nextId(), std::move(left))), 0);
     }
 
     auto precedence() const -> int override
@@ -348,12 +353,14 @@ class WordOpParser : public InfixParselet
             return right;
 
         if (*right)
-            return simplifyOrForward(p.env, std::make_unique<BinaryWordOpExpr>(std::get<std::string>(t.value),
+            return simplifyOrForward(p.env, std::make_unique<BinaryWordOpExpr>(p.nextId(),
+                                                                               std::get<std::string>(t.value),
                                                                                std::move(left),
                                                                                std::move(*right)));
 
         /* Parse as unary operator */
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryWordOpExpr>(std::get<std::string>(t.value),
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryWordOpExpr>(p.nextId(),
+                                                                                       std::get<std::string>(t.value),
                                                                                        std::move(left))), 0);
     }
 
@@ -373,7 +380,7 @@ class ScalarParser : public PrefixParselet
 {
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
-        return std::make_unique<ConstExpr>(std::get<Type>(t.value));
+        return std::make_unique<ConstExpr>(p.nextId(), std::get<Type>(t.value));
     }
 };
 
@@ -387,7 +394,7 @@ class RegExpParser : public PrefixParselet
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto value = ReType::Type.make(std::get<std::string>(t.value));
-        return std::make_unique<ConstExpr>(std::move(value));
+        return std::make_unique<ConstExpr>(p.nextId(), std::move(value));
     }
 };
 
@@ -408,7 +415,7 @@ public:
 
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
-        return std::make_unique<ConstExpr>(value_);
+        return std::make_unique<ConstExpr>(p.nextId(), value_);
     }
 
     Value value_;
@@ -443,7 +450,10 @@ class SubscriptParser : public PrefixParselet, public InfixParselet
         if (!body)
             return body;
 
-        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::make_unique<FieldExpr>("_"),
+        auto outerId = p.nextId();
+        auto innerId = p.nextId();
+        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(outerId,
+                                                                        std::make_unique<FieldExpr>(innerId, "_"),
                                                                         std::move(*body)));
     }
 
@@ -454,7 +464,8 @@ class SubscriptParser : public PrefixParselet, public InfixParselet
         if (!body)
             return body;
 
-        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::move(left),
+        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(p.nextId(),
+                                                                        std::move(left),
                                                                         std::move(*body)));
     }
 
@@ -479,7 +490,11 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
          * with the current node on the left. As "standalone" sub-selects are not useful. */
         auto body = p.parseTo(Token::RBRACE);
         TRY_EXPECTED(body);
-        return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::make_unique<FieldExpr>("_"),
+
+        auto outerId = p.nextId();
+        auto innerId = p.nextId();
+        return simplifyOrForward(p.env, std::make_unique<SubExpr>(outerId,
+                                                                  std::make_unique<FieldExpr>(innerId, "_"),
                                                                   std::move(*body)));
     }
 
@@ -488,7 +503,8 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
         auto _ = scopedNotInPath(p);
         auto body = p.parseTo(Token::RBRACE);
         TRY_EXPECTED(body);
-        return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::move(left),
+        return simplifyOrForward(p.env, std::make_unique<SubExpr>(p.nextId(),
+                                                                  std::move(left),
                                                                   std::move(*body)));
     }
 
@@ -510,15 +526,15 @@ public:
     {
         /* Self */
         if (t.type == Token::SELF)
-            return std::make_unique<FieldExpr>("_", t);
+            return std::make_unique<FieldExpr>(p.nextId(), "_", t);
 
         /* Any Child */
         if (t.type == Token::OP_TIMES)
-            return std::make_unique<AnyChildExpr>();
+            return std::make_unique<AnyChildExpr>(p.nextId());
 
         /* Wildcard */
         if (t.type == Token::WILDCARD)
-            return std::make_unique<WildcardExpr>();
+            return std::make_unique<WildcardExpr>(p.nextId());
 
         auto word = std::get<std::string>(t.value);
 
@@ -531,25 +547,25 @@ public:
             TRY_EXPECTED(arguments);
 
             if (word == "any") {
-                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(p.nextId(), std::move(*arguments)));
             } else if (word == "each" || word == "all") {
-                return simplifyOrForward(p.env, std::make_unique<EachExpr>(std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<EachExpr>(p.nextId(), std::move(*arguments)));
             } else {
-                return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<CallExpression>(p.nextId(), word, std::move(*arguments)));
             }
         } else if (!p.ctx.inPath) {
             /* Parse Symbols (words in upper-case) */
             if (isSymbolWord(word)) {
-                return std::make_unique<ConstExpr>(Value::make<std::string>(std::move(word)));
+                return std::make_unique<ConstExpr>(p.nextId(), Value::make<std::string>(std::move(word)));
             }
             /* Constant */
             else if (auto constant = p.env->findConstant(word)) {
-                return std::make_unique<ConstExpr>(*constant);
+                return std::make_unique<ConstExpr>(p.nextId(), *constant);
             }
         }
 
         /* Single field name */
-        return std::make_unique<FieldExpr>(std::move(word), t);
+        return std::make_unique<FieldExpr>(p.nextId(), std::move(word), t);
     }
 };
 
@@ -567,15 +583,15 @@ public:
     {
         /* Self */
         if (t.type == Token::SELF)
-            return std::make_unique<FieldExpr>("_");
+            return std::make_unique<FieldExpr>(p.nextId(), "_");
 
         /* Any Child */
         if (t.type == Token::OP_TIMES)
-            return std::make_unique<AnyChildExpr>();
+            return std::make_unique<AnyChildExpr>(p.nextId());
 
         /* Wildcard */
         if (t.type == Token::WILDCARD)
-            return std::make_unique<WildcardExpr>();
+            return std::make_unique<WildcardExpr>(p.nextId());
 
         auto word = std::get<std::string>(t.value);
 
@@ -591,26 +607,26 @@ public:
             auto arguments = p.parseList(Token::RPAREN);
             TRY_EXPECTED(arguments);
 
-            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
+            return simplifyOrForward(p.env, std::make_unique<CallExpression>(p.nextId(), word, std::move(*arguments)));
         } else if (!p.ctx.inPath) {
             /* Parse Symbols (words in upper-case) */
             if (isSymbolWord(word)) {
                 if (t.containsPoint(comp_->point)) {
-                    return std::make_unique<CompletionWordExpr>(word.substr(0, comp_->point - t.begin), comp_, t);
+                    return std::make_unique<CompletionWordExpr>(p.nextId(), word.substr(0, comp_->point - t.begin), comp_, t);
                 }
-                return std::make_unique<CompletionConstExpr>(Value::make<std::string>(std::move(word)));
+                return std::make_unique<CompletionConstExpr>(p.nextId(), Value::make<std::string>(std::move(word)));
             }
             /* Constant */
             else if (auto constant = p.env->findConstant(word)) {
-                return std::make_unique<ConstExpr>(*constant);
+                return std::make_unique<ConstExpr>(p.nextId(), *constant);
             }
         }
 
         /* Single field name */
         if (t.containsPoint(comp_->point)) {
-            return std::make_unique<CompletionFieldOrWordExpr>(word.substr(0, comp_->point - t.begin), comp_, t, p.ctx.inPath);
+            return std::make_unique<CompletionFieldOrWordExpr>(p.nextId(), word.substr(0, comp_->point - t.begin), comp_, t, p.ctx.inPath);
         }
-        return std::make_unique<FieldExpr>(std::move(word));
+        return std::make_unique<FieldExpr>(p.nextId(), std::move(word));
     }
 
     Completion* comp_;
@@ -637,7 +653,7 @@ public:
         auto right = p.parsePrecedence(precedence());
         TRY_EXPECTED(right);
 
-        return std::make_unique<PathExpr>(std::move(left), std::move(*right));
+        return std::make_unique<PathExpr>(p.nextId(), std::move(left), std::move(*right));
     }
 
     auto precedence() const -> int override
@@ -668,10 +684,10 @@ public:
 
         if (!*right) {
             Token expectedWord(Token::WORD, "", t.end, t.end);
-            right = std::make_unique<CompletionFieldOrWordExpr>("", comp_, expectedWord, p.ctx.inPath);
+            right = std::make_unique<CompletionFieldOrWordExpr>(p.nextId(), "", comp_, expectedWord, p.ctx.inPath);
         }
 
-        return std::make_unique<PathExpr>(std::move(left), std::move(*right));
+        return std::make_unique<PathExpr>(p.nextId(), std::move(left), std::move(*right));
     }
 
     Completion* comp_;
@@ -803,8 +819,10 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
 
         /* Expand a single value to `** == <value>` */
         if (autoWildcard && *root && (*root)->constant()) {
+            auto outerId = p.nextId();
+            auto innerId = p.nextId();
             root = std::make_unique<BinaryExpr<OperatorEq>>(
-                std::make_unique<WildcardExpr>(), std::move(*root));
+                outerId, std::make_unique<WildcardExpr>(innerId), std::move(*root));
         }
 
         if (!*root)
@@ -813,7 +831,7 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
         if (any) {
             std::vector<ExprPtr> args;
             args.emplace_back(std::move(*root));
-            return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(args)));
+            return simplifyOrForward(p.env, std::make_unique<AnyExpr>(p.nextId(), std::move(args)));
         } else {
             return root;
         }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -950,9 +950,9 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     return values;
 }
 
-auto diagnostics(Environment& env, const AST& ast, const Diagnostics& diag) -> expected<std::vector<Diagnostics::Message>, Error>
+auto diagnostics(const Diagnostics& diag) -> expected<std::vector<Diagnostics::Message>, Error>
 {
-    return diag.buildMessages(env, ast);
+    return diag.buildMessages();
 }
 
 }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -932,14 +932,12 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     // For thread-safety we work on a local diagnostics object that gets merged
     // into diag after query evaluation.
     Diagnostics localDiag;
-    localDiag.prepareIndizes(ast.expr());
+    localDiag.prepareIndices(ast.expr());
 
     Context ctx(&env, &localDiag);
 
-    auto mutableAST = &ast.expr(); // TODO: make const again!
-
     std::vector<Value> values;
-    auto res = mutableAST->eval(ctx, Value::field(node), LambdaResultFn([&values](Context, Value&& value) {
+    auto res = ast.expr().eval(ctx, Value::field(node), LambdaResultFn([&values](const Context&, Value&& value) {
         values.push_back(std::move(value));
         return Result::Continue;
     }));

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -124,7 +124,7 @@ static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -
         return nullptr;
 
     std::deque<Value> values;
-    auto stub = Context(env, Context::Phase::Compilation);
+    auto stub = Context(env, nullptr, Context::Phase::Compilation);
     auto res = (*expr)->eval(stub, Value::undef(), LambdaResultFn([&, n = 0](Context ctx, Value&& vv) mutable {
         n += 1;
         if ((n <= MultiConstExpr::Limit) && (!vv.isa(ValueType::Undef) || vv.nodePtr())) {
@@ -888,7 +888,7 @@ auto complete(Environment& env, std::string_view query, size_t point, const Mode
             showComparisonWildcardHint = true;
     }
 
-    Context ctx(&env);
+    Context ctx(&env, nullptr);
     if (options.timeoutMs > 0)
         ctx.timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(options.timeoutMs);
 
@@ -929,9 +929,14 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     if (!node.model_)
         return unexpected<Error>(Error::NullModel, "ModelNode must have a model!");
 
-    Context ctx(&env);
+    // For thread-safety we work on a local diagnostics object that gets merged
+    // into diag after query evaluation.
+    Diagnostics localDiag;
+    localDiag.prepareIndizes(ast.expr());
 
-    auto mutableAST = ast.expr().clone();
+    Context ctx(&env, &localDiag);
+
+    auto mutableAST = &ast.expr(); // TODO: make const again!
 
     std::vector<Value> values;
     auto res = mutableAST->eval(ctx, Value::field(node), LambdaResultFn([&values](Context, Value&& value) {
@@ -940,9 +945,9 @@ auto eval(Environment& env, const AST& ast, const ModelNode& node, Diagnostics* 
     }));
     TRY_EXPECTED(res);
 
-    if (diag) {
-        diag->collect(*mutableAST);
-    }
+    // Merge diagnostics
+    if (diag)
+        diag->append(localDiag);
 
     return values;
 }

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -104,5 +104,5 @@ auto GetDiagnosticMessages(std::string_view query) -> std::vector<Diagnostics::M
         INFO(res.error().message);
     REQUIRE(res);
 
-    return diagnostics(env, **ast, diag).value_or(std::vector<Diagnostics::Message>());
+    return diagnostics(diag).value_or(std::vector<Diagnostics::Message>());
 }

--- a/test/diagnostics.cpp
+++ b/test/diagnostics.cpp
@@ -27,16 +27,12 @@ TEST_CASE("UnknownField", "[diag.unknown-field]") {
     EXPECT_DIAGNOSTIC_MESSAGE_CONTAINING("**.not_a_field > 0", "No matches for field");
 }
 
+TEST_CASE("UnknownFields", "[diag.unknown-fields]") {
+    EXPECT_N_DIAGNOSTIC_MESSAGES("**.not_a_field > 0 or **.not_b_field < 1 or **.not_c_field != 31", 6);
+}
+
 TEST_CASE("ComparatorTypeMissmatch", "[diag.comparator-type-missmatch]") {
-    EXPECT_DIAGNOSTIC_MESSAGE_CONTAINING("['string'] > 123", "All values compared to true. Left hand types are string");
-}
-
-TEST_CASE("AnyUnknownField", "[diag.any-suppress-if-any]") {
-    EXPECT_N_DIAGNOSTIC_MESSAGES("any(**.not_a_field > 0 or **.number = 123)", 0);
-}
-
-TEST_CASE("OrShortCircuit", "[diag.suppress-short-circuitted-or]") {
-    EXPECT_N_DIAGNOSTIC_MESSAGES("**.number = 123 or **.not_a_field > 0", 0);
+    EXPECT_DIAGNOSTIC_MESSAGE_CONTAINING("['string'] > 123", "All values compared to false. Left hand types are string");
 }
 
 TEST_CASE("DiagnosticsSerialization", "[diag.serialization]") {
@@ -46,7 +42,7 @@ TEST_CASE("DiagnosticsSerialization", "[diag.serialization]") {
 
     // Create two diagnostic messages.
     Diagnostics originalDiag;
-    auto ast = compile(env, "**.number == \"string\" or **.number == \"string\"");
+    auto ast = compile(env, R"(**.number == "string" or **.number == "string")");
     REQUIRE(ast.has_value());
     auto root = model.value()->root(0);
     REQUIRE(root);

--- a/test/diagnostics.cpp
+++ b/test/diagnostics.cpp
@@ -58,8 +58,8 @@ TEST_CASE("DiagnosticsSerialization", "[diag.serialization]") {
     REQUIRE(readResult.has_value());
     
     // Both diagnostics objects must generate the exact same messages.
-    auto originalMessages = diagnostics(env, **ast, originalDiag);
-    auto deserializedMessages = diagnostics(env, **ast, deserializedDiag);
+    auto originalMessages = diagnostics(originalDiag);
+    auto deserializedMessages = diagnostics(deserializedDiag);
     
     REQUIRE(originalMessages.has_value());
     REQUIRE(deserializedMessages.has_value());

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -1,6 +1,7 @@
 #include "simfil/simfil.h"
 #include "simfil/environment.h"
 #include "simfil/exception-handler.h"
+#include "simfil/expression-visitor.h"
 #include "simfil/model/json.h"
 #include "simfil/value.h"
 #include "src/expressions.h"
@@ -745,7 +746,9 @@ TEST_CASE("Visit AST", "[visit.ast]")
     {
         std::optional<std::string> visitedFieldName;
 
-        auto visit(FieldExpr& expr) -> void override
+        using ExprVisitor::visit;
+
+        auto visit(const FieldExpr& expr) -> void override
         {
             ExprVisitor::visit(expr);
 


### PR DESCRIPTION
# Changes
- Removed `clone()` from `Expr`.
- Made `eval` and `ieval` const again (prior diagnostics state).
- Diagnostics data is now stored in the diagnostics object instead of the AST nodes. We do not need to copy the whole AST prior evaluation anymore. Instead, AST nodes can query `ctx.diag` for a matching diagnostics data object.
- `Expr` now contains a stable and unique `id()`
- Moved `ExprVisitor` to its own files.

Because of the simplification of the diagnostics message generation, some corner-cases such as
`or` short-circuiting may produce no diagnostics for skipped branches and `any` could produce diagnostics even though another branch matched.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core expression evaluation/parsing APIs (`Expr` becomes const-eval with stable ids, `Context` gains `Diagnostics*`) and rewires diagnostics collection/serialization, which could affect query evaluation results and diagnostic accuracy across complex expressions.
> 
> **Overview**
> Reworks diagnostics collection to be **external to the AST**: expressions now have a stable `ExprId`, and runtime stats (field hits/evaluations and comparison operand types/results) are recorded via `Context::diag` into `Diagnostics` storage rather than mutating/cloning AST nodes.
> 
> Introduces a standalone recursive `ExprVisitor` (`include/simfil/expression-visitor.h` + `src/expression-visitor.cpp`) and updates all expressions, completion nodes, and the parser to be `const`-evaluated (`eval`/`ieval`) with `accept(...) const`. `eval()` now builds per-run diagnostics (`prepareIndices` + local merge) and diagnostics serialization format is updated accordingly; tests are adjusted to reflect the new message behavior and aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e83f0d2ddea3ee58d856719a1a14d7a97b358802. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->