### PR TITLE
Basic Schema Field Pruning

### DIFF
--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -22,6 +22,7 @@ namespace simfil
 class Expr;
 class Function;
 class Diagnostics;
+class Schema;
 struct ResultFn;
 struct Debug;
 
@@ -61,6 +62,8 @@ struct Trace
 struct Environment
 {
 public:
+    using QuerySchemaCallback = std::function<const Schema*(SchemaId)>;
+
     /**
      * Construct a SIMFIL execution environment with a string cache,
      * which is used to map field names to short integer IDs.
@@ -116,6 +119,12 @@ public:
     [[nodiscard]]
     auto strings() const -> std::shared_ptr<StringPool>;
 
+    /**
+     * Query an object schema by its schema id.
+     * Returns nullptr if no callback is configured or the schema is unknown.
+     */
+    auto querySchema(SchemaId schemaId) const -> const Schema*;
+
 public:
     std::unique_ptr<std::mutex> warnMtx;
     std::vector<std::pair<std::string, std::string>> warnings;
@@ -129,6 +138,7 @@ public:
     /* constant ident -> value */
     std::map<std::string, Value, CaseInsensitiveCompare> constants;
 
+    QuerySchemaCallback querySchemaCallback;
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;
 };

--- a/include/simfil/environment.h
+++ b/include/simfil/environment.h
@@ -139,6 +139,15 @@ public:
     std::map<std::string, Value, CaseInsensitiveCompare> constants;
 
     QuerySchemaCallback querySchemaCallback;
+
+    /**
+     * Enable cached schema-guided wildcard field traversal plans.
+     *
+     * Disabling this keeps the older behavior where wildcard field lookups only
+     * ask each node schema whether the requested field can appear below it.
+     */
+    bool enableWildcardFieldPlans = true;
+
     Debug* debug = nullptr;
     std::shared_ptr<StringPool> stringPool;
 };

--- a/include/simfil/expression-visitor.h
+++ b/include/simfil/expression-visitor.h
@@ -21,6 +21,7 @@ class UnpackExpr;
 class UnaryWordOpExpr;
 class BinaryWordOpExpr;
 class FieldExpr;
+class WildcardFieldExpr;
 class PathExpr;
 class AndExpr;
 class OrExpr;
@@ -54,6 +55,7 @@ public:
     virtual void visit(const CallExpression& expr);
     virtual void visit(const PathExpr& expr);
     virtual void visit(const FieldExpr& expr);
+    virtual void visit(const WildcardFieldExpr& expr);
     virtual void visit(const UnpackExpr& expr);
     virtual void visit(const UnaryWordOpExpr& expr);
     virtual void visit(const BinaryWordOpExpr& expr);

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -8,11 +8,15 @@
 #include "simfil/result.h"
 
 #include <memory>
+#include <stdexcept>
 
 namespace simfil
 {
 
+class Expr;
 class ExprVisitor;
+
+using ExprPtr = std::unique_ptr<Expr>;
 
 class Expr
 {
@@ -31,17 +35,16 @@ public:
         VALUE,
     };
 
-    Expr() = delete;
-    explicit Expr(ExprId id)
-        : id_(id)
-    {}
-    explicit Expr(ExprId id, const Token& token)
-        : id_(id)
+    Expr() = default;
+    explicit Expr(const Token& token)
     {
         assert(token.end >= token.begin);
         sourceLocation_.offset = token.begin;
         sourceLocation_.size = token.end - token.begin;
     }
+    explicit Expr(SourceLocation location)
+        : sourceLocation_(location)
+    {}
 
     virtual ~Expr() = default;
 
@@ -54,6 +57,28 @@ public:
     virtual auto constant() const -> bool
     {
         return false;
+    }
+
+    /* Accept expression visitor */
+    virtual auto accept(ExprVisitor& v) const -> void = 0;
+
+    /* Get the number of child expressions */
+    virtual auto numChildren() const -> std::size_t
+    {
+        return 0;
+    }
+
+    /* Get the n-th child expression */
+    virtual auto childAt(std::size_t index) -> ExprPtr&
+    {
+        if (numChildren() == 0)
+            throw std::out_of_range("AST Child index out of range");
+        throw std::runtime_error("Missing childAt function implementation");
+    }
+
+    virtual auto childAt(std::size_t index) const -> const ExprPtr&
+    {
+        return const_cast<Expr&>(*this).childAt(index);
     }
 
     /* Debug */
@@ -90,11 +115,7 @@ public:
         return ieval(ctx, std::move(val), res);
     }
 
-    /* Accept expression visitor */
-    virtual auto accept(ExprVisitor& v) const -> void = 0;
-
     /* Source location the expression got parsed from */
-    [[nodiscard]]
     auto sourceLocation() const -> SourceLocation
     {
         return sourceLocation_;
@@ -110,11 +131,9 @@ private:
         return ieval(ctx, value, result);
     }
 
-    ExprId id_;
+    ExprId id_ = 0;
     SourceLocation sourceLocation_;
 };
-
-using ExprPtr = std::unique_ptr<Expr>;
 
 class AST
 {
@@ -125,6 +144,8 @@ public:
     {}
 
     ~AST();
+
+    auto reenumerate() -> void;
 
     auto expr() const -> const Expr&
     {
@@ -137,6 +158,8 @@ public:
     }
 
 private:
+    static auto reenumerate(Expr& expr, Expr::ExprId& nextId) -> void;
+
     /* The original query string of the AST */
     std::string queryString_;
 

--- a/include/simfil/expression.h
+++ b/include/simfil/expression.h
@@ -69,16 +69,14 @@ public:
     }
 
     /* Get the n-th child expression */
-    virtual auto childAt(std::size_t index) -> ExprPtr&
+    virtual auto childAt(std::size_t) -> ExprPtr&
     {
-        if (numChildren() == 0)
-            throw std::out_of_range("AST Child index out of range");
-        throw std::runtime_error("Missing childAt function implementation");
+        throw std::out_of_range("AST child index out of range");
     }
 
-    virtual auto childAt(std::size_t index) const -> const ExprPtr&
+    virtual auto childAt(std::size_t) const -> const ExprPtr&
     {
-        return const_cast<Expr&>(*this).childAt(index);
+        throw std::out_of_range("AST child index out of range");
     }
 
     /* Debug */

--- a/include/simfil/model/model.h
+++ b/include/simfil/model/model.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "simfil/model/string-pool.h"
+#include "simfil/model/schema.h"
 #include "simfil/byte-array.h"
 #include "tl/expected.hpp"
 #if defined(SIMFIL_WITH_MODEL_JSON)
@@ -274,7 +275,9 @@ public:
         size_t stringDataBytes = 0;
         size_t stringRangeBytes = 0;
         size_t objectMemberBytes = 0;
+        size_t objectSchemaBytes = 0;
         size_t arrayMemberBytes = 0;
+        size_t arraySchemaBytes = 0;
 
         [[nodiscard]] size_t totalBytes() const
         {
@@ -284,7 +287,9 @@ public:
                 + stringDataBytes
                 + stringRangeBytes
                 + objectMemberBytes
-                + arrayMemberBytes;
+                + objectSchemaBytes
+                + arrayMemberBytes
+                + arraySchemaBytes;
         }
     };
 
@@ -299,12 +304,18 @@ protected:
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
+    [[nodiscard]] SchemaId objectSchemaId(ArrayIndex members) const;
+    auto setObjectSchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>;
+    [[nodiscard]] SchemaId arraySchemaId(ArrayIndex members) const;
+    auto setArraySchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>;
+
     /**
      * Protected object/array member storage access,
      * so derived ModelPools can create Object/Array-derived nodes.
      */
     Object::Storage& objectMemberStorage();
     [[nodiscard]] Object::Storage const& objectMemberStorage() const;
+
     Array::Storage& arrayMemberStorage();
     [[nodiscard]] Array::Storage const& arrayMemberStorage() const;
 };

--- a/include/simfil/model/nodes.h
+++ b/include/simfil/model/nodes.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "arena.h"
+#include "schema.h"
 #include "string-pool.h"
 #include "simfil/byte-array.h"
 #include "simfil/error.h"
@@ -56,8 +57,9 @@ enum class ValueType
     Bytes,
     TransientObject,
     Object,
-    Array
-    // If you add types, update TypeFlags::flags bit size!
+    Array,
+    // End
+    LAST_
 };
 
 using ScalarValueType = std::variant<
@@ -276,6 +278,9 @@ struct ModelNode
     /// Get an Object model's field names
     [[nodiscard]] virtual StringId keyAt(int64_t i) const;
 
+    /// Get the schema id for schema-aware container nodes, or NoSchemaId otherwise.
+    [[nodiscard]] virtual SchemaId schema() const;
+
     /// Get the number of children
     [[nodiscard]] virtual uint32_t size() const;
 
@@ -431,6 +436,7 @@ struct ModelNodeBase : public ModelNode
     [[nodiscard]] ModelNode::Ptr get(const StringId&) const override;
     [[nodiscard]] ModelNode::Ptr at(int64_t) const override;
     [[nodiscard]] StringId keyAt(int64_t) const override;
+    [[nodiscard]] SchemaId schema() const override;
     [[nodiscard]] uint32_t size() const override;
     bool iterate(IterCallback const&) const override {return true;}  // NOLINT (allow discard)
 
@@ -547,6 +553,9 @@ public:
 
     bool forEach(std::function<bool(ModelNodeType const&)> const& callback) const;
 
+    [[nodiscard]] SchemaId schema() const override;
+    auto setSchema(SchemaId schemaId) -> tl::expected<void, Error>;
+
     [[nodiscard]] ValueType type() const override;
     [[nodiscard]] ModelNode::Ptr at(int64_t) const override;
     [[nodiscard]] uint32_t size() const override;
@@ -609,6 +618,9 @@ public:
     addField(std::string_view const& name, model_ptr<OtherModelNodeType> const& value) {
         return addFieldInternal(name, static_cast<ModelNode::Ptr>(value));
     }
+
+    [[nodiscard]] SchemaId schema() const override;
+    auto setSchema(SchemaId schemaId) -> tl::expected<void, Error>;
 
     [[nodiscard]] ValueType type() const override;
     [[nodiscard]] ModelNode::Ptr at(int64_t) const override;

--- a/include/simfil/model/nodes.impl.h
+++ b/include/simfil/model/nodes.impl.h
@@ -22,6 +22,18 @@ ValueType BaseArray<ModelType, ModelNodeType>::type() const
 }
 
 template <class ModelType, class ModelNodeType>
+SchemaId BaseArray<ModelType, ModelNodeType>::schema() const
+{
+    return model().arraySchemaId(members_);
+}
+
+template <class ModelType, class ModelNodeType>
+auto BaseArray<ModelType, ModelNodeType>::setSchema(SchemaId schemaId) -> tl::expected<void, Error>
+{
+    return model().setArraySchemaId(members_, schemaId);
+}
+
+template <class ModelType, class ModelNodeType>
 ModelNode::Ptr BaseArray<ModelType, ModelNodeType>::at(int64_t i) const
 {
     if (i < 0 || i >= (int64_t)storage_->size(members_))
@@ -94,6 +106,18 @@ template <class ModelType, class ModelNodeType>
 ValueType BaseObject<ModelType, ModelNodeType>::type() const
 {
     return ValueType::Object;
+}
+
+template <class ModelType, class ModelNodeType>
+SchemaId BaseObject<ModelType, ModelNodeType>::schema() const
+{
+    return model().objectSchemaId(members_);
+}
+
+template <class ModelType, class ModelNodeType>
+auto BaseObject<ModelType, ModelNodeType>::setSchema(SchemaId schemaId) -> tl::expected<void, Error>
+{
+    return model().setObjectSchemaId(members_, schemaId);
 }
 
 template <class ModelType, class ModelNodeType>

--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -1,0 +1,273 @@
+#pragma once
+
+#include "simfil/model/string-pool.h"
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <sfl/small_vector.hpp>
+#include <vector>
+
+namespace simfil
+{
+
+class Schema;
+
+using SchemaId = std::uint16_t;
+constexpr SchemaId NoSchemaId = SchemaId{0};
+constexpr SchemaId MaxSchemaId = SchemaId{std::numeric_limits<SchemaId>::max()};
+
+/**
+ * Concept defining a callback to query a Schema* by SchemaId.
+ */
+template <class Fn>
+concept QuerySchemaFn = requires(const Fn& fn) {
+    { fn(SchemaId{}) } -> std::convertible_to<const Schema*>;
+};
+template <class Fn>
+concept QueryMutableSchemaFn = requires(const Fn& fn) {
+    { fn(SchemaId{}) } -> std::convertible_to<Schema*>;
+};
+
+/**
+ *
+ */
+class Schema
+{
+public:
+    /** Schema kind */
+    enum class Kind {
+        Object,
+        Array,
+    };
+
+    /** Finalization state */
+    enum class State {
+        Dirty,
+        Finalizing,
+        Clean,
+    };
+
+    virtual ~Schema() = default;
+
+    /**
+     * Return this schemas kind.
+     */
+    virtual auto kind() const -> Kind = 0;
+
+    /**
+     * Returns true if this schema or any of the schemas it refers to
+     * can possibly contain the given field.
+     *
+     * @param fieldId The field id to query the schema for
+     */
+    virtual auto canHaveField(StringId fieldId) const -> bool = 0;
+
+    /**
+     * Finalize this schema and all schemas it refers to.
+     *
+     * @param queryFn Schema Query callback.
+     */
+    virtual auto finalize(const std::function<Schema*(SchemaId)>& queryFn) -> State
+    {
+        return State::Clean;
+    }
+
+    /**
+     * @return All nested field names.
+     */
+    virtual auto nestedFields() const & -> std::span<const StringId> = 0;
+};
+
+/**
+ * Schema for object nodes.
+ *
+ * Stores direct fields and optional child schema ids per field. After
+ * `finalize()` it also caches all reachable child fields.
+ */
+class ObjectSchema : public Schema
+{
+public:
+    struct FieldSummary {
+        StringId field = 0;
+        sfl::small_vector<SchemaId, 1> schemas;
+
+        auto operator<=>(const FieldSummary& other) const
+        {
+            return field <=> other.field;
+        }
+    };
+
+    auto kind() const -> Kind override
+    {
+        return Kind::Object;
+    }
+
+    auto canHaveField(StringId field) const -> bool override
+    {
+        // Be conservative if the schema has not been finalized.
+        if (state_ != State::Clean)
+            return true;
+
+        auto iter = std::lower_bound(flatFields_.begin(), flatFields_.end(), field);
+        return iter != flatFields_.end() && *iter == field;
+    }
+
+    /**
+     * Add a direct field and optional child schemas reachable through it.
+     */
+    auto addField(StringId field, std::initializer_list<SchemaId> schemas = {}) -> void
+    {
+        FieldSummary summary;
+        summary.field = field;
+        summary.schemas.insert(summary.schemas.end(), schemas.begin(), schemas.end());
+        fields_.push_back(std::move(summary));
+        state_ = State::Dirty;
+    }
+
+    /**
+     * Recompute the cached descendant field set from this schema and all
+     * reachable child schemas.
+     */
+    auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
+    {
+        if (state_ == State::Clean || state_ == State::Finalizing)
+            return state_;
+
+        state_ = State::Finalizing;
+        flatFields_.clear();
+        auto canFinalize = true;
+
+        for (const auto& field : fields_) {
+            flatFields_.push_back(field.field);
+            for (const auto& fieldSchemaId : field.schemas) {
+                if (auto* childSchema = lookup(fieldSchemaId)) {
+                    auto childState = childSchema->finalize(lookup);
+                    if (childState != State::Clean) {
+                        canFinalize = false;
+                        continue;
+                    }
+
+                    auto childFields = childSchema->nestedFields();
+                    flatFields_.insert(flatFields_.end(), childFields.begin(), childFields.end());
+                }
+            }
+        }
+
+        if (!canFinalize) {
+            flatFields_.clear();
+            state_ = State::Dirty;
+            return State::Dirty;
+        }
+
+        std::sort(flatFields_.begin(), flatFields_.end());
+        flatFields_.erase(std::unique(flatFields_.begin(), flatFields_.end()), flatFields_.end());
+        state_ = State::Clean;
+        return State::Clean;
+    }
+
+    auto fields() const & -> std::span<const FieldSummary>
+    {
+        return {fields_.begin(), fields_.end()};
+    }
+
+    auto nestedFields() const & -> std::span<const StringId> override
+    {
+        return {flatFields_.cbegin(), flatFields_.cend()};
+    }
+
+private:
+    sfl::small_vector<FieldSummary, 4> fields_;
+
+    std::vector<StringId> flatFields_; // Ordered!
+    State state_ = State::Dirty;
+};
+
+/**
+ * Schema for array nodes.
+ *
+ * Stores the set of possible element schemas. After `finalize()` it caches
+ * all fields reachable through any element schema.
+ */
+class ArraySchema : public Schema
+{
+public:
+    auto kind() const -> Kind override
+    {
+        return Kind::Array;
+    }
+
+    auto canHaveField(StringId field) const -> bool override
+    {
+        if (state_ != State::Clean)
+            return true;
+
+        auto iter = std::lower_bound(flatFields_.begin(), flatFields_.end(), field);
+        return iter != flatFields_.end() && *iter == field;
+    }
+
+    /**
+     * Add possible schemas for elements contained in the array.
+     */
+    auto addElementSchemas(std::initializer_list<SchemaId> schemas) -> void
+    {
+        schemas_.insert(schemas_.end(), schemas.begin(), schemas.end());
+        state_ = State::Dirty;
+    }
+
+    /**
+     * Recompute the cached descendant field set from all possible element
+     * schemas.
+     */
+    auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
+    {
+        if (state_ == State::Clean || state_ == State::Finalizing)
+            return state_;
+
+        state_ = State::Finalizing;
+        flatFields_.clear();
+        auto canFinalize = true;
+
+        for (const auto& schemaId : schemas_) {
+            if (auto* childSchema = lookup(schemaId)) {
+                auto childState = childSchema->finalize(lookup);
+                if (childState != State::Clean) {
+                    canFinalize = false;
+                    continue;
+                }
+
+                auto childFields = childSchema->nestedFields();
+                flatFields_.insert(flatFields_.end(), childFields.begin(), childFields.end());
+            }
+        }
+
+        if (!canFinalize) {
+            flatFields_.clear();
+            state_ = State::Dirty;
+            return State::Dirty;
+        }
+
+        std::sort(flatFields_.begin(), flatFields_.end());
+        flatFields_.erase(std::unique(flatFields_.begin(), flatFields_.end()), flatFields_.end());
+        state_ = State::Clean;
+        return State::Clean;
+    }
+
+    auto nestedFields() const & -> std::span<const StringId> override
+    {
+        return {flatFields_.cbegin(), flatFields_.cend()};
+    }
+
+    auto elementSchemas() const & -> std::span<const SchemaId>
+    {
+        return {schemas_.begin(), schemas_.end()};
+    }
+
+private:
+    sfl::small_vector<SchemaId, 1> schemas_;
+    std::vector<StringId> flatFields_; // Ordered!
+    State state_ = State::Dirty;
+};
+
+}

--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -78,6 +78,22 @@ public:
      */
     virtual auto nestedFields() const & -> std::span<const StringId> = 0;
 
+    /**
+     * Return true once `canHaveField` is backed by finalized field caches.
+     */
+    virtual auto finalized() const -> bool
+    {
+        return true;
+    }
+
+    /**
+     * Monotonic counter for cache invalidation after schema mutations.
+     */
+    virtual auto revision() const -> std::uint64_t
+    {
+        return 0;
+    }
+
 protected:
     using SchemaIdStack = sfl::small_vector<SchemaId, 8>;
 
@@ -195,6 +211,7 @@ public:
         summary.schemas.insert(summary.schemas.end(), schemas.begin(), schemas.end());
         fields_.push_back(std::move(summary));
         state_ = State::Dirty;
+        ++revision_;
     }
 
     /**
@@ -220,6 +237,16 @@ public:
         return {flatFields_.cbegin(), flatFields_.cend()};
     }
 
+    auto finalized() const -> bool override
+    {
+        return state_ == State::Clean;
+    }
+
+    auto revision() const -> std::uint64_t override
+    {
+        return revision_;
+    }
+
 private:
     auto collectNestedFields(const std::function<Schema*(SchemaId)>& lookup,
                              SchemaIdStack& visited,
@@ -235,6 +262,7 @@ private:
     sfl::small_vector<FieldSummary, 4> fields_;
 
     std::vector<StringId> flatFields_; // Ordered!
+    std::uint64_t revision_ = 0;
     State state_ = State::Dirty;
 };
 
@@ -264,6 +292,7 @@ public:
     {
         schemas_.insert(schemas_.end(), schemas.begin(), schemas.end());
         state_ = State::Dirty;
+        ++revision_;
     }
 
     /**
@@ -284,6 +313,16 @@ public:
         return {flatFields_.cbegin(), flatFields_.cend()};
     }
 
+    auto finalized() const -> bool override
+    {
+        return state_ == State::Clean;
+    }
+
+    auto revision() const -> std::uint64_t override
+    {
+        return revision_;
+    }
+
     auto elementSchemas() const & -> std::span<const SchemaId>
     {
         return {schemas_.begin(), schemas_.end()};
@@ -300,6 +339,7 @@ private:
 
     sfl::small_vector<SchemaId, 1> schemas_;
     std::vector<StringId> flatFields_; // Ordered!
+    std::uint64_t revision_ = 0;
     State state_ = State::Dirty;
 };
 

--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -5,8 +5,11 @@
 #include <cassert>
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <limits>
+#include <ranges>
 #include <sfl/small_vector.hpp>
+#include <span>
 #include <vector>
 
 namespace simfil
@@ -59,15 +62,11 @@ public:
     /**
      * Returns true if this schema or any of the schemas it refers to
      * can possibly contain the given field.
-     *
-     * @param fieldId The field id to query the schema for
      */
     virtual auto canHaveField(StringId fieldId) const -> bool = 0;
 
     /**
      * Finalize this schema and all schemas it refers to.
-     *
-     * @param queryFn Schema Query callback.
      */
     virtual auto finalize(const std::function<Schema*(SchemaId)>& queryFn) -> State
     {
@@ -78,6 +77,83 @@ public:
      * @return All nested field names.
      */
     virtual auto nestedFields() const & -> std::span<const StringId> = 0;
+
+protected:
+    using SchemaIdStack = sfl::small_vector<SchemaId, 8>;
+
+    /**
+     * Append all fields reachable from this schema without relying on cached
+     * finalization state. This lets cyclic schema graphs still produce an exact
+     * field set by cutting recursion at already visited schema ids.
+     */
+    virtual auto collectNestedFields(const std::function<Schema*(SchemaId)>& queryFn,
+                                     SchemaIdStack& visited,
+                                     std::vector<StringId>& fields) const -> void = 0;
+
+    /**
+     * Append fields reachable through a schema id, using a finalized child
+     * cache when possible and falling back to raw graph traversal for cycles.
+     */
+    static auto appendSchemaFields(SchemaId schemaId,
+                                   const std::function<Schema*(SchemaId)>& queryFn,
+                                   SchemaIdStack& visited,
+                                   std::vector<StringId>& fields) -> void
+    {
+        if (schemaId == NoSchemaId || std::ranges::find(visited, schemaId) != visited.end())
+            return;
+
+        auto* schema = queryFn(schemaId);
+        if (!schema)
+            return;
+
+        visited.push_back(schemaId);
+
+        if (schema->finalize(queryFn) == State::Clean) {
+            auto childFields = schema->nestedFields();
+            fields.insert(fields.end(), childFields.begin(), childFields.end());
+            return;
+        }
+
+        schema->collectNestedFields(queryFn, visited, fields);
+    }
+
+    /**
+     * Shared finalization implementation for concrete schema classes.
+     */
+    template <class CollectFn>
+    static auto finalizeFields(State& state,
+                               std::vector<StringId>& flatFields,
+                               const std::function<Schema*(SchemaId)>& queryFn,
+                               CollectFn&& collect) -> State
+    {
+        if (state == State::Clean || state == State::Finalizing)
+            return state;
+
+        state = State::Finalizing;
+        flatFields.clear();
+
+        SchemaIdStack visited;
+        collect(queryFn, visited, flatFields);
+
+        std::ranges::sort(flatFields);
+        auto duplicates = std::ranges::unique(flatFields);
+        flatFields.erase(duplicates.begin(), duplicates.end());
+
+        state = State::Clean;
+        return State::Clean;
+    }
+
+    /**
+     * Shared membership test; dirty schemas remain conservative.
+     */
+    static auto containsField(State state, const std::vector<StringId>& flatFields, StringId field) -> bool
+    {
+        if (state != State::Clean)
+            return true;
+
+        auto iter = std::ranges::lower_bound(flatFields, field);
+        return iter != flatFields.end() && *iter == field;
+    }
 };
 
 /**
@@ -106,12 +182,7 @@ public:
 
     auto canHaveField(StringId field) const -> bool override
     {
-        // Be conservative if the schema has not been finalized.
-        if (state_ != State::Clean)
-            return true;
-
-        auto iter = std::lower_bound(flatFields_.begin(), flatFields_.end(), field);
-        return iter != flatFields_.end() && *iter == field;
+        return containsField(state_, flatFields_, field);
     }
 
     /**
@@ -132,39 +203,11 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        if (state_ == State::Clean || state_ == State::Finalizing)
-            return state_;
-
-        state_ = State::Finalizing;
-        flatFields_.clear();
-        auto canFinalize = true;
-
-        for (const auto& field : fields_) {
-            flatFields_.push_back(field.field);
-            for (const auto& fieldSchemaId : field.schemas) {
-                if (auto* childSchema = lookup(fieldSchemaId)) {
-                    auto childState = childSchema->finalize(lookup);
-                    if (childState != State::Clean) {
-                        canFinalize = false;
-                        continue;
-                    }
-
-                    auto childFields = childSchema->nestedFields();
-                    flatFields_.insert(flatFields_.end(), childFields.begin(), childFields.end());
-                }
-            }
-        }
-
-        if (!canFinalize) {
-            flatFields_.clear();
-            state_ = State::Dirty;
-            return State::Dirty;
-        }
-
-        std::sort(flatFields_.begin(), flatFields_.end());
-        flatFields_.erase(std::unique(flatFields_.begin(), flatFields_.end()), flatFields_.end());
-        state_ = State::Clean;
-        return State::Clean;
+        return finalizeFields(state_, flatFields_, lookup, [this](const auto& queryFn,
+                                                                  auto& visited,
+                                                                  auto& fields) {
+            collectNestedFields(queryFn, visited, fields);
+        });
     }
 
     auto fields() const & -> std::span<const FieldSummary>
@@ -178,6 +221,17 @@ public:
     }
 
 private:
+    auto collectNestedFields(const std::function<Schema*(SchemaId)>& lookup,
+                             SchemaIdStack& visited,
+                             std::vector<StringId>& fields) const -> void override
+    {
+        for (const auto& field : fields_) {
+            fields.push_back(field.field);
+            for (const auto& fieldSchemaId : field.schemas)
+                appendSchemaFields(fieldSchemaId, lookup, visited, fields);
+        }
+    }
+
     sfl::small_vector<FieldSummary, 4> fields_;
 
     std::vector<StringId> flatFields_; // Ordered!
@@ -200,11 +254,7 @@ public:
 
     auto canHaveField(StringId field) const -> bool override
     {
-        if (state_ != State::Clean)
-            return true;
-
-        auto iter = std::lower_bound(flatFields_.begin(), flatFields_.end(), field);
-        return iter != flatFields_.end() && *iter == field;
+        return containsField(state_, flatFields_, field);
     }
 
     /**
@@ -222,36 +272,11 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        if (state_ == State::Clean || state_ == State::Finalizing)
-            return state_;
-
-        state_ = State::Finalizing;
-        flatFields_.clear();
-        auto canFinalize = true;
-
-        for (const auto& schemaId : schemas_) {
-            if (auto* childSchema = lookup(schemaId)) {
-                auto childState = childSchema->finalize(lookup);
-                if (childState != State::Clean) {
-                    canFinalize = false;
-                    continue;
-                }
-
-                auto childFields = childSchema->nestedFields();
-                flatFields_.insert(flatFields_.end(), childFields.begin(), childFields.end());
-            }
-        }
-
-        if (!canFinalize) {
-            flatFields_.clear();
-            state_ = State::Dirty;
-            return State::Dirty;
-        }
-
-        std::sort(flatFields_.begin(), flatFields_.end());
-        flatFields_.erase(std::unique(flatFields_.begin(), flatFields_.end()), flatFields_.end());
-        state_ = State::Clean;
-        return State::Clean;
+        return finalizeFields(state_, flatFields_, lookup, [this](const auto& queryFn,
+                                                                  auto& visited,
+                                                                  auto& fields) {
+            collectNestedFields(queryFn, visited, fields);
+        });
     }
 
     auto nestedFields() const & -> std::span<const StringId> override
@@ -265,6 +290,14 @@ public:
     }
 
 private:
+    auto collectNestedFields(const std::function<Schema*(SchemaId)>& lookup,
+                             SchemaIdStack& visited,
+                             std::vector<StringId>& fields) const -> void override
+    {
+        for (const auto& schemaId : schemas_)
+            appendSchemaFields(schemaId, lookup, visited, fields);
+    }
+
     sfl::small_vector<SchemaId, 1> schemas_;
     std::vector<StringId> flatFields_; // Ordered!
     State state_ = State::Dirty;

--- a/include/simfil/parser.h
+++ b/include/simfil/parser.h
@@ -59,7 +59,6 @@ public:
     };
 
     struct Context {
-        Expr::ExprId id = 0;
         bool inPath = false;
     };
 
@@ -103,11 +102,6 @@ public:
      */
     auto mode() const -> Mode;
     auto relaxed() const -> bool;
-
-    /**
-     * Get the next expression id.
-     */
-    auto nextId() -> Expr::ExprId;
 
     Context ctx;
     Environment* const env;

--- a/include/simfil/value.h
+++ b/include/simfil/value.h
@@ -104,7 +104,7 @@ inline auto valueType2String(ValueType t) -> const char*
  */
 struct TypeFlags
 {
-    std::bitset<10> flags;
+    std::bitset<static_cast<size_t>(ValueType::LAST_)> flags;
 
     auto test(ValueType type) const
     {

--- a/include/simfil/value.h
+++ b/include/simfil/value.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cassert>
 #include <bitset>
+#include <type_traits>
 
 #include "model/nodes.h"
 #include "simfil/byte-array.h"
@@ -104,11 +105,11 @@ inline auto valueType2String(ValueType t) -> const char*
  */
 struct TypeFlags
 {
-    std::bitset<static_cast<size_t>(ValueType::LAST_)> flags;
+    std::bitset<static_cast<size_t>(static_cast<std::underlying_type_t<ValueType>>(ValueType::LAST_))> flags;
 
     auto test(ValueType type) const
     {
-        return flags.test(static_cast<std::underlying_type_t<ValueType>>(type));
+        return flags.test(static_cast<size_t>(static_cast<std::underlying_type_t<ValueType>>(type)));
     }
 
     auto test(TypeFlags other) const

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -17,7 +17,6 @@
 #include <atomic>
 #include <fstream>
 #include <chrono>
-#include <optional>
 #include <iostream>
 
 #if defined(WITH_READLINE)
@@ -36,6 +35,7 @@ struct
     bool auto_wildcard = false;
     bool verbose = true;
     bool multi_threaded = true;
+    bool schema = true;
 } options;
 
 static void set_option(const std::string& option, bool& flag, std::string_view cmd)
@@ -197,6 +197,8 @@ static void show_help()
         << "Options:\n"
         << "  -D <identifier=value>\n"
         << "          Define a constant variable, set to value\n"
+        << "  -s SCHEMA\n"
+        << "          Use a JSON-Schema from SCHEMA file\n"
         << "  -h\n"
         << "          Show this help"
         << "\n";
@@ -240,6 +242,10 @@ int main(int argc, char *argv[])
 #endif
     };
 
+    auto load_schema = [](const std::string_view& filename) {
+        std::cerr << "Schema support is not implemented!\n";
+    };
+
     auto tail_args = false;
     while (*++argv != nullptr) {
         std::string_view arg = *argv;
@@ -251,6 +257,18 @@ int main(int argc, char *argv[])
             case 'h':
                 show_help();
                 return 0;
+            case 's':
+                arg.remove_prefix(2);
+                if (arg.empty()) {
+                    arg = *++argv;
+                }
+                if (!arg.empty()) {
+                    load_schema(arg);
+                } else {
+                    std::cerr << "Missing schema file\n";
+                    return 1;
+                }
+                break;
             case 'D':
                 arg.remove_prefix(2);
                 if (arg.empty()) {
@@ -284,6 +302,7 @@ int main(int argc, char *argv[])
             set_option("wildcard", options.auto_wildcard, cmd);
             set_option("verbose", options.verbose, cmd);
             set_option("mt", options.multi_threaded, cmd);
+            set_option("schema", options.schema, cmd);
             continue;
         }
 

--- a/repl/repl.cpp
+++ b/repl/repl.cpp
@@ -242,8 +242,15 @@ int main(int argc, char *argv[])
 #endif
     };
 
-    auto load_schema = [](const std::string_view& filename) {
+    auto load_schema = [](std::string_view) {
         std::cerr << "Schema support is not implemented!\n";
+    };
+
+    auto take_option_value = [&argv](std::string_view arg) -> std::string_view {
+        arg.remove_prefix(2);
+        if (!arg.empty() || argv[1] == nullptr)
+            return arg;
+        return *++argv;
     };
 
     auto tail_args = false;
@@ -258,10 +265,7 @@ int main(int argc, char *argv[])
                 show_help();
                 return 0;
             case 's':
-                arg.remove_prefix(2);
-                if (arg.empty()) {
-                    arg = *++argv;
-                }
+                arg = take_option_value(arg);
                 if (!arg.empty()) {
                     load_schema(arg);
                 } else {
@@ -270,10 +274,7 @@ int main(int argc, char *argv[])
                 }
                 break;
             case 'D':
-                arg.remove_prefix(2);
-                if (arg.empty()) {
-                    arg = *++argv;
-                }
+                arg = take_option_value(arg);
                 if (auto pos = arg.find('='); (pos != std::string::npos) && (pos > 0)) {
                     constants.try_emplace(std::string(arg.substr(0, pos)), simfil::Value::make(std::string(arg.substr(pos + 1))));
                 } else {

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -125,8 +125,8 @@ auto completeWords(const simfil::Context& ctx, std::string_view prefix, simfil::
 namespace simfil
 {
 
-CompletionFieldOrWordExpr::CompletionFieldOrWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token, bool inPath)
-    : Expr(id, token)
+CompletionFieldOrWordExpr::CompletionFieldOrWordExpr(std::string prefix, Completion* comp, const Token& token, bool inPath)
+    : Expr(token)
     , prefix_(std::move(prefix))
     , comp_(comp)
     , inPath_(inPath)
@@ -225,9 +225,8 @@ struct FindExpressionRange : ExprVisitor
 
 }
 
-CompletionAndExpr::CompletionAndExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp)
-    : Expr(id)
-    , left_(std::move(left))
+CompletionAndExpr::CompletionAndExpr(ExprPtr left, ExprPtr right, const Completion* comp)
+    : left_(std::move(left))
     , right_(std::move(right))
 {
     FindExpressionRange leftRange;
@@ -281,9 +280,8 @@ auto CompletionAndExpr::toString() const -> std::string
     return "(and ? ?)";
 }
 
-CompletionOrExpr::CompletionOrExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp)
-    : Expr(id)
-    , left_(std::move(left))
+CompletionOrExpr::CompletionOrExpr(ExprPtr left, ExprPtr right, const Completion* comp)
+    : left_(std::move(left))
     , right_(std::move(right))
 {
     FindExpressionRange leftRange;
@@ -337,8 +335,8 @@ auto CompletionOrExpr::toString() const -> std::string
     return "(or ? ?)";
 }
 
-CompletionWordExpr::CompletionWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token)
-    : Expr(id, token)
+CompletionWordExpr::CompletionWordExpr(std::string prefix, Completion* comp, const Token& token)
+    : Expr(token)
     , prefix_(std::move(prefix))
     , comp_(comp)
 {}

--- a/src/completion.h
+++ b/src/completion.h
@@ -45,7 +45,7 @@ struct Completion
 class CompletionFieldOrWordExpr : public Expr
 {
 public:
-    CompletionFieldOrWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token, bool inPath);
+    CompletionFieldOrWordExpr(std::string prefix, Completion* comp, const Token& token, bool inPath);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& value, const ResultFn& result) const -> tl::expected<Result, Error> override;
@@ -60,7 +60,7 @@ public:
 class CompletionAndExpr : public Expr
 {
 public:
-    CompletionAndExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
+    CompletionAndExpr(ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
@@ -73,7 +73,7 @@ public:
 class CompletionOrExpr : public Expr
 {
 public:
-    CompletionOrExpr(ExprId id, ExprPtr left, ExprPtr right, const Completion* comp);
+    CompletionOrExpr(ExprPtr left, ExprPtr right, const Completion* comp);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
@@ -86,7 +86,7 @@ public:
 class CompletionWordExpr : public Expr
 {
 public:
-    CompletionWordExpr(ExprId id, std::string prefix, Completion* comp, const Token& token);
+    CompletionWordExpr(std::string prefix, Completion* comp, const Token& token);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -253,6 +253,13 @@ auto Diagnostics::prepareIndices(const Expr& ast) -> void
             indices_[e.id()] = fieldIndex_++;
         }
 
+        auto visit(const WildcardFieldExpr& e) -> void override {
+            ExprVisitor::visit(e);
+            if (e.id() >= indices_.size())
+                indices_.resize(e.id() + 1, Diagnostics::InvalidIndex);
+            indices_[e.id()] = fieldIndex_++;
+        }
+
         auto visitComparisonOperator(const ComparisonExprBase& e) -> void
         {
             if (e.id() >= indices_.size())

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -59,6 +59,13 @@ auto Environment::strings() const -> std::shared_ptr<StringPool> {
     return stringPool;
 }
 
+auto Environment::querySchema(SchemaId schemaId) const -> const Schema*
+{
+    if (!querySchemaCallback || schemaId == NoSchemaId)
+        return nullptr;
+    return querySchemaCallback(schemaId);
+}
+
 Context::Context(Environment* env, Diagnostics* diag, Context::Phase phase)
     : env(env)
     , diag(diag)

--- a/src/expression-visitor.cpp
+++ b/src/expression-visitor.cpp
@@ -13,6 +13,10 @@ ExprVisitor::~ExprVisitor() = default;
 void ExprVisitor::visit(const Expr& e)
 {
     index_++;
+
+    const auto count = e.numChildren();
+    for (auto i = 0; i < count; ++i)
+        e.childAt(i)->accept(*this);
 }
 
 void ExprVisitor::visit(const WildcardExpr& expr)
@@ -38,58 +42,31 @@ void ExprVisitor::visit(const ConstExpr& expr)
 void ExprVisitor::visit(const SubscriptExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.index_)
-        expr.index_->accept(*this);
 }
 
 void ExprVisitor::visit(const SubExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.sub_)
-        expr.sub_->accept(*this);
 }
 
 void ExprVisitor::visit(const AnyExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
 }
 
 void ExprVisitor::visit(const EachExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
 }
 
 void ExprVisitor::visit(const CallExpression& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    for (const auto& arg : expr.args_)
-        if (arg)
-            arg->accept(*this);
 }
 
 void ExprVisitor::visit(const PathExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
 }
 
 void ExprVisitor::visit(const FieldExpr& expr)
@@ -97,50 +74,34 @@ void ExprVisitor::visit(const FieldExpr& expr)
     visit(static_cast<const Expr&>(expr));
 }
 
+void ExprVisitor::visit(const WildcardFieldExpr& expr)
+{
+    visit(static_cast<const Expr&>(expr));
+}
+
 void ExprVisitor::visit(const UnpackExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.sub_)
-        expr.sub_->accept(*this);
 }
 
 void ExprVisitor::visit(const UnaryWordOpExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
 }
 
 void ExprVisitor::visit(const BinaryWordOpExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
 }
 
 void ExprVisitor::visit(const AndExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
 }
 
 void ExprVisitor::visit(const OrExpr& expr)
 {
     visit(static_cast<const Expr&>(expr));
-
-    if (expr.left_)
-        expr.left_->accept(*this);
-    if (expr.right_)
-        expr.right_->accept(*this);
 }
 
 void ExprVisitor::visit(const BinaryExpr<OperatorEq>& e)

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -2,6 +2,8 @@
 
 #include "fmt/format.h"
 #include "simfil/environment.h"
+#include "simfil/expression.h"
+#include "simfil/model/string-pool.h"
 #include "simfil/result.h"
 #include "simfil/value.h"
 #include "simfil/function.h"
@@ -77,9 +79,7 @@ auto boolify(const Value& v) -> bool
 
 }
 
-WildcardExpr::WildcardExpr(ExprId id)
-    : Expr(id)
-{}
+WildcardExpr::WildcardExpr() = default;
 
 auto WildcardExpr::type() const -> Type
 {
@@ -143,9 +143,7 @@ auto WildcardExpr::toString() const -> std::string
     return "**"s;
 }
 
-AnyChildExpr::AnyChildExpr(ExprId id)
-    : Expr(id)
-{}
+AnyChildExpr::AnyChildExpr() = default;
 
 auto AnyChildExpr::type() const -> Type
 {
@@ -186,14 +184,12 @@ auto AnyChildExpr::toString() const -> std::string
     return "*"s;
 }
 
-FieldExpr::FieldExpr(ExprId id, std::string name)
-    : Expr(id)
-    , name_(std::move(name))
+FieldExpr::FieldExpr(std::string name)
+    : name_(std::move(name))
 {}
 
-FieldExpr::FieldExpr(ExprId id, std::string name, const Token& token)
-    : Expr(id, token)
-    , name_(std::move(name))
+FieldExpr::FieldExpr(std::string name, const Token& token)
+    : name_(std::move(name))
 {}
 
 auto FieldExpr::type() const -> Type
@@ -262,14 +258,12 @@ auto FieldExpr::toString() const -> std::string
     return name_;
 }
 
-MultiConstExpr::MultiConstExpr(ExprId id, const std::vector<Value>& vec)
-    : Expr(id)
-    , values_(vec)
+MultiConstExpr::MultiConstExpr(const std::vector<Value>& vec)
+    : values_(vec)
 {}
 
-MultiConstExpr::MultiConstExpr(ExprId id, std::vector<Value>&& vec)
-    : Expr(id)
-    , values_(std::move(vec))
+MultiConstExpr::MultiConstExpr(std::vector<Value>&& vec)
+    : values_(std::move(vec))
 {}
 
 auto MultiConstExpr::type() const -> Type
@@ -308,9 +302,8 @@ auto MultiConstExpr::toString() const -> std::string
     return fmt::format("{{{}}}", fmt::join(items, " "));
 }
 
-ConstExpr::ConstExpr(ExprId id, Value value)
-    : Expr(id)
-    , value_(std::move(value))
+ConstExpr::ConstExpr(Value value)
+    : value_(std::move(value))
 {}
 
 auto ConstExpr::type() const -> Type
@@ -345,9 +338,8 @@ auto ConstExpr::value() const -> const Value&
     return value_;
 }
 
-SubscriptExpr::SubscriptExpr(ExprId id, ExprPtr left, ExprPtr index)
-    : Expr(id)
-    , left_(std::move(left))
+SubscriptExpr::SubscriptExpr(ExprPtr left, ExprPtr index)
+    : left_(std::move(left))
     , index_(std::move(index))
 {}
 
@@ -400,14 +392,30 @@ void SubscriptExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto SubscriptExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto SubscriptExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return index_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
 auto SubscriptExpr::toString() const -> std::string
 {
     return fmt::format("(index {} {})", left_->toString(), index_->toString());
 }
 
-SubExpr::SubExpr(ExprId id, ExprPtr left, ExprPtr sub)
-    : Expr(id)
-    , left_(std::move(left))
+SubExpr::SubExpr(ExprPtr left, ExprPtr sub)
+    : left_(std::move(left))
     , sub_(std::move(sub))
 {}
 
@@ -453,9 +461,25 @@ void SubExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
-AnyExpr::AnyExpr(ExprId id, std::vector<ExprPtr> args)
-    : Expr(id)
-    , args_(std::move(args))
+auto SubExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto SubExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return sub_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
+AnyExpr::AnyExpr(std::vector<ExprPtr> args)
+    : args_(std::move(args))
 {}
 
 auto AnyExpr::type() const -> Type
@@ -497,6 +521,16 @@ auto AnyExpr::accept(ExprVisitor& v) const -> void
     v.visit(*this);
 }
 
+auto AnyExpr::numChildren() const -> std::size_t
+{
+    return args_.size();
+}
+
+auto AnyExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    return args_[index];
+}
+
 auto AnyExpr::toString() const -> std::string
 {
     if (args_.empty())
@@ -509,9 +543,8 @@ auto AnyExpr::toString() const -> std::string
     return fmt::format("(any {})", fmt::join(items, " "));
 }
 
-EachExpr::EachExpr(ExprId id, std::vector<ExprPtr> args)
-    : Expr(id)
-    , args_(std::move(args))
+EachExpr::EachExpr(std::vector<ExprPtr> args)
+    : args_(std::move(args))
 {}
 
 auto EachExpr::type() const -> Type
@@ -552,6 +585,16 @@ auto EachExpr::accept(ExprVisitor& v) const -> void
     v.visit(*this);
 }
 
+auto EachExpr::numChildren() const -> std::size_t
+{
+    return args_.size();
+}
+
+auto EachExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    return args_[index];
+}
+
 auto EachExpr::toString() const -> std::string
 {
     if (args_.empty())
@@ -564,9 +607,8 @@ auto EachExpr::toString() const -> std::string
     return fmt::format("(each {})", fmt::join(items, " "));
 }
 
-CallExpression::CallExpression(ExprId id, std::string name, std::vector<ExprPtr> args)
-    : Expr(id)
-    , name_(std::move(name))
+CallExpression::CallExpression(std::string name, std::vector<ExprPtr> args)
+    : name_(std::move(name))
     , args_(std::move(args))
 {}
 
@@ -606,6 +648,16 @@ void CallExpression::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto CallExpression::numChildren() const -> std::size_t
+{
+    return args_.size();
+}
+
+auto CallExpression::childAt(std::size_t index) -> ExprPtr&
+{
+    return args_[index];
+}
+
 auto CallExpression::toString() const -> std::string
 {
     if (args_.empty())
@@ -618,9 +670,8 @@ auto CallExpression::toString() const -> std::string
     return fmt::format("({} {})", name_, fmt::join(items, " "));
 }
 
-PathExpr::PathExpr(ExprId id, ExprPtr left, ExprPtr right)
-    : Expr(id)
-    , left_(std::move(left))
+PathExpr::PathExpr(ExprPtr left, ExprPtr right)
+    : left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -667,14 +718,30 @@ void PathExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto PathExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto PathExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return right_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
 auto PathExpr::toString() const -> std::string
 {
     return fmt::format("(. {} {})", left_->toString(), right_->toString());
 }
 
-UnpackExpr::UnpackExpr(ExprId id, ExprPtr sub)
-    : Expr(id)
-    , sub_(std::move(sub))
+UnpackExpr::UnpackExpr(ExprPtr sub)
+    : sub_(std::move(sub))
 {}
 
 auto UnpackExpr::type() const -> Type
@@ -717,14 +784,25 @@ void UnpackExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto UnpackExpr::numChildren() const -> std::size_t
+{
+    return 1;
+}
+
+auto UnpackExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    if (index == 0)
+        return sub_;
+    return Expr::childAt(index);
+}
+
 auto UnpackExpr::toString() const -> std::string
 {
     return fmt::format("(... {})", sub_->toString());
 }
 
-UnaryWordOpExpr::UnaryWordOpExpr(ExprId id, std::string ident, ExprPtr left)
-    : Expr(id)
-    , ident_(std::move(ident))
+UnaryWordOpExpr::UnaryWordOpExpr(std::string ident, ExprPtr left)
+    : ident_(std::move(ident))
     , left_(std::move(left))
 {}
 
@@ -756,14 +834,25 @@ void UnaryWordOpExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto UnaryWordOpExpr::numChildren() const -> std::size_t
+{
+    return 1;
+}
+
+auto UnaryWordOpExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    if (index == 0)
+        return left_;
+    return Expr::childAt(index);
+}
+
 auto UnaryWordOpExpr::toString() const -> std::string
 {
     return fmt::format("({} {})", ident_, left_->toString());
 }
 
-BinaryWordOpExpr::BinaryWordOpExpr(ExprId id, std::string ident, ExprPtr left, ExprPtr right)
-    : Expr(id)
-    , ident_(std::move(ident))
+BinaryWordOpExpr::BinaryWordOpExpr(std::string ident, ExprPtr left, ExprPtr right)
+    : ident_(std::move(ident))
     , left_(std::move(left))
     , right_(std::move(right))
 {}
@@ -806,14 +895,30 @@ void BinaryWordOpExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto BinaryWordOpExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto BinaryWordOpExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return right_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
 auto BinaryWordOpExpr::toString() const -> std::string
 {
     return fmt::format("({} {} {})", ident_, left_->toString(), right_->toString());
 }
 
-AndExpr::AndExpr(ExprId id, ExprPtr left, ExprPtr right)
-    : Expr(id)
-    , left_(std::move(left))
+AndExpr::AndExpr(ExprPtr left, ExprPtr right)
+    : left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -850,14 +955,30 @@ void AndExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto AndExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto AndExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return right_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
 auto AndExpr::toString() const -> std::string
 {
     return fmt::format("(and {} {})", left_->toString(), right_->toString());
 }
 
-OrExpr::OrExpr(ExprId id, ExprPtr left, ExprPtr right)
-    : Expr(id)
-    , left_(std::move(left))
+OrExpr::OrExpr(ExprPtr left, ExprPtr right)
+    : left_(std::move(left))
     , right_(std::move(right))
 {
     assert(left_.get());
@@ -895,9 +1016,135 @@ void OrExpr::accept(ExprVisitor& v) const
     v.visit(*this);
 }
 
+auto OrExpr::numChildren() const -> std::size_t
+{
+    return 2;
+}
+
+auto OrExpr::childAt(std::size_t index) -> ExprPtr&
+{
+    switch (index) {
+    case 0:
+        return left_;
+    case 1:
+        return right_;
+    default:
+        return Expr::childAt(index);
+    }
+}
+
 auto OrExpr::toString() const -> std::string
 {
     return fmt::format("(or {} {})", left_->toString(), right_->toString());
+}
+
+WildcardFieldExpr::WildcardFieldExpr(std::string name, SourceLocation location)
+    : Expr(location)
+    , name_(std::move(name))
+{}
+
+auto WildcardFieldExpr::type() const -> Type
+{
+    return Type::PATH;
+}
+
+auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error>
+{
+    if (ctx.phase == Context::Phase::Compilation)
+        return ores(ctx, Value::undef());
+
+    CountedResultFn<const ResultFn&> res(ores, ctx);
+
+    Diagnostics::FieldExprData* diag = nullptr;
+    if (ctx.diag)
+        diag = &ctx.diag->get<Diagnostics::FieldExprData>(*this);
+
+    if (diag) {
+        diag->location = sourceLocation();
+        if (diag->name.empty())
+            diag->name = name_;
+    }
+
+    // Querying a field not in the string-pool
+    // is a no-op here (not true for FieldExpr).
+    if (!nameId_) {
+        nameId_ = ctx.env->strings()->get(name_);
+        if (!nameId_) {
+            if (diag)
+                diag->evaluations++;
+            res.ensureCall();
+            return {Result::Continue};
+        }
+    }
+
+    struct Iterate
+    {
+        Context& ctx;
+        ResultFn& res;
+        StringId field;
+        Diagnostics::FieldExprData* diag;
+
+        [[nodiscard]] auto iterate(ModelNode const& val) noexcept -> tl::expected<Result, Error>
+        {
+            if (field == StringPool::StaticStringIds::Empty)
+                return Result::Continue;
+
+            if (val.type() == ValueType::Null) [[unlikely]]
+                return Result::Continue;
+
+            if (auto* schema = ctx.env->querySchema(val.schema())) {
+                if (!schema->canHaveField(field))
+                    return Result::Continue;
+            }
+
+            if (diag)
+                diag->evaluations++;
+
+            if (auto sub = val.get(field)) {
+                if (diag)
+                    diag->hits++;
+
+                auto result = res(ctx, Value::field(*sub));
+                TRY_EXPECTED(result);
+                if (*result == Result::Stop) [[unlikely]]
+                    return *result;
+            }
+
+            tl::expected<Result, Error> finalResult = Result::Continue;
+            val.iterate(ModelNode::IterLambda([&, this](const auto& subNode) {
+                auto subResult = iterate(subNode);
+                if (!subResult) {
+                    finalResult = std::move(subResult);
+                    return false;
+                }
+
+                if (*subResult == Result::Stop) {
+                    finalResult = Result::Stop;
+                    return false;
+                }
+
+                return true;
+            }));
+
+            return finalResult;
+        }
+    };
+
+    auto r = val.nodePtr()
+        ? Iterate{ctx, res, nameId_, diag}.iterate(**val.nodePtr())
+        : tl::expected<Result, Error>(Result::Continue);
+    res.ensureCall();
+    return r;
+}
+
+void WildcardFieldExpr::accept(ExprVisitor& v) const
+{
+    v.visit(*this);
+}
+
+auto WildcardFieldExpr::toString() const -> std::string
+{
+    return fmt::format("**.{}", name_);
 }
 
 }

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -5,6 +5,7 @@
 #include "simfil/expression.h"
 #include "simfil/model/string-pool.h"
 #include "simfil/result.h"
+#include "simfil/sourcelocation.h"
 #include "simfil/value.h"
 #include "simfil/function.h"
 #include "simfil/diagnostics.h"
@@ -80,6 +81,10 @@ auto boolify(const Value& v) -> bool
 }
 
 WildcardExpr::WildcardExpr() = default;
+
+WildcardExpr::WildcardExpr(SourceLocation location)
+    : Expr(location)
+{}
 
 auto WildcardExpr::type() const -> Type
 {
@@ -254,6 +259,16 @@ void FieldExpr::accept(ExprVisitor& v) const
 }
 
 auto FieldExpr::toString() const -> std::string
+{
+    return name_;
+}
+
+auto FieldExpr::isCurrent() const -> bool
+{
+    return name_ == "_";
+}
+
+auto FieldExpr::field() const -> std::string
 {
     return name_;
 }
@@ -740,6 +755,26 @@ auto PathExpr::toString() const -> std::string
     return fmt::format("(. {} {})", left_->toString(), right_->toString());
 }
 
+auto PathExpr::left() -> Expr*
+{
+    return left_.get();
+}
+
+auto PathExpr::left() const -> const Expr*
+{
+    return left_.get();
+}
+
+auto PathExpr::right() -> Expr*
+{
+    return right_.get();
+}
+
+auto PathExpr::right() const -> const Expr*
+{
+    return right_.get();
+}
+
 UnpackExpr::UnpackExpr(ExprPtr sub)
     : sub_(std::move(sub))
 {}
@@ -1038,8 +1073,9 @@ auto OrExpr::toString() const -> std::string
     return fmt::format("(or {} {})", left_->toString(), right_->toString());
 }
 
-WildcardFieldExpr::WildcardFieldExpr(std::string name, SourceLocation location)
+WildcardFieldExpr::WildcardFieldExpr(bool recurse, std::string name, SourceLocation location)
     : Expr(location)
+    , recurse_(recurse)
     , name_(std::move(name))
 {}
 
@@ -1083,24 +1119,34 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
         ResultFn& res;
         StringId field;
         Diagnostics::FieldExprData* diag;
+        size_t maxDepth = 0; // 0 = recurse inf.
+        bool pruneRoot = true;
 
-        [[nodiscard]] auto iterate(ModelNode const& val) noexcept -> tl::expected<Result, Error>
+        [[nodiscard]] auto iterate(ModelNode const& val, size_t depth) noexcept -> tl::expected<Result, Error>
         {
+            if (maxDepth > 0 && depth > maxDepth) {
+                return Result::Continue;
+            }
+
             if (field == StringPool::StaticStringIds::Empty)
                 return Result::Continue;
 
             if (val.type() == ValueType::Null) [[unlikely]]
                 return Result::Continue;
 
-            if (auto* schema = ctx.env->querySchema(val.schema())) {
-                if (!schema->canHaveField(field))
-                    return Result::Continue;
+            // `*.field` still needs to inspect immediate children even when the
+            // current node's schema is partial and cannot prove descendant fields.
+            if ((depth > 0 || pruneRoot)) {
+                if (auto* schema = ctx.env->querySchema(val.schema())) {
+                    if (!schema->canHaveField(field))
+                        return Result::Continue;
+                }
             }
 
             if (diag)
                 diag->evaluations++;
 
-            if (auto sub = val.get(field)) {
+            if (auto sub = val.get(field); sub && (maxDepth == 0 || depth > 0)) {
                 if (diag)
                     diag->hits++;
 
@@ -1112,7 +1158,7 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
 
             tl::expected<Result, Error> finalResult = Result::Continue;
             val.iterate(ModelNode::IterLambda([&, this](const auto& subNode) {
-                auto subResult = iterate(subNode);
+                auto subResult = iterate(subNode, depth + 1);
                 if (!subResult) {
                     finalResult = std::move(subResult);
                     return false;
@@ -1131,7 +1177,7 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
     };
 
     auto r = val.nodePtr()
-        ? Iterate{ctx, res, nameId_, diag}.iterate(**val.nodePtr())
+        ? Iterate{ctx, res, nameId_, diag, recurse_ ? 0ul : 1ul, recurse_}.iterate(**val.nodePtr(), 0)
         : tl::expected<Result, Error>(Result::Continue);
     res.ensureCall();
     return r;
@@ -1144,7 +1190,7 @@ void WildcardFieldExpr::accept(ExprVisitor& v) const
 
 auto WildcardFieldExpr::toString() const -> std::string
 {
-    return fmt::format("**.{}", name_);
+    return fmt::format("{}.{}", recurse_ ? "**" : "*", name_);
 }
 
 }

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -1281,10 +1281,17 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
             if (!schema)
                 return {};
 
-            if (const auto* plan = expr.schemaPlan(ctx, schemaId, *schema))
-                return {plan->canHaveField, plan};
+            if (ctx.env->enableWildcardFieldPlans) {
+                if (const auto* plan = expr.schemaPlan(ctx, schemaId, *schema))
+                    return {plan->canHaveField, plan};
+            }
 
-            return {schema->canHaveField(field), nullptr};
+            // This is the original schema-pruning path: the current node can be
+            // rejected, but child iteration is still generic when it may match.
+            if (schema->canHaveField(field))
+                return {};
+
+            return {false, nullptr};
         }
 
         [[nodiscard]] static auto matchingPlan(const SchemaPlan* plan, ValueType valType) noexcept -> const SchemaPlan*

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -194,7 +194,8 @@ FieldExpr::FieldExpr(std::string name)
 {}
 
 FieldExpr::FieldExpr(std::string name, const Token& token)
-    : name_(std::move(name))
+    : Expr(token)
+    , name_(std::move(name))
 {}
 
 auto FieldExpr::type() const -> Type
@@ -414,14 +415,12 @@ auto SubscriptExpr::numChildren() const -> std::size_t
 
 auto SubscriptExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return index_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, index_);
+}
+
+auto SubscriptExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, index_);
 }
 
 auto SubscriptExpr::toString() const -> std::string
@@ -483,14 +482,12 @@ auto SubExpr::numChildren() const -> std::size_t
 
 auto SubExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return sub_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, sub_);
+}
+
+auto SubExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, sub_);
 }
 
 AnyExpr::AnyExpr(std::vector<ExprPtr> args)
@@ -543,7 +540,12 @@ auto AnyExpr::numChildren() const -> std::size_t
 
 auto AnyExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    return args_[index];
+    return detail::childAtOrThrow(index, args_);
+}
+
+auto AnyExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, args_);
 }
 
 auto AnyExpr::toString() const -> std::string
@@ -607,7 +609,12 @@ auto EachExpr::numChildren() const -> std::size_t
 
 auto EachExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    return args_[index];
+    return detail::childAtOrThrow(index, args_);
+}
+
+auto EachExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, args_);
 }
 
 auto EachExpr::toString() const -> std::string
@@ -670,7 +677,12 @@ auto CallExpression::numChildren() const -> std::size_t
 
 auto CallExpression::childAt(std::size_t index) -> ExprPtr&
 {
-    return args_[index];
+    return detail::childAtOrThrow(index, args_);
+}
+
+auto CallExpression::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, args_);
 }
 
 auto CallExpression::toString() const -> std::string
@@ -740,14 +752,12 @@ auto PathExpr::numChildren() const -> std::size_t
 
 auto PathExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return right_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, right_);
+}
+
+auto PathExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, right_);
 }
 
 auto PathExpr::toString() const -> std::string
@@ -826,9 +836,12 @@ auto UnpackExpr::numChildren() const -> std::size_t
 
 auto UnpackExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    if (index == 0)
-        return sub_;
-    return Expr::childAt(index);
+    return detail::childAtOrThrow(index, sub_);
+}
+
+auto UnpackExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, sub_);
 }
 
 auto UnpackExpr::toString() const -> std::string
@@ -876,9 +889,12 @@ auto UnaryWordOpExpr::numChildren() const -> std::size_t
 
 auto UnaryWordOpExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    if (index == 0)
-        return left_;
-    return Expr::childAt(index);
+    return detail::childAtOrThrow(index, left_);
+}
+
+auto UnaryWordOpExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_);
 }
 
 auto UnaryWordOpExpr::toString() const -> std::string
@@ -937,14 +953,12 @@ auto BinaryWordOpExpr::numChildren() const -> std::size_t
 
 auto BinaryWordOpExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return right_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, right_);
+}
+
+auto BinaryWordOpExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, right_);
 }
 
 auto BinaryWordOpExpr::toString() const -> std::string
@@ -997,14 +1011,12 @@ auto AndExpr::numChildren() const -> std::size_t
 
 auto AndExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return right_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, right_);
+}
+
+auto AndExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, right_);
 }
 
 auto AndExpr::toString() const -> std::string
@@ -1058,14 +1070,12 @@ auto OrExpr::numChildren() const -> std::size_t
 
 auto OrExpr::childAt(std::size_t index) -> ExprPtr&
 {
-    switch (index) {
-    case 0:
-        return left_;
-    case 1:
-        return right_;
-    default:
-        return Expr::childAt(index);
-    }
+    return detail::childAtOrThrow(index, left_, right_);
+}
+
+auto OrExpr::childAt(std::size_t index) const -> const ExprPtr&
+{
+    return detail::childAtOrThrow(index, left_, right_);
 }
 
 auto OrExpr::toString() const -> std::string
@@ -1075,8 +1085,8 @@ auto OrExpr::toString() const -> std::string
 
 WildcardFieldExpr::WildcardFieldExpr(bool recurse, std::string name, SourceLocation location)
     : Expr(location)
-    , recurse_(recurse)
     , name_(std::move(name))
+    , recurse_(recurse)
 {}
 
 auto WildcardFieldExpr::type() const -> Type

--- a/src/expressions.cpp
+++ b/src/expressions.cpp
@@ -4,6 +4,7 @@
 #include "simfil/environment.h"
 #include "simfil/expression.h"
 #include "simfil/model/string-pool.h"
+#include "simfil/model/schema.h"
 #include "simfil/result.h"
 #include "simfil/sourcelocation.h"
 #include "simfil/value.h"
@@ -13,6 +14,7 @@
 #include "fmt/core.h"
 #include "fmt/ranges.h"
 #include "src/expected.h"
+#include <algorithm>
 #include <memory>
 #include <ranges>
 
@@ -105,7 +107,8 @@ auto WildcardExpr::ieval(Context ctx, const Value& val, const ResultFn& ores) co
 
         [[nodiscard]] auto iterate(ModelNode const& val) noexcept -> tl::expected<Result, Error>
         {
-            if (val.type() == ValueType::Null) [[unlikely]]
+            const auto valType = val.type();
+            if (valType == ValueType::Null) [[unlikely]]
                 return Result::Continue;
 
             auto result = res(ctx, Value::field(val));
@@ -1089,6 +1092,98 @@ WildcardFieldExpr::WildcardFieldExpr(bool recurse, std::string name, SourceLocat
     , recurse_(recurse)
 {}
 
+auto WildcardFieldExpr::childSchemaMayHaveField(const Context& ctx, SchemaId schemaId) const -> bool
+{
+    if (schemaId == NoSchemaId)
+        return true;
+
+    const auto* childSchema = ctx.env->querySchema(schemaId);
+    if (!childSchema || !childSchema->finalized())
+        return true;
+
+    return childSchema->canHaveField(nameId_);
+}
+
+auto WildcardFieldExpr::buildObjectSchemaPlan(const Context& ctx, const ObjectSchema& schema) const -> SchemaPlan
+{
+    SchemaPlan plan;
+    plan.kind = SchemaPlan::Kind::Object;
+    plan.directField = false;
+
+    for (const auto& field : schema.fields()) {
+        if (field.field == nameId_)
+            plan.directField = true;
+
+        const auto descendsToTarget = field.schemas.empty()
+            || std::ranges::any_of(field.schemas, [this, &ctx](auto schemaId) {
+                return childSchemaMayHaveField(ctx, schemaId);
+            });
+        if (descendsToTarget)
+            plan.objectChildFields.push_back(field.field);
+    }
+
+    std::ranges::sort(plan.objectChildFields);
+    auto duplicates = std::ranges::unique(plan.objectChildFields);
+    plan.objectChildFields.erase(duplicates.begin(), duplicates.end());
+
+    const auto fieldCount = schema.fields().size();
+    const auto sparseChildPlan = plan.objectChildFields.size() * 2 < fieldCount;
+    const auto skipsLargeDirectLookup = !plan.directField && fieldCount > 4;
+    if (!sparseChildPlan && !skipsLargeDirectLookup) {
+        plan.kind = SchemaPlan::Kind::Unknown;
+        plan.directField = true;
+        plan.objectChildFields.clear();
+    }
+
+    return plan;
+}
+
+auto WildcardFieldExpr::buildSchemaPlan(const Context& ctx, const Schema& schema) const -> SchemaPlan
+{
+    SchemaPlan plan;
+    plan.canHaveField = schema.canHaveField(nameId_);
+    if (!plan.canHaveField) {
+        plan.directField = false;
+        return plan;
+    }
+
+    if (schema.kind() == Schema::Kind::Object) {
+        if (const auto* objectSchema = dynamic_cast<const ObjectSchema*>(&schema))
+            return buildObjectSchemaPlan(ctx, *objectSchema);
+        return plan;
+    }
+
+    if (schema.kind() == Schema::Kind::Array) {
+        if (dynamic_cast<const ArraySchema*>(&schema))
+            plan.kind = SchemaPlan::Kind::Array;
+        plan.directField = false;
+    }
+
+    return plan;
+}
+
+auto WildcardFieldExpr::schemaPlan(const Context& ctx, SchemaId schemaId, const Schema& schema) const -> const SchemaPlan*
+{
+    if (schemaId == NoSchemaId || !schema.finalized())
+        return nullptr;
+
+    const auto planIndex = static_cast<std::size_t>(schemaId);
+    const auto schemaRevision = schema.revision();
+    if (planIndex < schemaPlans_.size()) {
+        const auto& cachedPlan = schemaPlans_[planIndex];
+        if (cachedPlan && cachedPlan->schema == &schema && cachedPlan->schemaRevision == schemaRevision)
+            return &cachedPlan->plan;
+    }
+
+    if (schemaPlans_.size() <= planIndex)
+        schemaPlans_.resize(planIndex + 1);
+    auto plan = buildSchemaPlan(ctx, schema);
+    schemaPlans_[planIndex] = std::make_unique<CachedSchemaPlan>(
+        CachedSchemaPlan{schemaId, &schema, schemaRevision, std::move(plan)});
+
+    return &schemaPlans_[planIndex]->plan;
+}
+
 auto WildcardFieldExpr::type() const -> Type
 {
     return Type::PATH;
@@ -1127,10 +1222,16 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
     {
         Context& ctx;
         ResultFn& res;
+        const WildcardFieldExpr& expr;
         StringId field;
         Diagnostics::FieldExprData* diag;
         size_t maxDepth = 0; // 0 = recurse inf.
         bool pruneRoot = true;
+
+        struct SchemaDecision {
+            bool canHaveField = true;
+            const SchemaPlan* plan = nullptr;
+        };
 
         [[nodiscard]] auto iterate(ModelNode const& val, size_t depth) noexcept -> tl::expected<Result, Error>
         {
@@ -1141,31 +1242,120 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
             if (field == StringPool::StaticStringIds::Empty)
                 return Result::Continue;
 
-            if (val.type() == ValueType::Null) [[unlikely]]
+            const auto valType = val.type();
+            if (valType == ValueType::Null) [[unlikely]]
                 return Result::Continue;
 
-            // `*.field` still needs to inspect immediate children even when the
-            // current node's schema is partial and cannot prove descendant fields.
-            if ((depth > 0 || pruneRoot)) {
-                if (auto* schema = ctx.env->querySchema(val.schema())) {
-                    if (!schema->canHaveField(field))
-                        return Result::Continue;
-                }
-            }
+            const auto schemaDecision = decideBySchema(val, depth);
+            if (!schemaDecision.canHaveField)
+                return Result::Continue;
 
             if (diag)
                 diag->evaluations++;
 
-            if (auto sub = val.get(field); sub && (maxDepth == 0 || depth > 0)) {
-                if (diag)
-                    diag->hits++;
+            const auto plan = matchingPlan(schemaDecision.plan, valType);
+            auto directResult = emitDirectField(val, plan, depth);
+            TRY_EXPECTED(directResult);
+            if (*directResult == Result::Stop)
+                return Result::Stop;
 
-                auto result = res(ctx, Value::field(*sub));
-                TRY_EXPECTED(result);
-                if (*result == Result::Stop) [[unlikely]]
-                    return *result;
+            // Once the requested non-recursive depth has been processed, avoid
+            // descending just to let the next call reject the child by depth.
+            if (maxDepth > 0 && depth >= maxDepth)
+                return Result::Continue;
+
+            if (plan && plan->kind == SchemaPlan::Kind::Object) {
+                return iterateObjectFields(val, *plan, depth);
             }
 
+            return iterateAllChildren(val, depth);
+        }
+
+        [[nodiscard]] auto decideBySchema(ModelNode const& val, size_t depth) const noexcept -> SchemaDecision
+        {
+            if (!(depth > 0 || pruneRoot))
+                return {};
+
+            const auto schemaId = val.schema();
+            const auto* schema = ctx.env->querySchema(schemaId);
+            if (!schema)
+                return {};
+
+            if (const auto* plan = expr.schemaPlan(ctx, schemaId, *schema))
+                return {plan->canHaveField, plan};
+
+            return {schema->canHaveField(field), nullptr};
+        }
+
+        [[nodiscard]] static auto matchingPlan(const SchemaPlan* plan, ValueType valType) noexcept -> const SchemaPlan*
+        {
+            if (!plan)
+                return nullptr;
+
+            if (plan->kind == SchemaPlan::Kind::Object && valType == ValueType::Object)
+                return plan;
+
+            if (plan->kind == SchemaPlan::Kind::Array && valType == ValueType::Array)
+                return plan;
+
+            return nullptr;
+        }
+
+        [[nodiscard]] auto emitDirectField(ModelNode const& val,
+                                           const SchemaPlan* plan,
+                                           size_t depth) noexcept -> tl::expected<Result, Error>
+        {
+            const auto directFieldPossible = !plan
+                || (plan->kind == SchemaPlan::Kind::Object && plan->directField);
+            if (!directFieldPossible || (maxDepth > 0 && depth == 0))
+                return Result::Continue;
+
+            auto sub = val.get(field);
+            if (!sub)
+                return Result::Continue;
+
+            if (diag)
+                diag->hits++;
+
+            auto result = res(ctx, Value::field(*sub));
+            TRY_EXPECTED(result);
+            return *result;
+        }
+
+        [[nodiscard]] auto iterateObjectFields(ModelNode const& val,
+                                               const SchemaPlan& plan,
+                                               size_t depth) noexcept -> tl::expected<Result, Error>
+        {
+            if (plan.objectChildFields.empty())
+                return Result::Continue;
+
+            // For dense plans the normal iterator is cheaper because it resolves
+            // each child once and lets that child's schema reject irrelevant paths.
+            if (plan.objectChildFields.size() * 2 >= val.size())
+                return iterateAllChildren(val, depth);
+
+            tl::expected<Result, Error> finalResult = Result::Continue;
+            for (auto i = 0u; i < val.size(); ++i) {
+                if (!std::ranges::binary_search(plan.objectChildFields, val.keyAt(i)))
+                    continue;
+
+                auto child = val.at(i);
+                if (!child)
+                    continue;
+
+                auto subResult = iterate(*child, depth + 1);
+                if (!subResult)
+                    return subResult;
+
+                if (*subResult == Result::Stop)
+                    return Result::Stop;
+            }
+
+            return finalResult;
+        }
+
+        [[nodiscard]] auto iterateAllChildren(ModelNode const& val, size_t depth) noexcept -> tl::expected<Result, Error>
+        {
             tl::expected<Result, Error> finalResult = Result::Continue;
             val.iterate(ModelNode::IterLambda([&, this](const auto& subNode) {
                 auto subResult = iterate(subNode, depth + 1);
@@ -1187,7 +1377,7 @@ auto WildcardFieldExpr::ieval(Context ctx, const Value& val, const ResultFn& ore
     };
 
     auto r = val.nodePtr()
-        ? Iterate{ctx, res, nameId_, diag, recurse_ ? 0ul : 1ul, recurse_}.iterate(**val.nodePtr(), 0)
+        ? Iterate{ctx, res, *this, nameId_, diag, recurse_ ? 0ul : 1ul, recurse_}.iterate(**val.nodePtr(), 0)
         : tl::expected<Result, Error>(Result::Continue);
     res.ensureCall();
     return r;

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -76,6 +76,7 @@ class ConstExpr : public Expr
 public:
     ConstExpr() = delete;
     template <class CType_>
+    requires (!std::derived_from<std::remove_cvref_t<CType_>, ConstExpr>)
     explicit ConstExpr(CType_&& value)
         : value_(Value::make(std::forward<CType_>(value)))
     {}

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -15,7 +15,7 @@ namespace simfil
 class WildcardExpr : public Expr
 {
 public:
-    explicit WildcardExpr(ExprId);
+    WildcardExpr();
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
@@ -29,7 +29,7 @@ public:
 class AnyChildExpr : public Expr
 {
 public:
-    explicit AnyChildExpr(ExprId);
+    AnyChildExpr();
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
@@ -40,8 +40,8 @@ public:
 class FieldExpr : public Expr
 {
 public:
-    FieldExpr(ExprId id, std::string name);
-    FieldExpr(ExprId id, std::string name, const Token& token);
+    explicit FieldExpr(std::string name);
+    FieldExpr(std::string name, const Token& token);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
@@ -59,8 +59,8 @@ public:
     static constexpr size_t Limit = 10000;
 
     MultiConstExpr() = delete;
-    MultiConstExpr(ExprId id, const std::vector<Value>& vec);
-    MultiConstExpr(ExprId id, std::vector<Value>&& vec);
+    explicit MultiConstExpr(const std::vector<Value>& vec);
+    explicit MultiConstExpr(std::vector<Value>&& vec);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
@@ -76,11 +76,10 @@ class ConstExpr : public Expr
 public:
     ConstExpr() = delete;
     template <class CType_>
-    ConstExpr(ExprId id, CType_&& value)
-        : Expr(id)
-        , value_(Value::make(std::forward<CType_>(value)))
+    explicit ConstExpr(CType_&& value)
+        : value_(Value::make(std::forward<CType_>(value)))
     {}
-    ConstExpr(ExprId id, Value value);
+    explicit ConstExpr(Value value);
 
     auto type() const -> Type override;
     auto constant() const -> bool override;
@@ -97,11 +96,13 @@ protected:
 class SubscriptExpr : public Expr
 {
 public:
-    SubscriptExpr(ExprId id, ExprPtr left, ExprPtr index);
+    SubscriptExpr(ExprPtr left, ExprPtr index);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_;
@@ -111,12 +112,14 @@ public:
 class SubExpr : public Expr
 {
 public:
-    SubExpr(ExprId id, ExprPtr left, ExprPtr sub);
+    SubExpr(ExprPtr left, ExprPtr sub);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
     auto ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, sub_;
@@ -125,11 +128,13 @@ public:
 class AnyExpr : public Expr
 {
 public:
-    AnyExpr(ExprId id, std::vector<ExprPtr> args);
+    explicit AnyExpr(std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
@@ -138,11 +143,13 @@ public:
 class EachExpr : public Expr
 {
 public:
-    EachExpr(ExprId id, std::vector<ExprPtr> args);
+    explicit EachExpr(std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
@@ -151,12 +158,14 @@ public:
 class CallExpression : public Expr
 {
 public:
-    CallExpression(ExprId id, std::string name, std::vector<ExprPtr> args);
+    CallExpression(std::string name, std::vector<ExprPtr> args);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     auto ieval(Context ctx, Value&& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string name_;
@@ -167,12 +176,14 @@ public:
 class PathExpr : public Expr
 {
 public:
-    PathExpr(ExprId id, ExprPtr left, ExprPtr right);
+    PathExpr(ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
     auto ieval(Context ctx, Value&& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -186,11 +197,13 @@ public:
 class UnpackExpr : public Expr
 {
 public:
-    UnpackExpr(ExprId id, ExprPtr sub);
+    explicit UnpackExpr(ExprPtr sub);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr sub_;
@@ -203,9 +216,8 @@ template <class Operator>
 class UnaryExpr : public Expr
 {
 public:
-    UnaryExpr(ExprId id, ExprPtr sub)
-        : Expr(id)
-        , sub_(std::move(sub))
+    explicit UnaryExpr(ExprPtr sub)
+        : sub_(std::move(sub))
     {}
 
     auto type() const -> Type override
@@ -223,10 +235,22 @@ public:
         }));
     }
 
-    void accept(ExprVisitor& v) const override
+    auto accept(ExprVisitor& v) const -> void override
     {
         v.visit(*this);
         sub_->accept(v);
+    }
+
+    auto numChildren() const -> std::size_t override
+    {
+        return 1;
+    }
+
+    auto childAt(std::size_t index) -> ExprPtr& override
+    {
+        if (index == 0)
+            return sub_;
+        return Expr::childAt(index);
     }
 
     auto toString() const -> std::string override
@@ -244,15 +268,13 @@ template <class Operator>
 class BinaryExpr : public Expr
 {
 public:
-    BinaryExpr(ExprId id, ExprPtr left, ExprPtr right)
-        : Expr(id)
-        , left_(std::move(left))
+    BinaryExpr(ExprPtr left, ExprPtr right)
+        : left_(std::move(left))
         , right_(std::move(right))
     {}
 
-    BinaryExpr(ExprId id, const Token& token, ExprPtr left, ExprPtr right)
-        : Expr(id, token)
-        , left_(std::move(left))
+    BinaryExpr(const Token& token, ExprPtr left, ExprPtr right)
+        : left_(std::move(left))
         , right_(std::move(right))
     {}
 
@@ -273,11 +295,26 @@ public:
         }));
     }
 
-    void accept(ExprVisitor& v) const override
+    auto accept(ExprVisitor& v) const -> void override
     {
         v.visit(*this);
-        left_->accept(v);
-        right_->accept(v);
+    }
+
+    auto numChildren() const -> std::size_t override
+    {
+        return 2;
+    }
+
+    auto childAt(std::size_t index) -> ExprPtr& override
+    {
+        switch (index) {
+        case 0:
+            return left_;
+        case 1:
+            return right_;
+        default:
+            return Expr::childAt(index);
+        }
     }
 
     auto toString() const -> std::string override
@@ -292,14 +329,13 @@ class ComparisonExprBase : public Expr
 {
 public:
 
-    ComparisonExprBase(ExprId id, ExprPtr left, ExprPtr right)
-        : Expr(id)
-        , left_(std::move(left))
+    ComparisonExprBase(ExprPtr left, ExprPtr right)
+        : left_(std::move(left))
         , right_(std::move(right))
     {}
 
-    ComparisonExprBase(ExprId id, const Token& token, ExprPtr left, ExprPtr right)
-        : Expr(id, token)
+    ComparisonExprBase(const Token& token, ExprPtr left, ExprPtr right)
+        : Expr(token)
         , left_(std::move(left))
         , right_(std::move(right))
     {}
@@ -307,6 +343,23 @@ public:
     auto type() const -> Type override
     {
         return Type::VALUE;
+    }
+
+    auto numChildren() const -> std::size_t override
+    {
+        return 2;
+    }
+
+    auto childAt(std::size_t index) -> ExprPtr& override
+    {
+        switch (index) {
+        case 0:
+            return left_;
+        case 1:
+            return right_;
+        default:
+            return Expr::childAt(index);
+        }
     }
 
     ExprPtr left_, right_;
@@ -352,11 +405,9 @@ public:
         }));
     }
 
-    void accept(ExprVisitor& v) const override
+    auto accept(ExprVisitor& v) const -> void override
     {
         v.visit(static_cast<const Child&>(*this));
-        left_->accept(v);
-        right_->accept(v);
     }
 
     auto toString() const -> std::string override
@@ -404,11 +455,13 @@ class BinaryExpr<OperatorGtEq> : public ComparisonExpr<OperatorGtEq, BinaryExpr<
 class UnaryWordOpExpr : public Expr
 {
 public:
-    UnaryWordOpExpr(ExprId id, std::string ident, ExprPtr left);
+    UnaryWordOpExpr(std::string ident, ExprPtr left);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -418,11 +471,13 @@ public:
 class BinaryWordOpExpr : public Expr
 {
 public:
-    BinaryWordOpExpr(ExprId id, std::string ident, ExprPtr left, ExprPtr right);
+    BinaryWordOpExpr(std::string ident, ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -432,11 +487,13 @@ public:
 class AndExpr : public Expr
 {
 public:
-    AndExpr(ExprId id, ExprPtr left, ExprPtr right);
+    AndExpr(ExprPtr left, ExprPtr right);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -445,14 +502,33 @@ public:
 class OrExpr : public Expr
 {
 public:
-    OrExpr(ExprId id, ExprPtr left, ExprPtr right);
+    OrExpr(ExprPtr left, ExprPtr right);
+
+    auto type() const -> Type override;
+    auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
+    void accept(ExprVisitor& v) const override;
+    auto numChildren() const -> std::size_t override;
+    auto childAt(std::size_t index) -> ExprPtr& override;
+    auto toString() const -> std::string override;
+
+    ExprPtr left_, right_;
+};
+
+/** A specialized expression for queries of the form `**.field`, that
+ *  takes object schema information into account.
+ */
+class WildcardFieldExpr : public Expr
+{
+public:
+    explicit WildcardFieldExpr(std::string name, SourceLocation location = {});
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
     void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
-    ExprPtr left_, right_;
+    std::string name_;
+    mutable StringId nameId_ = {};
 };
 
 }

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -5,17 +5,21 @@
 #include "simfil/operator.h"
 #include "simfil/diagnostics.h"
 #include "simfil/expression-visitor.h"
+#include "simfil/sourcelocation.h"
 
-#include <cstdint>
 #include <string>
 
 namespace simfil
 {
 
+/**
+ * Returns the current node and every child of it recursively.
+ */
 class WildcardExpr : public Expr
 {
 public:
     WildcardExpr();
+    explicit WildcardExpr(SourceLocation location);
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& ores) const -> tl::expected<Result, Error> override;
@@ -49,6 +53,10 @@ public:
     void accept(ExprVisitor& v) const override;
     auto toString() const -> std::string override;
 
+    /** Returns true if this field is "_" */
+    auto isCurrent() const -> bool;
+    auto field() const -> std::string;
+
     std::string name_;
     mutable StringId nameId_ = {};
 };
@@ -75,11 +83,13 @@ class ConstExpr : public Expr
 {
 public:
     ConstExpr() = delete;
+
     template <class CType_>
     requires (!std::derived_from<std::remove_cvref_t<CType_>, ConstExpr>)
     explicit ConstExpr(CType_&& value)
         : value_(Value::make(std::forward<CType_>(value)))
     {}
+
     explicit ConstExpr(Value value);
 
     auto type() const -> Type override;
@@ -186,6 +196,11 @@ public:
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
     auto toString() const -> std::string override;
+
+    auto left() -> Expr*;
+    auto left() const -> const Expr*;
+    auto right() -> Expr*;
+    auto right() const -> const Expr*;
 
     ExprPtr left_, right_;
 };
@@ -515,13 +530,16 @@ public:
     ExprPtr left_, right_;
 };
 
-/** A specialized expression for queries of the form `**.field`, that
- *  takes object schema information into account.
+/**
+ * A specialized expression for queries of the form `**.field`, that
+ * takes object schema information into account.
+ *
+ * Special form of `WildcardExpr`.
  */
 class WildcardFieldExpr : public Expr
 {
 public:
-    explicit WildcardFieldExpr(std::string name, SourceLocation location = {});
+    explicit WildcardFieldExpr(bool recurse, std::string name, SourceLocation location = {});
 
     auto type() const -> Type override;
     auto ieval(Context ctx, const Value& val, const ResultFn& res) const -> tl::expected<Result, Error> override;
@@ -530,6 +548,7 @@ public:
 
     std::string name_;
     mutable StringId nameId_ = {};
+    const bool recurse_ = {};
 };
 
 }

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -7,10 +7,47 @@
 #include "simfil/expression-visitor.h"
 #include "simfil/sourcelocation.h"
 
+#include <array>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 namespace simfil
 {
+
+namespace detail
+{
+
+inline auto childAtOrThrow(std::size_t index, std::vector<ExprPtr>& children) -> ExprPtr&
+{
+    return children.at(index);
+}
+
+inline auto childAtOrThrow(std::size_t index, const std::vector<ExprPtr>& children) -> const ExprPtr&
+{
+    return children.at(index);
+}
+
+template <class... Children>
+auto childAtOrThrow(std::size_t index, Children&... children) -> ExprPtr&
+{
+    std::array<ExprPtr*, sizeof...(Children)> childPtrs{&children...};
+    if (index >= childPtrs.size())
+        throw std::out_of_range("AST child index out of range");
+    return *childPtrs[index];
+}
+
+template <class... Children>
+auto childAtOrThrow(std::size_t index, const Children&... children) -> const ExprPtr&
+{
+    std::array<const ExprPtr*, sizeof...(Children)> childPtrs{&children...};
+    if (index >= childPtrs.size())
+        throw std::out_of_range("AST child index out of range");
+    return *childPtrs[index];
+}
+
+}
 
 /**
  * Returns the current node and every child of it recursively.
@@ -85,10 +122,15 @@ public:
     ConstExpr() = delete;
 
     template <class CType_>
-    requires (!std::derived_from<std::remove_cvref_t<CType_>, ConstExpr>)
+    requires (!std::is_base_of_v<ConstExpr, std::remove_cvref_t<CType_>>)
     explicit ConstExpr(CType_&& value)
         : value_(Value::make(std::forward<CType_>(value)))
     {}
+
+    ConstExpr(const ConstExpr&) = delete;
+    ConstExpr(ConstExpr&&) = delete;
+    auto operator=(const ConstExpr&) -> ConstExpr& = delete;
+    auto operator=(ConstExpr&&) -> ConstExpr& = delete;
 
     explicit ConstExpr(Value value);
 
@@ -114,6 +156,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_;
@@ -131,6 +174,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, sub_;
@@ -146,6 +190,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
@@ -161,6 +206,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::vector<ExprPtr> args_;
@@ -177,6 +223,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string name_;
@@ -195,6 +242,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     auto left() -> Expr*;
@@ -220,6 +268,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr sub_;
@@ -254,7 +303,6 @@ public:
     auto accept(ExprVisitor& v) const -> void override
     {
         v.visit(*this);
-        sub_->accept(v);
     }
 
     auto numChildren() const -> std::size_t override
@@ -264,9 +312,12 @@ public:
 
     auto childAt(std::size_t index) -> ExprPtr& override
     {
-        if (index == 0)
-            return sub_;
-        return Expr::childAt(index);
+        return detail::childAtOrThrow(index, sub_);
+    }
+
+    auto childAt(std::size_t index) const -> const ExprPtr& override
+    {
+        return detail::childAtOrThrow(index, sub_);
     }
 
     auto toString() const -> std::string override
@@ -290,7 +341,8 @@ public:
     {}
 
     BinaryExpr(const Token& token, ExprPtr left, ExprPtr right)
-        : left_(std::move(left))
+        : Expr(token)
+        , left_(std::move(left))
         , right_(std::move(right))
     {}
 
@@ -323,14 +375,12 @@ public:
 
     auto childAt(std::size_t index) -> ExprPtr& override
     {
-        switch (index) {
-        case 0:
-            return left_;
-        case 1:
-            return right_;
-        default:
-            return Expr::childAt(index);
-        }
+        return detail::childAtOrThrow(index, left_, right_);
+    }
+
+    auto childAt(std::size_t index) const -> const ExprPtr& override
+    {
+        return detail::childAtOrThrow(index, left_, right_);
     }
 
     auto toString() const -> std::string override
@@ -368,14 +418,12 @@ public:
 
     auto childAt(std::size_t index) -> ExprPtr& override
     {
-        switch (index) {
-        case 0:
-            return left_;
-        case 1:
-            return right_;
-        default:
-            return Expr::childAt(index);
-        }
+        return detail::childAtOrThrow(index, left_, right_);
+    }
+
+    auto childAt(std::size_t index) const -> const ExprPtr& override
+    {
+        return detail::childAtOrThrow(index, left_, right_);
     }
 
     ExprPtr left_, right_;
@@ -478,6 +526,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -494,6 +543,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     std::string ident_;
@@ -510,6 +560,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;
@@ -525,6 +576,7 @@ public:
     void accept(ExprVisitor& v) const override;
     auto numChildren() const -> std::size_t override;
     auto childAt(std::size_t index) -> ExprPtr& override;
+    auto childAt(std::size_t index) const -> const ExprPtr& override;
     auto toString() const -> std::string override;
 
     ExprPtr left_, right_;

--- a/src/expressions.h
+++ b/src/expressions.h
@@ -8,6 +8,8 @@
 #include "simfil/sourcelocation.h"
 
 #include <array>
+#include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -601,6 +603,34 @@ public:
     std::string name_;
     mutable StringId nameId_ = {};
     const bool recurse_ = {};
+
+private:
+    struct SchemaPlan {
+        enum class Kind {
+            Unknown,
+            Object,
+            Array,
+        };
+
+        Kind kind = Kind::Unknown;
+        bool canHaveField = true;
+        bool directField = true;
+        std::vector<StringId> objectChildFields;
+    };
+
+    struct CachedSchemaPlan {
+        SchemaId schemaId = NoSchemaId;
+        const Schema* schema = nullptr;
+        std::uint64_t schemaRevision = 0;
+        SchemaPlan plan;
+    };
+
+    auto schemaPlan(const Context& ctx, SchemaId schemaId, const Schema& schema) const -> const SchemaPlan*;
+    auto buildSchemaPlan(const Context& ctx, const Schema& schema) const -> SchemaPlan;
+    auto buildObjectSchemaPlan(const Context& ctx, const ObjectSchema& schema) const -> SchemaPlan;
+    auto childSchemaMayHaveField(const Context& ctx, SchemaId schemaId) const -> bool;
+
+    mutable std::vector<std::unique_ptr<CachedSchemaPlan>> schemaPlans_;
 };
 
 }

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <variant>
 #include <vector>
+#include <deque>
 #include <streambuf>
 
 #include <fmt/format.h>
@@ -15,11 +16,13 @@
 #include <bitsery/bitsery.h>
 #include <bitsery/adapter/buffer.h>
 #include <bitsery/adapter/stream.h>
+#include <bitsery/traits/deque.h>
 #include <bitsery/traits/string.h>
 #include <bitsery/traits/vector.h>
 #include <tl/expected.hpp>
 
 #include "../expected.h"
+#include "simfil/model/schema.h"
 
 namespace simfil
 {
@@ -86,6 +89,10 @@ struct ModelPool::Impl
         ModelColumn<StringRange, detail::ColumnPageSize> strings_;
         ModelColumn<StringRange, detail::ColumnPageSize> byteArrays_;
 
+        ModelColumn<SchemaId, detail::ColumnPageSize> objectSchemas_;
+        ModelColumn<SchemaId, detail::ColumnPageSize> objectSingletonSchemas_;
+        ModelColumn<SchemaId, detail::ColumnPageSize> arraySchemas_;
+        ModelColumn<SchemaId, detail::ColumnPageSize> arraySingletonSchemas_;
         Object::Storage objectMemberArrays_;
         Array::Storage arrayMemberArrays_;
     } columns_;
@@ -99,6 +106,10 @@ struct ModelPool::Impl
         s.text1b(columns_.stringData_, maxColumnSize);
         s.object(columns_.strings_);
         s.object(columns_.byteArrays_);
+        s.object(columns_.objectSchemas_);
+        s.object(columns_.objectSingletonSchemas_);
+        s.object(columns_.arraySchemas_);
+        s.object(columns_.arraySingletonSchemas_);
 
         s.ext(columns_.objectMemberArrays_, bitsery::ext::ArrayArenaExt{});
         s.ext(columns_.arrayMemberArrays_, bitsery::ext::ArrayArenaExt{});
@@ -119,6 +130,20 @@ ModelPool::~ModelPool()  // NOLINT
 std::vector<std::string> ModelPool::checkForErrors() const
 {
     std::vector<std::string> errors;
+    auto objectHasSchema = [&](ArrayIndex members) {
+        if (Object::Storage::is_singleton_handle(members)) {
+            return Object::Storage::singleton_payload(members)
+                < impl_->columns_.objectSingletonSchemas_.size();
+        }
+        return members < impl_->columns_.objectSchemas_.size();
+    };
+    auto arrayHasSchema = [&](ArrayIndex members) {
+        if (Array::Storage::is_singleton_handle(members)) {
+            return Array::Storage::singleton_payload(members)
+                < impl_->columns_.arraySingletonSchemas_.size();
+        }
+        return members < impl_->columns_.arraySchemas_.size();
+    };
 
     auto validateArrayIndex = [&](auto i, auto arrType, auto const& arena) {
         if (!arena.valid(static_cast<ArrayIndex>(i))) {
@@ -142,6 +167,10 @@ std::vector<std::string> ModelPool::checkForErrors() const
             if (node->addr().column() == Objects)
                 if (!validateArrayIndex(node->addr().index(), "object", impl_->columns_.objectMemberArrays_))
                     return;
+            if (!objectHasSchema(node->addr().index())) {
+                errors.emplace_back(fmt::format("Missing object schema index {}.", node->addr().index()));
+                return;
+            }
             for (auto const& [fieldName, fieldValue] : node->fields()) {
                 validatePooledString(fieldName);
                 validateModelNode(fieldValue);
@@ -151,6 +180,10 @@ std::vector<std::string> ModelPool::checkForErrors() const
             if (node->addr().column() == Arrays)
                 if (!validateArrayIndex(node->addr().index(), "arrays", impl_->columns_.arrayMemberArrays_))
                     return;
+            if (!arrayHasSchema(node->addr().index())) {
+                errors.emplace_back(fmt::format("Missing array schema index {}.", node->addr().index()));
+                return;
+            }
             for (auto const& member : *node)
                 validateModelNode(member);
         }
@@ -163,16 +196,28 @@ std::vector<std::string> ModelPool::checkForErrors() const
     };
 
     // Validate objects
-    for (auto i = 0; i < impl_->columns_.objectMemberArrays_.size(); ++i)
+    for (auto i = FirstRegularArrayIndex; i < impl_->columns_.objectMemberArrays_.size(); ++i)
         validateModelNode(ModelNode::Ptr::make(
             shared_from_this(),
             ModelNodeAddress{Objects, (uint32_t)i}));
+    for (auto i = 0u; i < impl_->columns_.objectMemberArrays_.singleton_handle_count(); ++i)
+        validateModelNode(ModelNode::Ptr::make(
+            shared_from_this(),
+            ModelNodeAddress{
+                Objects,
+                SingletonArrayHandleMask | static_cast<uint32_t>(i)}));
 
     // Validate arrays
-    for (auto i = 0; i < impl_->columns_.arrayMemberArrays_.size(); ++i)
+    for (auto i = FirstRegularArrayIndex; i < impl_->columns_.arrayMemberArrays_.size(); ++i)
         validateModelNode(ModelNode::Ptr::make(
             shared_from_this(),
             ModelNodeAddress{Arrays, (uint32_t)i}));
+    for (auto i = 0u; i < impl_->columns_.arrayMemberArrays_.singleton_handle_count(); ++i)
+        validateModelNode(ModelNode::Ptr::make(
+            shared_from_this(),
+            ModelNodeAddress{
+                Arrays,
+                SingletonArrayHandleMask | static_cast<uint32_t>(i)}));
 
     // Validate roots
     for (auto i = 0; i < numRoots(); ++i)
@@ -205,6 +250,10 @@ void ModelPool::clear()
     clear_and_shrink(columns.strings_);
     clear_and_shrink(columns.stringData_);
     clear_and_shrink(columns.byteArrays_);
+    clear_and_shrink(columns.objectSchemas_);
+    clear_and_shrink(columns.objectSingletonSchemas_);
+    clear_and_shrink(columns.arraySchemas_);
+    clear_and_shrink(columns.arraySingletonSchemas_);
     clear_and_shrink(columns.objectMemberArrays_);
     clear_and_shrink(columns.arrayMemberArrays_);
 }
@@ -293,12 +342,32 @@ void ModelPool::addRoot(ModelNode::Ptr const& rootNode) {
 model_ptr<Object> ModelPool::newObject(size_t initialFieldCapacity, bool fixedSize)
 {
     auto memberArrId = impl_->columns_.objectMemberArrays_.new_array(initialFieldCapacity, fixedSize);
+    if (Object::Storage::is_singleton_handle(memberArrId)) {
+        auto singletonIndex = Object::Storage::singleton_payload(memberArrId);
+        if (impl_->columns_.objectSingletonSchemas_.size() <= singletonIndex)
+            impl_->columns_.objectSingletonSchemas_.resize(singletonIndex + 1);
+        impl_->columns_.objectSingletonSchemas_[singletonIndex] = SchemaId{};
+    } else {
+        if (impl_->columns_.objectSchemas_.size() <= memberArrId)
+            impl_->columns_.objectSchemas_.resize(memberArrId + 1);
+        impl_->columns_.objectSchemas_[memberArrId] = SchemaId{};
+    }
     return model_ptr<Object>::make(shared_from_this(), ModelNodeAddress{Objects, (uint32_t)memberArrId});
 }
 
 model_ptr<Array> ModelPool::newArray(size_t initialFieldCapacity, bool fixedSize)
 {
     auto memberArrId = impl_->columns_.arrayMemberArrays_.new_array(initialFieldCapacity, fixedSize);
+    if (Array::Storage::is_singleton_handle(memberArrId)) {
+        auto singletonIndex = Array::Storage::singleton_payload(memberArrId);
+        if (impl_->columns_.arraySingletonSchemas_.size() <= singletonIndex)
+            impl_->columns_.arraySingletonSchemas_.resize(singletonIndex + 1);
+        impl_->columns_.arraySingletonSchemas_[singletonIndex] = SchemaId{};
+    } else {
+        if (impl_->columns_.arraySchemas_.size() <= memberArrId)
+            impl_->columns_.arraySchemas_.resize(memberArrId + 1);
+        impl_->columns_.arraySchemas_[memberArrId] = SchemaId{};
+    }
     return model_ptr<Array>::make(shared_from_this(), ModelNodeAddress{Arrays, (uint32_t)memberArrId});
 }
 
@@ -434,7 +503,11 @@ ModelPool::SerializationSizeStats ModelPool::serializationSizeStats() const
     stats.stringRangeBytes = impl_->columns_.strings_.byte_size();
     stats.stringRangeBytes += impl_->columns_.byteArrays_.byte_size();
     stats.objectMemberBytes = impl_->columns_.objectMemberArrays_.byte_size();
+    stats.objectSchemaBytes = impl_->columns_.objectSchemas_.byte_size()
+        + impl_->columns_.objectSingletonSchemas_.byte_size();
     stats.arrayMemberBytes = impl_->columns_.arrayMemberArrays_.byte_size();
+    stats.arraySchemaBytes = impl_->columns_.arraySchemas_.byte_size()
+        + impl_->columns_.arraySingletonSchemas_.byte_size();
     return stats;
 }
 
@@ -445,6 +518,64 @@ std::optional<std::string_view> ModelPool::lookupStringId(const simfil::StringId
 
 Object::Storage& ModelPool::objectMemberStorage() {
     return impl_->columns_.objectMemberArrays_;
+}
+
+SchemaId ModelPool::objectSchemaId(ArrayIndex members) const
+{
+    if (Object::Storage::is_singleton_handle(members)) {
+        auto singletonIndex = Object::Storage::singleton_payload(members);
+        if (singletonIndex >= impl_->columns_.objectSingletonSchemas_.size())
+            return {};
+        return SchemaId{impl_->columns_.objectSingletonSchemas_[singletonIndex]};
+    }
+    if (members >= impl_->columns_.objectSchemas_.size())
+        return {};
+    return SchemaId{impl_->columns_.objectSchemas_[members]};
+}
+
+auto ModelPool::setObjectSchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>
+{
+    if (Object::Storage::is_singleton_handle(members)) {
+        auto singletonIndex = Object::Storage::singleton_payload(members);
+        if (singletonIndex >= impl_->columns_.objectSingletonSchemas_.size())
+            return tl::unexpected<Error>(Error::RuntimeError, "Object singleton schema index out of range.");
+        impl_->columns_.objectSingletonSchemas_[singletonIndex] = schemaId;
+        return {};
+    }
+    if (members >= impl_->columns_.objectSchemas_.size())
+        return tl::unexpected<Error>(Error::RuntimeError, "Object schema index out of range.");
+
+    impl_->columns_.objectSchemas_[members] = schemaId;
+    return {};
+}
+
+SchemaId ModelPool::arraySchemaId(ArrayIndex members) const
+{
+    if (Array::Storage::is_singleton_handle(members)) {
+        auto singletonIndex = Array::Storage::singleton_payload(members);
+        if (singletonIndex >= impl_->columns_.arraySingletonSchemas_.size())
+            return {};
+        return SchemaId{impl_->columns_.arraySingletonSchemas_[singletonIndex]};
+    }
+    if (members >= impl_->columns_.arraySchemas_.size())
+        return {};
+    return SchemaId{impl_->columns_.arraySchemas_[members]};
+}
+
+auto ModelPool::setArraySchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>
+{
+    if (Array::Storage::is_singleton_handle(members)) {
+        auto singletonIndex = Array::Storage::singleton_payload(members);
+        if (singletonIndex >= impl_->columns_.arraySingletonSchemas_.size())
+            return tl::unexpected<Error>(Error::RuntimeError, "Array singleton schema index out of range.");
+        impl_->columns_.arraySingletonSchemas_[singletonIndex] = schemaId;
+        return {};
+    }
+    if (members >= impl_->columns_.arraySchemas_.size())
+        return tl::unexpected<Error>(Error::RuntimeError, "Array schema index out of range.");
+
+    impl_->columns_.arraySchemas_[members] = schemaId;
+    return {};
 }
 
 Object::Storage const& ModelPool::objectMemberStorage() const
@@ -480,6 +611,7 @@ tl::expected<void, Error> ModelPool::read(const std::vector<uint8_t>& input, con
             "Failed to read ModelPool: Error {}",
             static_cast<std::underlying_type_t<bitsery::ReaderError>>(s.adapter().error())));
     }
+
     return {};
 }
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -535,16 +535,19 @@ SchemaId ModelPool::objectSchemaId(ArrayIndex members) const
 
 auto ModelPool::setObjectSchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>
 {
+    if (!impl_->columns_.objectMemberArrays_.valid(members))
+        return tl::unexpected<Error>(Error::RuntimeError, "Object schema index out of range.");
+
     if (Object::Storage::is_singleton_handle(members)) {
         auto singletonIndex = Object::Storage::singleton_payload(members);
-        if (singletonIndex >= impl_->columns_.objectSingletonSchemas_.size())
-            return tl::unexpected<Error>(Error::RuntimeError, "Object singleton schema index out of range.");
+        if (impl_->columns_.objectSingletonSchemas_.size() <= singletonIndex)
+            impl_->columns_.objectSingletonSchemas_.resize(singletonIndex + 1);
         impl_->columns_.objectSingletonSchemas_[singletonIndex] = schemaId;
         return {};
     }
-    if (members >= impl_->columns_.objectSchemas_.size())
-        return tl::unexpected<Error>(Error::RuntimeError, "Object schema index out of range.");
 
+    if (impl_->columns_.objectSchemas_.size() <= members)
+        impl_->columns_.objectSchemas_.resize(members + 1);
     impl_->columns_.objectSchemas_[members] = schemaId;
     return {};
 }
@@ -564,16 +567,19 @@ SchemaId ModelPool::arraySchemaId(ArrayIndex members) const
 
 auto ModelPool::setArraySchemaId(ArrayIndex members, SchemaId schemaId) -> tl::expected<void, Error>
 {
+    if (!impl_->columns_.arrayMemberArrays_.valid(members))
+        return tl::unexpected<Error>(Error::RuntimeError, "Array schema index out of range.");
+
     if (Array::Storage::is_singleton_handle(members)) {
         auto singletonIndex = Array::Storage::singleton_payload(members);
-        if (singletonIndex >= impl_->columns_.arraySingletonSchemas_.size())
-            return tl::unexpected<Error>(Error::RuntimeError, "Array singleton schema index out of range.");
+        if (impl_->columns_.arraySingletonSchemas_.size() <= singletonIndex)
+            impl_->columns_.arraySingletonSchemas_.resize(singletonIndex + 1);
         impl_->columns_.arraySingletonSchemas_[singletonIndex] = schemaId;
         return {};
     }
-    if (members >= impl_->columns_.arraySchemas_.size())
-        return tl::unexpected<Error>(Error::RuntimeError, "Array schema index out of range.");
 
+    if (impl_->columns_.arraySchemas_.size() <= members)
+        impl_->columns_.arraySchemas_.resize(members + 1);
     impl_->columns_.arraySchemas_[members] = schemaId;
     return {};
 }

--- a/src/model/nodes.cpp
+++ b/src/model/nodes.cpp
@@ -63,6 +63,13 @@ StringId ModelNode::keyAt(int64_t i) const {
     return result;
 }
 
+SchemaId ModelNode::schema() const {
+    SchemaId result = NoSchemaId;
+    if (model_)
+        model_->resolve(*this, Model::Lambda([&](auto&& resolved) { result = resolved.schema(); }));
+    return result;
+}
+
 /// Get the number of children
 uint32_t ModelNode::size() const {
     uint32_t result = 0;
@@ -184,6 +191,11 @@ ModelNode::Ptr ModelNodeBase::at(int64_t) const
 StringId ModelNodeBase::keyAt(int64_t) const
 {
     return 0;
+}
+
+SchemaId ModelNodeBase::schema() const
+{
+    return NoSchemaId;
 }
 
 uint32_t ModelNodeBase::size() const

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -113,11 +113,6 @@ auto Parser::relaxed() const -> bool
     return mode_ == Mode::Relaxed;
 }
 
-auto Parser::nextId() -> Expr::ExprId
-{
-    return ctx.id++;
-}
-
 auto Parser::parseInfix(expected<ExprPtr, Error> left, int prec) -> expected<ExprPtr, Error>
 {
     TRY_EXPECTED(left);
@@ -127,7 +122,7 @@ auto Parser::parseInfix(expected<ExprPtr, Error> left, int prec) -> expected<Exp
         auto parser = findInfixParser(token);
         if (!parser) {
             if (relaxed())
-                return std::make_unique<NOOPExpr>(nextId());
+                return std::make_unique<NOOPExpr>();
 
             return unexpected<Error>(
                 Error::ParserError,
@@ -176,7 +171,7 @@ auto Parser::parseTo(Token::Type type) -> expected<ExprPtr, Error>
 
     if (!*expr) {
         if (relaxed())
-            return std::make_unique<NOOPExpr>(nextId());
+            return std::make_unique<NOOPExpr>();
 
         return unexpected<Error>(
             Error::ParserError,

--- a/src/rewrite-rules.h
+++ b/src/rewrite-rules.h
@@ -37,14 +37,15 @@ inline auto rewriteTopDown(ExprPtr expr, std::span<RewriteRule> rules, const Rew
     return std::move(expr);
 }
 
-/** Rewrite `PathExpr(WildcardExpr, WildcardExpr)` -> `WildcardExpr` */
-inline auto rewriteWildcardWildcard(ExprPtr& expr) -> ExprPtr
+/** Rewrite `PathExpr(AnyChildExpr, FieldExpr)` -> `WildcardFieldExpr(non-recursive)` */
+inline auto rewriteAnyChildField(ExprPtr& expr) -> ExprPtr
 {
     if (const auto* path = dynamic_cast<const PathExpr*>(expr.get())) {
-        const auto* lhs = path->left_.get();
-        const auto* rhs = path->right_.get();
-        if (dynamic_cast<const WildcardExpr*>(lhs) && dynamic_cast<const WildcardExpr*>(rhs))
-            return std::make_unique<WildcardExpr>();
+        const auto* lhs = dynamic_cast<const AnyChildExpr*>(path->left());
+        const auto* rhs = dynamic_cast<const FieldExpr*>(path->right());
+        if (lhs && rhs && !rhs->isCurrent()) {
+            return std::make_unique<WildcardFieldExpr>(false, rhs->field(), rhs->sourceLocation());
+        }
     }
 
     return nullptr;
@@ -56,16 +57,16 @@ inline auto rewriteWildcardThis(ExprPtr& expr) -> ExprPtr
     auto rewrite = [](const PathExpr* path, const Expr* left, const Expr* right) -> std::unique_ptr<WildcardExpr> {
         const auto* lhs = dynamic_cast<const WildcardExpr*>(left);
         const auto* rhs = dynamic_cast<const FieldExpr*>(right);
-        if (lhs && rhs && rhs->name_ == "_") {
-            return std::make_unique<WildcardExpr>();
+        if (lhs && rhs && rhs->isCurrent()) {
+            return std::make_unique<WildcardExpr>(lhs->sourceLocation());
         }
         return nullptr;
     };
 
     if (const auto* path = dynamic_cast<const PathExpr*>(expr.get())) {
-        if (auto replacement = rewrite(path, path->left_.get(), path->right_.get()))
+        if (auto replacement = rewrite(path, path->left(), path->right()))
             return std::move(replacement);
-        if (auto replacement = rewrite(path, path->right_.get(), path->left_.get()))
+        if (auto replacement = rewrite(path, path->right(), path->left()))
             return std::move(replacement);
     }
 
@@ -76,13 +77,13 @@ inline auto rewriteWildcardThis(ExprPtr& expr) -> ExprPtr
 inline auto rewriteAnyWildcardField(ExprPtr& expr) -> ExprPtr
 {
     if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
-        auto* lhs = dynamic_cast<PathExpr*>(path->left_.get());
-        auto* rhs = dynamic_cast<FieldExpr*>(path->right_.get());
+        auto* lhs = dynamic_cast<PathExpr*>(path->left());
+        auto* rhs = dynamic_cast<FieldExpr*>(path->right());
         if (lhs && rhs) {
-            auto* lhsRhs = dynamic_cast<WildcardExpr*>(lhs->right_.get());
+            auto* lhsRhs = dynamic_cast<WildcardExpr*>(lhs->right());
             if (lhsRhs) {
                 return std::make_unique<PathExpr>(std::move(lhs->left_),
-                                                  std::make_unique<WildcardFieldExpr>(rhs->name_, rhs->sourceLocation()));
+                                                  std::make_unique<WildcardFieldExpr>(true, rhs->field(), rhs->sourceLocation()));
             }
         }
     }
@@ -93,10 +94,10 @@ inline auto rewriteAnyWildcardField(ExprPtr& expr) -> ExprPtr
 inline auto rewriteWildcardField(ExprPtr& expr) -> ExprPtr
 {
     if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
-        auto* lhs = dynamic_cast<WildcardExpr*>(path->left_.get());
-        auto* rhs = dynamic_cast<FieldExpr*>(path->right_.get());
-        if (lhs && rhs) {
-            return std::make_unique<WildcardFieldExpr>(rhs->name_, rhs->sourceLocation());
+        auto* lhs = dynamic_cast<WildcardExpr*>(path->left());
+        auto* rhs = dynamic_cast<FieldExpr*>(path->right());
+        if (lhs && rhs && !rhs->isCurrent()) {
+            return std::make_unique<WildcardFieldExpr>(true, rhs->field(), rhs->sourceLocation());
         }
     }
 

--- a/src/rewrite-rules.h
+++ b/src/rewrite-rules.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "simfil/value.h"
+#include "simfil/expression.h"
+
+#include "expressions.h"
+
+#include <memory>
+
+namespace simfil
+{
+
+using RewriteRule = std::function<ExprPtr(ExprPtr&)>;
+
+/**
+ * Apply a list of rewrite-rules top-down to an expression (sub-)tree.
+ */
+inline auto rewriteTopDown(ExprPtr expr, std::span<RewriteRule> rules, const RewriteRule* sourceRule = nullptr) -> ExprPtr
+{
+    for (const auto& rule : rules) {
+        // Prevent rule self-recursion.
+        if (&rule == sourceRule)
+            continue;
+
+        auto rewrite = rule(expr);
+        if (rewrite && rewrite.get() != expr.get()) {
+            return rewriteTopDown(std::move(rewrite), rules, &rule); // NOLINT
+        }
+    }
+
+    const auto count = expr->numChildren();
+    for (auto i = 0; i < count; ++i) {
+        auto& child = expr->childAt(i);
+        child = rewriteTopDown(std::move(child), rules, nullptr);
+    }
+
+    return std::move(expr);
+}
+
+/** Rewrite `PathExpr(WildcardExpr, WildcardExpr)` -> `WildcardExpr` */
+inline auto rewriteWildcardWildcard(ExprPtr& expr) -> ExprPtr
+{
+    if (const auto* path = dynamic_cast<const PathExpr*>(expr.get())) {
+        const auto* lhs = path->left_.get();
+        const auto* rhs = path->right_.get();
+        if (dynamic_cast<const WildcardExpr*>(lhs) && dynamic_cast<const WildcardExpr*>(rhs))
+            return std::make_unique<WildcardExpr>();
+    }
+
+    return nullptr;
+}
+
+/** Rewrite `PathExpr(WildcardExpr, _) | PathExpr(_, WildcardExpr)` -> `WildcardExpr` */
+inline auto rewriteWildcardThis(ExprPtr& expr) -> ExprPtr
+{
+    auto rewrite = [](const PathExpr* path, const Expr* left, const Expr* right) -> std::unique_ptr<WildcardExpr> {
+        const auto* lhs = dynamic_cast<const WildcardExpr*>(left);
+        const auto* rhs = dynamic_cast<const FieldExpr*>(right);
+        if (lhs && rhs && rhs->name_ == "_") {
+            return std::make_unique<WildcardExpr>();
+        }
+        return nullptr;
+    };
+
+    if (const auto* path = dynamic_cast<const PathExpr*>(expr.get())) {
+        if (auto replacement = rewrite(path, path->left_.get(), path->right_.get()))
+            return std::move(replacement);
+        if (auto replacement = rewrite(path, path->right_.get(), path->left_.get()))
+            return std::move(replacement);
+    }
+
+    return nullptr;
+}
+
+/** Rewrite `PathExpr(PathExpr(?, WildcardExpr), FieldExpr)` -> `PathExpr(?, WildcardFieldExpr(field))` */
+inline auto rewriteAnyWildcardField(ExprPtr& expr) -> ExprPtr
+{
+    if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
+        auto* lhs = dynamic_cast<PathExpr*>(path->left_.get());
+        auto* rhs = dynamic_cast<FieldExpr*>(path->right_.get());
+        if (lhs && rhs) {
+            auto* lhsRhs = dynamic_cast<WildcardExpr*>(lhs->right_.get());
+            if (lhsRhs) {
+                return std::make_unique<PathExpr>(std::move(lhs->left_),
+                                                  std::make_unique<WildcardFieldExpr>(rhs->name_, rhs->sourceLocation()));
+            }
+        }
+    }
+    return nullptr;
+}
+
+/** Rewrite `PathExpr(WildcardExpr, FieldExpr)` -> `WildcardFieldExpr(field)` */
+inline auto rewriteWildcardField(ExprPtr& expr) -> ExprPtr
+{
+    if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
+        auto* lhs = dynamic_cast<WildcardExpr*>(path->left_.get());
+        auto* rhs = dynamic_cast<FieldExpr*>(path->right_.get());
+        if (lhs && rhs) {
+            return std::make_unique<WildcardFieldExpr>(rhs->name_, rhs->sourceLocation());
+        }
+    }
+
+    return nullptr;
+}
+
+}

--- a/src/rewrite-rules.h
+++ b/src/rewrite-rules.h
@@ -6,6 +6,7 @@
 #include "expressions.h"
 
 #include <memory>
+#include <span>
 
 namespace simfil
 {
@@ -15,7 +16,7 @@ using RewriteRule = std::function<ExprPtr(ExprPtr&)>;
 /**
  * Apply a list of rewrite-rules top-down to an expression (sub-)tree.
  */
-inline auto rewriteTopDown(ExprPtr expr, std::span<RewriteRule> rules, const RewriteRule* sourceRule = nullptr) -> ExprPtr
+inline auto rewriteTopDown(ExprPtr expr, std::span<const RewriteRule> rules, const RewriteRule* sourceRule = nullptr) -> ExprPtr
 {
     for (const auto& rule : rules) {
         // Prevent rule self-recursion.
@@ -54,19 +55,18 @@ inline auto rewriteAnyChildField(ExprPtr& expr) -> ExprPtr
 /** Rewrite `PathExpr(WildcardExpr, _) | PathExpr(_, WildcardExpr)` -> `WildcardExpr` */
 inline auto rewriteWildcardThis(ExprPtr& expr) -> ExprPtr
 {
-    auto rewrite = [](const PathExpr* path, const Expr* left, const Expr* right) -> std::unique_ptr<WildcardExpr> {
+    auto rewrite = [](const Expr* left, const Expr* right) -> std::unique_ptr<WildcardExpr> {
         const auto* lhs = dynamic_cast<const WildcardExpr*>(left);
-        const auto* rhs = dynamic_cast<const FieldExpr*>(right);
-        if (lhs && rhs && rhs->isCurrent()) {
+        if (const auto* rhs = dynamic_cast<const FieldExpr*>(right); lhs && rhs && rhs->isCurrent()) {
             return std::make_unique<WildcardExpr>(lhs->sourceLocation());
         }
         return nullptr;
     };
 
     if (const auto* path = dynamic_cast<const PathExpr*>(expr.get())) {
-        if (auto replacement = rewrite(path, path->left(), path->right()))
+        if (auto replacement = rewrite(path->left(), path->right()))
             return std::move(replacement);
-        if (auto replacement = rewrite(path, path->right(), path->left()))
+        if (auto replacement = rewrite(path->right(), path->left()))
             return std::move(replacement);
     }
 
@@ -78,9 +78,9 @@ inline auto rewriteAnyWildcardField(ExprPtr& expr) -> ExprPtr
 {
     if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
         auto* lhs = dynamic_cast<PathExpr*>(path->left());
-        auto* rhs = dynamic_cast<FieldExpr*>(path->right());
+        const auto* rhs = dynamic_cast<const FieldExpr*>(path->right());
         if (lhs && rhs) {
-            auto* lhsRhs = dynamic_cast<WildcardExpr*>(lhs->right());
+            const auto* lhsRhs = dynamic_cast<const WildcardExpr*>(lhs->right());
             if (lhsRhs) {
                 return std::make_unique<PathExpr>(std::move(lhs->left_),
                                                   std::make_unique<WildcardFieldExpr>(true, rhs->field(), rhs->sourceLocation()));
@@ -94,8 +94,8 @@ inline auto rewriteAnyWildcardField(ExprPtr& expr) -> ExprPtr
 inline auto rewriteWildcardField(ExprPtr& expr) -> ExprPtr
 {
     if (auto* path = dynamic_cast<PathExpr*>(expr.get())) {
-        auto* lhs = dynamic_cast<WildcardExpr*>(path->left());
-        auto* rhs = dynamic_cast<FieldExpr*>(path->right());
+        const auto* lhs = dynamic_cast<const WildcardExpr*>(path->left());
+        const auto* rhs = dynamic_cast<const FieldExpr*>(path->right());
         if (lhs && rhs && !rhs->isCurrent()) {
             return std::make_unique<WildcardFieldExpr>(true, rhs->field(), rhs->sourceLocation());
         }

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -55,6 +55,7 @@ static RewriteRule bottomUpRewriteRules[] = {
 
 static RewriteRule topDownRewriteRules[] = {
     rewriteAnyWildcardField,
+    rewriteAnyChildField,
 };
 
 /**

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -15,9 +15,10 @@
 #include "fmt/core.h"
 
 #include "expressions.h"
-#include "expression-patterns.h"
 #include "completion.h"
 #include "expected.h"
+#include "expression-patterns.h"
+#include "rewrite-rules.h"
 
 #include <algorithm>
 #include <cctype>
@@ -46,6 +47,15 @@ static constexpr std::string_view TypenameFloat("float");
 static constexpr std::string_view TypenameString("string");
 static constexpr std::string_view TypenameBytes("bytes");
 }
+
+static RewriteRule bottomUpRewriteRules[] = {
+    rewriteWildcardThis,
+    rewriteWildcardField,
+};
+
+static RewriteRule topDownRewriteRules[] = {
+    rewriteAnyWildcardField,
+};
 
 /**
  * Parser precedence groups.
@@ -116,7 +126,7 @@ static auto scopedNotInPath(Parser& p) {
  * Tries to evaluate the input expression on a stub context.
  * Returns the evaluated result on success, otherwise the original expression is returned.
  */
-static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -> expected<ExprPtr, Error>
+static auto simplifyOrForward(const RewriteRule* currentRule, Environment* env, expected<ExprPtr, Error> expr) -> expected<ExprPtr, Error>
 {
     if (!expr)
         return expr;
@@ -149,15 +159,51 @@ static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -
         env->warn("Expression is always "s + values[0].toString(), (*expr)->toString());
 
     if (values.size() == 1)
-        return std::make_unique<ConstExpr>((*expr)->id(), std::move(values[0]));
+        return std::make_unique<ConstExpr>(std::move(values[0]));
     if (values.size() > 1)
-        return std::make_unique<MultiConstExpr>((*expr)->id(), std::vector<Value>(std::make_move_iterator(values.begin()),
-                                                                               std::make_move_iterator(values.end())));
+        return std::make_unique<MultiConstExpr>(std::vector<Value>(std::make_move_iterator(values.begin()),
+                                                                   std::make_move_iterator(values.end())));
+
+    /* Apply bottom-up rewrite rules */
+    for (const auto& rule : bottomUpRewriteRules) {
+        /* Prevent rule self-recursion */
+        if (&rule == currentRule)
+            continue;
+
+        if (auto rewrite = rule(*expr)) {
+            /* If a rewrite rule matched we try to simplify and re-write its output again */
+            return simplifyOrForward(&rule, env, std::move(rewrite));
+        }
+    }
 
     return expr;
 }
 
+static auto simplifyOrForward(Environment* env, expected<ExprPtr, Error> expr) -> expected<ExprPtr, Error>
+{
+    return simplifyOrForward(nullptr, env, std::move(expr));
+}
+
+
 AST::~AST() = default;
+
+auto AST::reenumerate() -> void
+{
+    if (!expr_)
+        return;
+
+    auto nextId = Expr::ExprId{0};
+    reenumerate(*expr_, nextId);
+}
+
+auto AST::reenumerate(Expr& expr, Expr::ExprId& nextId) -> void
+{
+    expr.id_ = nextId++;
+
+    const auto count = expr.numChildren();
+    for (auto i = 0u; i < count; ++i)
+        reenumerate(*expr.childAt(i), nextId);
+}
 
 /**
  * Parser wrapper for parsing and & or operators.
@@ -174,12 +220,10 @@ public:
             return right;
 
         if (t.type == Token::OP_AND)
-            return simplifyOrForward(p.env, std::make_unique<AndExpr>(p.nextId(),
-                                                                      std::move(left),
+            return simplifyOrForward(p.env, std::make_unique<AndExpr>(std::move(left),
                                                                       std::move(*right)));
         else if (t.type == Token::OP_OR)
-            return simplifyOrForward(p.env, std::make_unique<OrExpr>(p.nextId(),
-                                                                     std::move(left),
+            return simplifyOrForward(p.env, std::make_unique<OrExpr>(std::move(left),
                                                                      std::move(*right)));
         assert(0);
         return nullptr;
@@ -205,12 +249,10 @@ public:
             return right;
 
         if (t.type == Token::OP_AND)
-            return simplifyOrForward(p.env, std::make_unique<CompletionAndExpr>(p.nextId(),
-                                                                                std::move(left),
+            return simplifyOrForward(p.env, std::make_unique<CompletionAndExpr>(std::move(left),
                                                                                 std::move(*right), comp_));
         else if (t.type == Token::OP_OR)
-            return simplifyOrForward(p.env, std::make_unique<CompletionOrExpr>(p.nextId(),
-                                                                               std::move(left),
+            return simplifyOrForward(p.env, std::make_unique<CompletionOrExpr>(std::move(left),
                                                                                std::move(*right), comp_));
         assert(0);
         return nullptr;
@@ -231,7 +273,7 @@ public:
     {
         auto type = p.consume();
         if (type.type == Token::C_NULL)
-            return std::make_unique<ConstExpr>(p.nextId(), Value::null());
+            return std::make_unique<ConstExpr>(Value::null());
 
         if (type.type != Token::Type::WORD)
             return unexpected<Error>(Error::InvalidType, fmt::format("'as' expected typename got {}", type.toString()));
@@ -239,17 +281,17 @@ public:
         auto name = std::get<std::string>(type.value);
         return simplifyOrForward(p.env, [&]() -> expected<ExprPtr, Error> {
             if (name == strings::TypenameNull)
-                return std::make_unique<ConstExpr>(p.nextId(), Value::null());
+                return std::make_unique<ConstExpr>(Value::null());
             if (name == strings::TypenameBool)
-                return std::make_unique<UnaryExpr<OperatorBool>>(p.nextId(), std::move(left));
+                return std::make_unique<UnaryExpr<OperatorBool>>(std::move(left));
             if (name == strings::TypenameInt)
-                return std::make_unique<UnaryExpr<OperatorAsInt>>(p.nextId(), std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsInt>>(std::move(left));
             if (name == strings::TypenameFloat)
-                return std::make_unique<UnaryExpr<OperatorAsFloat>>(p.nextId(), std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsFloat>>(std::move(left));
             if (name == strings::TypenameString)
-                return std::make_unique<UnaryExpr<OperatorAsString>>(p.nextId(), std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsString>>(std::move(left));
             if (name == strings::TypenameBytes)
-                return std::make_unique<UnaryExpr<OperatorAsBytes>>(p.nextId(), std::move(left));
+                return std::make_unique<UnaryExpr<OperatorAsBytes>>(std::move(left));
 
             return unexpected<Error>(Error::InvalidType, fmt::format("Invalid type name for cast '{}'", name));
         }());
@@ -277,8 +319,7 @@ public:
         if (!right)
             return right;
 
-        return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(p.nextId(),
-                                                                               t,
+        return simplifyOrForward(p.env, std::make_unique<BinaryExpr<Operator>>(t,
                                                                                std::move(left),
                                                                                std::move(*right)));
     }
@@ -303,7 +344,7 @@ class UnaryOpParser : public PrefixParselet
         if (!sub)
             return sub;
 
-        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(p.nextId(), std::move(*sub)));
+        return simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(*sub)));
     }
 };
 
@@ -315,7 +356,7 @@ class UnaryPostOpParser : public InfixParselet
 {
     auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(p.nextId(), std::move(left))), 0);
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryExpr<Operator>>(std::move(left))), 0);
     }
 
     auto precedence() const -> int override
@@ -331,7 +372,7 @@ class UnpackOpParser : public InfixParselet
 {
     auto parse(Parser& p, ExprPtr left, Token t) const -> expected<ExprPtr, Error> override
     {
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnpackExpr>(p.nextId(), std::move(left))), 0);
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnpackExpr>(std::move(left))), 0);
     }
 
     auto precedence() const -> int override
@@ -353,14 +394,12 @@ class WordOpParser : public InfixParselet
             return right;
 
         if (*right)
-            return simplifyOrForward(p.env, std::make_unique<BinaryWordOpExpr>(p.nextId(),
-                                                                               std::get<std::string>(t.value),
+            return simplifyOrForward(p.env, std::make_unique<BinaryWordOpExpr>(std::get<std::string>(t.value),
                                                                                std::move(left),
                                                                                std::move(*right)));
 
         /* Parse as unary operator */
-        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryWordOpExpr>(p.nextId(),
-                                                                                       std::get<std::string>(t.value),
+        return p.parseInfix(simplifyOrForward(p.env, std::make_unique<UnaryWordOpExpr>(std::get<std::string>(t.value),
                                                                                        std::move(left))), 0);
     }
 
@@ -380,7 +419,7 @@ class ScalarParser : public PrefixParselet
 {
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
-        return std::make_unique<ConstExpr>(p.nextId(), std::get<Type>(t.value));
+        return std::make_unique<ConstExpr>(std::get<Type>(t.value));
     }
 };
 
@@ -394,7 +433,7 @@ class RegExpParser : public PrefixParselet
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
         auto value = ReType::Type.make(std::get<std::string>(t.value));
-        return std::make_unique<ConstExpr>(p.nextId(), std::move(value));
+        return std::make_unique<ConstExpr>(std::move(value));
     }
 };
 
@@ -415,7 +454,7 @@ public:
 
     auto parse(Parser& p, Token t) const -> expected<ExprPtr, Error> override
     {
-        return std::make_unique<ConstExpr>(p.nextId(), value_);
+        return std::make_unique<ConstExpr>(value_);
     }
 
     Value value_;
@@ -450,10 +489,7 @@ class SubscriptParser : public PrefixParselet, public InfixParselet
         if (!body)
             return body;
 
-        auto outerId = p.nextId();
-        auto innerId = p.nextId();
-        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(outerId,
-                                                                        std::make_unique<FieldExpr>(innerId, "_"),
+        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::make_unique<FieldExpr>("_"),
                                                                         std::move(*body)));
     }
 
@@ -464,8 +500,7 @@ class SubscriptParser : public PrefixParselet, public InfixParselet
         if (!body)
             return body;
 
-        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(p.nextId(),
-                                                                        std::move(left),
+        return simplifyOrForward(p.env, std::make_unique<SubscriptExpr>(std::move(left),
                                                                         std::move(*body)));
     }
 
@@ -491,10 +526,7 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
         auto body = p.parseTo(Token::RBRACE);
         TRY_EXPECTED(body);
 
-        auto outerId = p.nextId();
-        auto innerId = p.nextId();
-        return simplifyOrForward(p.env, std::make_unique<SubExpr>(outerId,
-                                                                  std::make_unique<FieldExpr>(innerId, "_"),
+        return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::make_unique<FieldExpr>("_"),
                                                                   std::move(*body)));
     }
 
@@ -503,8 +535,7 @@ class SubSelectParser : public PrefixParselet, public InfixParselet
         auto _ = scopedNotInPath(p);
         auto body = p.parseTo(Token::RBRACE);
         TRY_EXPECTED(body);
-        return simplifyOrForward(p.env, std::make_unique<SubExpr>(p.nextId(),
-                                                                  std::move(left),
+        return simplifyOrForward(p.env, std::make_unique<SubExpr>(std::move(left),
                                                                   std::move(*body)));
     }
 
@@ -526,15 +557,15 @@ public:
     {
         /* Self */
         if (t.type == Token::SELF)
-            return std::make_unique<FieldExpr>(p.nextId(), "_", t);
+            return std::make_unique<FieldExpr>("_", t);
 
         /* Any Child */
         if (t.type == Token::OP_TIMES)
-            return std::make_unique<AnyChildExpr>(p.nextId());
+            return std::make_unique<AnyChildExpr>();
 
         /* Wildcard */
         if (t.type == Token::WILDCARD)
-            return std::make_unique<WildcardExpr>(p.nextId());
+            return std::make_unique<WildcardExpr>();
 
         auto word = std::get<std::string>(t.value);
 
@@ -547,25 +578,25 @@ public:
             TRY_EXPECTED(arguments);
 
             if (word == "any") {
-                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(p.nextId(), std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(*arguments)));
             } else if (word == "each" || word == "all") {
-                return simplifyOrForward(p.env, std::make_unique<EachExpr>(p.nextId(), std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<EachExpr>(std::move(*arguments)));
             } else {
-                return simplifyOrForward(p.env, std::make_unique<CallExpression>(p.nextId(), word, std::move(*arguments)));
+                return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
             }
         } else if (!p.ctx.inPath) {
             /* Parse Symbols (words in upper-case) */
             if (isSymbolWord(word)) {
-                return std::make_unique<ConstExpr>(p.nextId(), Value::make<std::string>(std::move(word)));
+                return std::make_unique<ConstExpr>(Value::make<std::string>(std::move(word)));
             }
             /* Constant */
             else if (auto constant = p.env->findConstant(word)) {
-                return std::make_unique<ConstExpr>(p.nextId(), *constant);
+                return std::make_unique<ConstExpr>(*constant);
             }
         }
 
         /* Single field name */
-        return std::make_unique<FieldExpr>(p.nextId(), std::move(word), t);
+        return simplifyOrForward(p.env, std::make_unique<FieldExpr>(std::move(word), t));
     }
 };
 
@@ -583,15 +614,15 @@ public:
     {
         /* Self */
         if (t.type == Token::SELF)
-            return std::make_unique<FieldExpr>(p.nextId(), "_");
+            return std::make_unique<FieldExpr>("_");
 
         /* Any Child */
         if (t.type == Token::OP_TIMES)
-            return std::make_unique<AnyChildExpr>(p.nextId());
+            return std::make_unique<AnyChildExpr>();
 
         /* Wildcard */
         if (t.type == Token::WILDCARD)
-            return std::make_unique<WildcardExpr>(p.nextId());
+            return std::make_unique<WildcardExpr>();
 
         auto word = std::get<std::string>(t.value);
 
@@ -607,26 +638,26 @@ public:
             auto arguments = p.parseList(Token::RPAREN);
             TRY_EXPECTED(arguments);
 
-            return simplifyOrForward(p.env, std::make_unique<CallExpression>(p.nextId(), word, std::move(*arguments)));
+            return simplifyOrForward(p.env, std::make_unique<CallExpression>(word, std::move(*arguments)));
         } else if (!p.ctx.inPath) {
             /* Parse Symbols (words in upper-case) */
             if (isSymbolWord(word)) {
                 if (t.containsPoint(comp_->point)) {
-                    return std::make_unique<CompletionWordExpr>(p.nextId(), word.substr(0, comp_->point - t.begin), comp_, t);
+                    return std::make_unique<CompletionWordExpr>(word.substr(0, comp_->point - t.begin), comp_, t);
                 }
-                return std::make_unique<CompletionConstExpr>(p.nextId(), Value::make<std::string>(std::move(word)));
+                return std::make_unique<CompletionConstExpr>(Value::make<std::string>(std::move(word)));
             }
             /* Constant */
             else if (auto constant = p.env->findConstant(word)) {
-                return std::make_unique<ConstExpr>(p.nextId(), *constant);
+                return std::make_unique<ConstExpr>(*constant);
             }
         }
 
         /* Single field name */
         if (t.containsPoint(comp_->point)) {
-            return std::make_unique<CompletionFieldOrWordExpr>(p.nextId(), word.substr(0, comp_->point - t.begin), comp_, t, p.ctx.inPath);
+            return std::make_unique<CompletionFieldOrWordExpr>(word.substr(0, comp_->point - t.begin), comp_, t, p.ctx.inPath);
         }
-        return std::make_unique<FieldExpr>(p.nextId(), std::move(word));
+        return simplifyOrForward(p.env, std::make_unique<FieldExpr>(std::move(word)));
     }
 
     Completion* comp_;
@@ -653,7 +684,7 @@ public:
         auto right = p.parsePrecedence(precedence());
         TRY_EXPECTED(right);
 
-        return std::make_unique<PathExpr>(p.nextId(), std::move(left), std::move(*right));
+        return simplifyOrForward(p.env, std::make_unique<PathExpr>(std::move(left), std::move(*right)));
     }
 
     auto precedence() const -> int override
@@ -684,10 +715,10 @@ public:
 
         if (!*right) {
             Token expectedWord(Token::WORD, "", t.end, t.end);
-            right = std::make_unique<CompletionFieldOrWordExpr>(p.nextId(), "", comp_, expectedWord, p.ctx.inPath);
+            right = std::make_unique<CompletionFieldOrWordExpr>("", comp_, expectedWord, p.ctx.inPath);
         }
 
-        return std::make_unique<PathExpr>(p.nextId(), std::move(left), std::move(*right));
+        return simplifyOrForward(p.env, std::make_unique<PathExpr>(std::move(left), std::move(*right)));
     }
 
     Completion* comp_;
@@ -819,10 +850,8 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
 
         /* Expand a single value to `** == <value>` */
         if (autoWildcard && *root && (*root)->constant()) {
-            auto outerId = p.nextId();
-            auto innerId = p.nextId();
-            root = std::make_unique<BinaryExpr<OperatorEq>>(
-                outerId, std::make_unique<WildcardExpr>(innerId), std::move(*root));
+            root = simplifyOrForward(p.env, std::make_unique<BinaryExpr<OperatorEq>>(
+                std::make_unique<WildcardExpr>(), std::move(*root)));
         }
 
         if (!*root)
@@ -831,17 +860,22 @@ auto compile(Environment& env, std::string_view query, bool any, bool autoWildca
         if (any) {
             std::vector<ExprPtr> args;
             args.emplace_back(std::move(*root));
-            return simplifyOrForward(p.env, std::make_unique<AnyExpr>(p.nextId(), std::move(args)));
+            return simplifyOrForward(p.env, std::make_unique<AnyExpr>(std::move(args)));
         } else {
             return root;
         }
     }();
     TRY_EXPECTED(expr);
 
+    /* Apply AST rewrite rules */
+    expr = rewriteTopDown(std::move(*expr), topDownRewriteRules);
+
     if (!p.match(Token::Type::NIL))
         return unexpected<Error>(Error::ExpectedEOF, "Expected end-of-input; got "s + p.current().toString());
 
-    return std::make_unique<AST>(std::string(query), std::move(*expr));
+    auto ast = std::make_unique<AST>(std::string(query), std::move(*expr));
+    ast->reenumerate();
+    return ast;
 }
 
 auto complete(Environment& env, std::string_view query, size_t point, const ModelNode& node, const CompletionOptions& options) -> expected<std::vector<CompletionCandidate>, Error>

--- a/src/simfil.cpp
+++ b/src/simfil.cpp
@@ -21,6 +21,7 @@
 #include "rewrite-rules.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cstdint>
@@ -48,12 +49,12 @@ static constexpr std::string_view TypenameString("string");
 static constexpr std::string_view TypenameBytes("bytes");
 }
 
-static RewriteRule bottomUpRewriteRules[] = {
+static const std::array<RewriteRule, 2> bottomUpRewriteRules = {
     rewriteWildcardThis,
     rewriteWildcardField,
 };
 
-static RewriteRule topDownRewriteRules[] = {
+static const std::array<RewriteRule, 2> topDownRewriteRules = {
     rewriteAnyWildcardField,
     rewriteAnyChildField,
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(test.simfil
   common.hpp
   common.cpp
   token.cpp
+  schema.cpp
   simfil.cpp
   diagnostics.cpp
   completion.cpp

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -15,6 +15,14 @@
 #include <string>
 #include <stdexcept>
 
+#if __has_include(<valgrind/callgrind.h>)
+#    include <valgrind/callgrind.h>
+#else
+#    define RUNNING_ON_VALGRIND false
+#    define CALLGRIND_START_INSTRUMENTATION (void)0
+#    define CALLGRIND_STOP_INSTRUMENTATION (void)0
+#endif
+
 using namespace simfil;
 
 static const char* const TestModel = R"json(

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -1,6 +1,5 @@
 #include "simfil/simfil.h"
 #include "simfil/model/model.h"
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <vector>

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -1,0 +1,463 @@
+#include "simfil/diagnostics.h"
+#include "simfil/model/nodes.h"
+#include "simfil/simfil.h"
+#include "simfil/environment.h"
+#include "simfil/model/schema.h"
+#include "simfil/model/model.h"
+#include "simfil/model/json.h"
+#include "common.hpp"
+
+#include <memory>
+#include <map>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+using namespace simfil;
+
+namespace
+{
+
+class SchemaRegistry
+{
+public:
+    std::map<SchemaId, std::unique_ptr<Schema>> schemas;
+
+    // Enable schema lookup.
+    //
+    // By having this flag we do not cheat the price of
+    // the function call for the no-schema benchmarks instead
+    // of setting the environments query pointer to null.
+    bool enabled = true;
+
+    auto get(SchemaId id) const -> const Schema*
+    {
+        if (!enabled)
+            return nullptr;
+
+        auto i = schemas.find(id);
+        if (i != schemas.end())
+            return i->second.get();
+        return nullptr;
+    }
+
+    auto finalize() -> void
+    {
+        auto& self = *this;
+        for (const auto& [key, value] : schemas) {
+            value->finalize([&self](auto id) { return self(id); });
+        }
+    }
+
+    auto operator()(SchemaId id) -> Schema*
+    {
+        return const_cast<Schema*>(const_cast<const SchemaRegistry*>(this)->get(id));
+    }
+
+    auto operator()(SchemaId id) const -> const Schema*
+    {
+        return get(id);
+    }
+
+    auto asFunction() const & -> std::function<const Schema*(SchemaId)>
+    {
+        return [this](SchemaId id) {
+            return (*this)(id);
+        };
+    }
+};
+
+}
+
+TEST_CASE("Object schema id assignment", "[model.schema]") {
+    auto model = std::make_shared<ModelPool>();
+
+    auto obj = model->newObject(0);
+    REQUIRE(obj->schema() == NoSchemaId);
+
+    obj->setSchema(SchemaId{1});
+    REQUIRE(obj->schema() == SchemaId{1});
+}
+
+TEST_CASE("Singleton object schema id assignment", "[model.schema]") {
+    auto model = std::make_shared<ModelPool>();
+
+    auto obj = model->newObject(1, true);
+    REQUIRE(obj->schema() == NoSchemaId);
+
+    REQUIRE(obj->addField("field", int64_t{1}));
+    obj->setSchema(SchemaId{1});
+    REQUIRE(obj->schema() == SchemaId{1});
+    REQUIRE(model->validate());
+}
+
+TEST_CASE("Array schema id assignment", "[model.schema]") {
+    auto model = std::make_shared<ModelPool>();
+
+    auto arr = model->newArray(0);
+    REQUIRE(arr->schema() == NoSchemaId);
+
+    arr->setSchema(SchemaId{1});
+    REQUIRE(arr->schema() == SchemaId{1});
+}
+
+TEST_CASE("Singleton array schema id assignment", "[model.schema]") {
+    auto model = std::make_shared<ModelPool>();
+
+    auto arr = model->newArray(1, true);
+    REQUIRE(arr->schema() == NoSchemaId);
+
+    arr->append(int64_t(1));
+    arr->setSchema(SchemaId{1});
+    REQUIRE(arr->schema() == SchemaId{1});
+    REQUIRE(model->validate());
+}
+
+TEST_CASE("Object schema finalization", "[model.schema]") {
+    auto strings = std::make_shared<StringPool>();
+    const auto a = strings->emplace("a").value();
+    const auto b = strings->emplace("b").value();
+    const auto c = strings->emplace("c").value();
+    const auto link = strings->emplace("link").value();
+    const auto back = strings->emplace("back").value();
+    const auto missing = strings->emplace("missing").value();
+
+    SECTION("dirty schemas are conservative") {
+        ObjectSchema schema;
+        schema.addField(a);
+
+        // No finalize() called, so canHaveField must return `true`.
+        REQUIRE(schema.canHaveField(a));
+        REQUIRE(schema.canHaveField(missing));
+
+        schema.finalize([](SchemaId) { return nullptr; });
+        REQUIRE(schema.canHaveField(a));
+        REQUIRE(!schema.canHaveField(missing));
+    }
+
+    SECTION("acyclic schemas finalize fields") {
+        std::vector<ObjectSchema> schemas(3);
+        schemas[1].addField(a, {SchemaId{2}});
+        schemas[2].addField(b);
+
+        auto lookup = [&](SchemaId schemaId) -> ObjectSchema* {
+            const auto index = static_cast<std::size_t>(schemaId);
+            return index < schemas.size() ? &schemas[index] : nullptr;
+        };
+
+        schemas[1].finalize(lookup);
+
+        REQUIRE(schemas[1].canHaveField(a));
+        REQUIRE(schemas[1].canHaveField(b));
+        REQUIRE_FALSE(schemas[1].canHaveField(c));
+    }
+
+    SECTION("cyclic schemas stay conservative") {
+        std::vector<ObjectSchema> schemas(3);
+        schemas[1].addField(link, {SchemaId{2}});
+        schemas[1].addField(c);
+        schemas[2].addField(back, {SchemaId{1}});
+
+        auto lookup = [&](SchemaId schemaId) -> ObjectSchema* {
+            const auto index = static_cast<std::size_t>(schemaId);
+            return index < schemas.size() ? &schemas[index] : nullptr;
+        };
+
+        schemas[1].finalize(lookup);
+
+        REQUIRE(schemas[1].canHaveField(missing));
+        REQUIRE(schemas[2].canHaveField(missing));
+    }
+
+    SECTION("array schemas finalize element fields") {
+        ObjectSchema objectA;
+        objectA.addField(a);
+
+        ObjectSchema objectB;
+        objectB.addField(b);
+
+        ArraySchema arraySchema;
+        arraySchema.addElementSchemas({SchemaId{1}, SchemaId{2}});
+
+        auto lookup = [&](SchemaId schemaId) -> Schema* {
+            switch (schemaId) {
+            case SchemaId{1}:
+                return &objectA;
+            case SchemaId{2}:
+                return &objectB;
+            default:
+                return nullptr;
+            }
+        };
+
+        arraySchema.finalize(lookup);
+
+        REQUIRE(arraySchema.canHaveField(a));
+        REQUIRE(arraySchema.canHaveField(b));
+        REQUIRE_FALSE(arraySchema.canHaveField(c));
+    }
+}
+
+TEST_CASE("Array schema serialization", "[model.schema]") {
+    auto model = std::make_shared<ModelPool>();
+    auto arr = model->newArray(1);
+    arr->append(int64_t(42));
+    REQUIRE(arr->setSchema(SchemaId{7}));
+    model->addRoot(arr);
+
+    std::stringstream stream;
+    REQUIRE(model->write(stream));
+
+    const auto input = std::vector<uint8_t>(std::istreambuf_iterator<char>(stream), {});
+    auto recoveredModel = std::make_shared<ModelPool>();
+    REQUIRE(recoveredModel->read(input));
+
+    auto recoveredRoot = recoveredModel->root(0);
+    REQUIRE(recoveredRoot);
+    REQUIRE((*recoveredRoot)->type() == ValueType::Array);
+    REQUIRE((*recoveredRoot)->schema() == SchemaId{7});
+}
+
+// A minimal test that makes sure a field not in the schema
+// is pruned if we query for it via **.field.
+TEST_CASE("WildcardFieldExpr Field Pruning", "[model.schema]")
+{
+    auto jsonModel = R"json(
+    {
+      "field": 123
+    }
+    )json";
+    auto model = json::parse(jsonModel).value();
+    auto registry = SchemaRegistry{};
+    auto strings = model->strings();
+    auto fieldId = strings->get("field");
+
+    // We need to add "noField" to the StringPool to prevent
+    // evaluation skipping the expression.
+    (void)strings->emplace("noField");
+
+    // Build a simple schema
+    auto schemaName = strings->emplace("schema1").value();
+    auto schema1 = std::make_unique<ObjectSchema>();
+    schema1->addField(fieldId, { NoSchemaId });
+
+    registry.schemas[(SchemaId)schemaName] = std::move(schema1);
+    registry.finalize();
+
+    // Assign schemas to the model
+    auto root = model->root(0);
+    REQUIRE(root);
+
+    auto rootObj = model->resolve<Object>(*root.value());
+    REQUIRE(rootObj);
+    REQUIRE(rootObj->setSchema((SchemaId)schemaName));
+    REQUIRE(rootObj->schema() == (SchemaId)schemaName);
+
+    // Run a query and check if pruning of unknown fields works
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto ast = compile(env, "**.noField", false, false);
+    REQUIRE(ast);
+
+    Diagnostics diagWithPruning;
+    registry.enabled = true;
+    auto resultWithPruning = eval(env, *ast.value(), *model->root(0).value(), &diagWithPruning);
+    REQUIRE(resultWithPruning);
+
+    Diagnostics diagNoPruning;
+    registry.enabled = false;
+    auto resultNoPruning = eval(env, *ast.value(), *model->root(0).value(), &diagNoPruning);
+    REQUIRE(resultNoPruning);
+
+    // We compare field evaluations for both runs
+    auto withPruningData = diagWithPruning.fieldData_[0];
+    auto noPruningData = diagNoPruning.fieldData_[0];
+    REQUIRE(withPruningData.evaluations < noPruningData.evaluations);
+}
+
+TEST_CASE("WildcardFieldExpr Array Field Pruning", "[model.schema]")
+{
+    auto jsonModel = R"json(
+    [
+      {
+        "field": 123
+      }
+    ]
+    )json";
+    auto model = json::parse(jsonModel).value();
+    auto registry = SchemaRegistry{};
+    auto strings = model->strings();
+    auto fieldId = strings->get("field");
+
+    (void)strings->emplace("noField");
+
+    constexpr auto objectSchemaId = SchemaId{1};
+    constexpr auto arraySchemaId = SchemaId{2};
+
+    auto objectSchema = std::make_unique<ObjectSchema>();
+    objectSchema->addField(fieldId, { NoSchemaId });
+    registry.schemas[objectSchemaId] = std::move(objectSchema);
+
+    auto arraySchema = std::make_unique<ArraySchema>();
+    arraySchema->addElementSchemas({objectSchemaId});
+    registry.schemas[arraySchemaId] = std::move(arraySchema);
+    registry.finalize();
+
+    auto root = model->root(0);
+    REQUIRE(root);
+    auto rootArray = model->resolve<Array>(*root.value());
+
+    REQUIRE(rootArray);
+    REQUIRE(rootArray->setSchema(arraySchemaId));
+    REQUIRE(rootArray->schema() == arraySchemaId);
+
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto ast = compile(env, "**.noField", false, false);
+    REQUIRE(ast);
+
+    auto modelRoot = model->root(0);
+    REQUIRE(modelRoot);
+
+    Diagnostics diagWithPruning;
+    registry.enabled = true;
+    auto resultWithPruning = eval(env, **ast, **modelRoot, &diagWithPruning);
+    REQUIRE(resultWithPruning);
+
+    Diagnostics diagNoPruning;
+    registry.enabled = false;
+    auto resultNoPruning = eval(env, **ast, **modelRoot, &diagNoPruning);
+    REQUIRE(resultNoPruning);
+
+    auto withPruningData = diagWithPruning.fieldData_[0];
+    auto noPruningData = diagNoPruning.fieldData_[0];
+    REQUIRE(withPruningData.evaluations < noPruningData.evaluations);
+}
+
+TEST_CASE("Schema query performance", "[perf.schema]") {
+    if (RUNNING_ON_VALGRIND) { // NOLINT
+        SKIP("Skipping benchmarks when running under valgrind");
+    }
+
+    constexpr auto n = std::size_t{10'000};
+    static_assert(n % 2 == 0, "n must be even");
+
+    const auto payloadASchemaId = SchemaId{1};
+    const auto payloadBSchemaId = SchemaId{2};
+    const auto xASchemaId = SchemaId{3};
+    const auto xBSchemaId = SchemaId{4};
+    const auto yASchemaId = SchemaId{5};
+    const auto yBSchemaId = SchemaId{6};
+    const auto rootObjASchemaId = SchemaId{7};
+    const auto rootObjBSchemaId = SchemaId{8};
+    const auto arraySchemaId = SchemaId{9};
+
+    auto strings = std::make_shared<StringPool>();
+    auto model = std::make_shared<ModelPool>(strings);
+    auto registry = SchemaRegistry{};
+
+    const auto aId = strings->emplace("a").value();
+    const auto bId = strings->emplace("b").value();
+    const auto yId = strings->emplace("y").value();
+    const auto xId = strings->emplace("x").value();
+    const auto payloadId = strings->emplace("payload").value();
+
+    auto payloadASchema = std::make_unique<ObjectSchema>();
+    payloadASchema->addField(xId, { xASchemaId });
+    registry.schemas[payloadASchemaId] = std::move(payloadASchema);
+
+    auto payloadBSchema = std::make_unique<ObjectSchema>();
+    payloadBSchema->addField(xId, { xBSchemaId });
+    registry.schemas[payloadBSchemaId] = std::move(payloadBSchema);
+
+    auto xASchema = std::make_unique<ObjectSchema>();
+    xASchema->addField(yId, { yASchemaId });
+    registry.schemas[xASchemaId] = std::move(xASchema);
+
+    auto xBSchema = std::make_unique<ObjectSchema>();
+    xBSchema->addField(yId, { yBSchemaId });
+    registry.schemas[xBSchemaId] = std::move(xBSchema);
+
+    auto yASchema = std::make_unique<ObjectSchema>();
+    yASchema->addField(aId);
+    registry.schemas[yASchemaId] = std::move(yASchema);
+
+    auto yBSchema = std::make_unique<ObjectSchema>();
+    yBSchema->addField(bId);
+    registry.schemas[yBSchemaId] = std::move(yBSchema);
+
+    auto rootObjASchema = std::make_unique<ObjectSchema>();
+    rootObjASchema->addField(payloadId, { payloadASchemaId });
+    registry.schemas[rootObjASchemaId] = std::move(rootObjASchema);
+
+    auto rootObjBSchema = std::make_unique<ObjectSchema>();
+    rootObjBSchema->addField(payloadId, { payloadBSchemaId });
+    registry.schemas[rootObjBSchemaId] = std::move(rootObjBSchema);
+
+    auto arraySchema = std::make_unique<ArraySchema>();
+    arraySchema->addElementSchemas({ rootObjASchemaId, rootObjBSchemaId });
+    registry.schemas[arraySchemaId] = std::move(arraySchema);
+    registry.finalize();
+
+    auto root = model->newArray(n);
+    for (auto i = 0u; i < n; ++i) {
+        auto obj = model->newObject(1, true);
+        auto payload = model->newObject(1, true);
+        auto x = model->newObject(1, true);
+        auto y = model->newObject(1, true);
+
+        if (i % 2 == 0) {
+            y->addField("a", int64_t(1));
+            y->setSchema(yASchemaId);
+            x->setSchema(xASchemaId);
+            payload->setSchema(payloadASchemaId);
+            obj->setSchema(rootObjASchemaId);
+        } else {
+            y->addField("b", int64_t(1));
+            y->setSchema(yBSchemaId);
+            x->setSchema(xBSchemaId);
+            payload->setSchema(payloadBSchemaId);
+            obj->setSchema(rootObjBSchemaId);
+        }
+
+        x->addField("y", y);
+        payload->addField("x", x);
+        obj->addField("payload", payload);
+        root->append(obj);
+    }
+
+    REQUIRE(root->setSchema(arraySchemaId));
+    model->addRoot(root);
+
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto ast = compile(env, "count(**.a == 1)", false, false);
+    REQUIRE(ast);
+
+    auto modelRoot = model->root(0);
+    REQUIRE(modelRoot);
+
+    registry.enabled = false;
+    BENCHMARK("Query nested field 'a' recursive without schema") {
+        auto res = eval(env, **ast, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(n / 2));
+        return count;
+    };
+
+    registry.enabled = true;
+    BENCHMARK("Query nested field 'a' recursive with schema") {
+        auto res = eval(env, **ast, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(n / 2));
+        return count;
+    };
+}

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -361,6 +361,7 @@ TEST_CASE("Schema query performance", "[perf.schema]") {
     const auto bId = strings->emplace("b").value();
     const auto yId = strings->emplace("y").value();
     const auto xId = strings->emplace("x").value();
+    const auto missingId = strings->emplace("missing").value();
     const auto payloadId = strings->emplace("payload").value();
 
     auto payloadASchema = std::make_unique<ObjectSchema>();
@@ -433,15 +434,18 @@ TEST_CASE("Schema query performance", "[perf.schema]") {
     Environment env(strings);
     env.querySchemaCallback = registry.asFunction();
 
-    auto ast = compile(env, "count(**.a == 1)", false, false);
-    REQUIRE(ast);
-
     auto modelRoot = model->root(0);
     REQUIRE(modelRoot);
 
+    auto aAst = compile(env, "count(**.a == 1)", false, false);
+    REQUIRE(aAst);
+
+    auto missingAst = compile(env, "count(**.missing == 1)", false, false);
+    REQUIRE(missingAst);
+
     registry.enabled = false;
     BENCHMARK("Query nested field 'a' recursive without schema") {
-        auto res = eval(env, **ast, **modelRoot, nullptr);
+        auto res = eval(env, **aAst, **modelRoot, nullptr);
         REQUIRE(res);
         REQUIRE(res->size() == 1);
 
@@ -450,14 +454,34 @@ TEST_CASE("Schema query performance", "[perf.schema]") {
         return count;
     };
 
+    BENCHMARK("Query missing field 'missing' without schema") {
+        auto res = eval(env, **missingAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == 0);
+        return count;
+    };
+
     registry.enabled = true;
     BENCHMARK("Query nested field 'a' recursive with schema") {
-        auto res = eval(env, **ast, **modelRoot, nullptr);
+        auto res = eval(env, **aAst, **modelRoot, nullptr);
         REQUIRE(res);
         REQUIRE(res->size() == 1);
 
         auto count = res->front().template as<ValueType::Int>();
         REQUIRE(count == int64_t(n / 2));
+        return count;
+    };
+
+    BENCHMARK("Query missing field 'missing' with schema") {
+        auto res = eval(env, **missingAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == 0);
         return count;
     };
 }

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -335,6 +335,45 @@ TEST_CASE("WildcardFieldExpr Array Field Pruning", "[model.schema]")
     REQUIRE(withPruningData.evaluations < noPruningData.evaluations);
 }
 
+TEST_CASE("WildcardFieldExpr non-recursive queries ignore partial root schemas", "[model.schema]")
+{
+    auto jsonModel = R"json(
+    {
+      "object": {
+        "field": 123
+      }
+    }
+    )json";
+    auto model = json::parse(jsonModel).value();
+    auto registry = SchemaRegistry{};
+    auto strings = model->strings();
+    auto objectId = strings->get("object");
+    (void)strings->emplace("field");
+
+    const auto rootSchemaId = SchemaId{1};
+    auto rootSchema = std::make_unique<ObjectSchema>();
+    rootSchema->addField(objectId, { NoSchemaId });
+    registry.schemas[rootSchemaId] = std::move(rootSchema);
+    registry.finalize();
+
+    auto root = model->root(0);
+    REQUIRE(root);
+    auto rootObj = model->resolve<Object>(*root.value());
+    REQUIRE(rootObj);
+    REQUIRE(rootObj->setSchema(rootSchemaId));
+
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto ast = compile(env, "*.field", false, false);
+    REQUIRE(ast);
+
+    auto result = eval(env, **ast, **root, nullptr);
+    REQUIRE(result);
+    REQUIRE(result->size() == 1);
+    REQUIRE((*result)[0].toString() == "123");
+}
+
 TEST_CASE("Schema query performance", "[perf.schema]") {
     if (RUNNING_ON_VALGRIND) { // NOLINT
         SKIP("Skipping benchmarks when running under valgrind");

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -34,8 +34,17 @@ public:
         if (!enabled)
             return nullptr;
 
-        auto i = schemas.find(id);
-        if (i != schemas.end())
+        if (auto i = schemas.find(id); i != schemas.end())
+            return i->second.get();
+        return nullptr;
+    }
+
+    auto get(SchemaId id) -> Schema*
+    {
+        if (!enabled)
+            return nullptr;
+
+        if (auto i = schemas.find(id); i != schemas.end())
             return i->second.get();
         return nullptr;
     }
@@ -43,14 +52,14 @@ public:
     auto finalize() -> void
     {
         auto& self = *this;
-        for (const auto& [key, value] : schemas) {
+        for (const auto& [_, value] : schemas) {
             value->finalize([&self](auto id) { return self(id); });
         }
     }
 
     auto operator()(SchemaId id) -> Schema*
     {
-        return const_cast<Schema*>(const_cast<const SchemaRegistry*>(this)->get(id));
+        return get(id);
     }
 
     auto operator()(SchemaId id) const -> const Schema*
@@ -139,7 +148,7 @@ TEST_CASE("Object schema finalization", "[model.schema]") {
         schemas[1].addField(a, {SchemaId{2}});
         schemas[2].addField(b);
 
-        auto lookup = [&](SchemaId schemaId) -> ObjectSchema* {
+        auto lookup = [&schemas](SchemaId schemaId) {
             const auto index = static_cast<std::size_t>(schemaId);
             return index < schemas.size() ? &schemas[index] : nullptr;
         };
@@ -151,21 +160,29 @@ TEST_CASE("Object schema finalization", "[model.schema]") {
         REQUIRE_FALSE(schemas[1].canHaveField(c));
     }
 
-    SECTION("cyclic schemas stay conservative") {
+    SECTION("cyclic schemas collect reachable fields") {
         std::vector<ObjectSchema> schemas(3);
         schemas[1].addField(link, {SchemaId{2}});
         schemas[1].addField(c);
         schemas[2].addField(back, {SchemaId{1}});
 
-        auto lookup = [&](SchemaId schemaId) -> ObjectSchema* {
+        auto lookup = [&schemas](SchemaId schemaId) {
             const auto index = static_cast<std::size_t>(schemaId);
             return index < schemas.size() ? &schemas[index] : nullptr;
         };
 
         schemas[1].finalize(lookup);
+        schemas[2].finalize(lookup);
 
-        REQUIRE(schemas[1].canHaveField(missing));
-        REQUIRE(schemas[2].canHaveField(missing));
+        REQUIRE(schemas[1].canHaveField(link));
+        REQUIRE(schemas[1].canHaveField(back));
+        REQUIRE(schemas[1].canHaveField(c));
+        REQUIRE_FALSE(schemas[1].canHaveField(missing));
+
+        REQUIRE(schemas[2].canHaveField(link));
+        REQUIRE(schemas[2].canHaveField(back));
+        REQUIRE(schemas[2].canHaveField(c));
+        REQUIRE_FALSE(schemas[2].canHaveField(missing));
     }
 
     SECTION("array schemas finalize element fields") {
@@ -178,7 +195,7 @@ TEST_CASE("Object schema finalization", "[model.schema]") {
         ArraySchema arraySchema;
         arraySchema.addElementSchemas({SchemaId{1}, SchemaId{2}});
 
-        auto lookup = [&](SchemaId schemaId) -> Schema* {
+        auto lookup = [&objectA, &objectB](SchemaId schemaId) -> Schema* {
             switch (schemaId) {
             case SchemaId{1}:
                 return &objectA;

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -691,7 +691,19 @@ TEST_CASE("Sparse wide schema query performance", "[perf.schema]") {
     };
 
     registry.enabled = true;
-    BENCHMARK("Query sparse wide field 'target' recursive with schema") {
+    env.enableWildcardFieldPlans = false;
+    BENCHMARK("Query sparse wide field 'target' recursive with basic schema pruning") {
+        auto res = eval(env, **targetAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(objectCount));
+        return count;
+    };
+
+    env.enableWildcardFieldPlans = true;
+    BENCHMARK("Query sparse wide field 'target' recursive with schema field plans") {
         auto res = eval(env, **targetAst, **modelRoot, nullptr);
         REQUIRE(res);
         REQUIRE(res->size() == 1);

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -679,6 +679,9 @@ TEST_CASE("Sparse wide schema query performance", "[perf.schema]") {
     auto targetAst = compile(env, "count(**.target == 1)", false, false);
     REQUIRE(targetAst);
 
+    auto exactPathAst = compile(env, "count(*." + branchNames.front() + ".payload.target == 1)", false, false);
+    REQUIRE(exactPathAst);
+
     registry.enabled = false;
     BENCHMARK("Query sparse wide field 'target' recursive without schema") {
         auto res = eval(env, **targetAst, **modelRoot, nullptr);
@@ -705,6 +708,18 @@ TEST_CASE("Sparse wide schema query performance", "[perf.schema]") {
     env.enableWildcardFieldPlans = true;
     BENCHMARK("Query sparse wide field 'target' recursive with schema field plans") {
         auto res = eval(env, **targetAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(objectCount));
+        return count;
+    };
+
+    registry.enabled = false;
+    env.enableWildcardFieldPlans = false;
+    BENCHMARK("Query sparse wide field 'target' via exact path without schema") {
+        auto res = eval(env, **exactPathAst, **modelRoot, nullptr);
         REQUIRE(res);
         REQUIRE(res->size() == 1);
 

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -9,6 +9,8 @@
 
 #include <memory>
 #include <map>
+#include <string>
+#include <vector>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark.hpp>
 
@@ -584,6 +586,118 @@ TEST_CASE("Schema query performance", "[perf.schema]") {
 
         auto count = res->front().template as<ValueType::Int>();
         REQUIRE(count == 0);
+        return count;
+    };
+}
+
+TEST_CASE("Sparse wide schema query performance", "[perf.schema]") {
+    if (RUNNING_ON_VALGRIND) { // NOLINT
+        SKIP("Skipping benchmarks when running under valgrind");
+    }
+
+    constexpr auto objectCount = std::size_t{2'000};
+    constexpr auto branchCount = std::size_t{32};
+
+    const auto targetBranchSchemaId = SchemaId{1};
+    const auto targetPayloadSchemaId = SchemaId{2};
+    const auto noiseBranchSchemaId = SchemaId{3};
+    const auto rootObjectSchemaId = SchemaId{4};
+    const auto arraySchemaId = SchemaId{5};
+
+    auto strings = std::make_shared<StringPool>();
+    auto model = std::make_shared<ModelPool>(strings);
+    auto registry = SchemaRegistry{};
+
+    const auto targetId = strings->emplace("target").value();
+    const auto payloadId = strings->emplace("payload").value();
+    const auto noiseId = strings->emplace("noise").value();
+
+    std::vector<std::string> branchNames;
+    std::vector<StringId> branchIds;
+    branchNames.reserve(branchCount);
+    branchIds.reserve(branchCount);
+    for (auto branchIndex = std::size_t{0}; branchIndex < branchCount; ++branchIndex) {
+        branchNames.push_back("branch" + std::to_string(branchIndex));
+        branchIds.push_back(strings->emplace(branchNames.back()).value());
+    }
+
+    auto targetBranchSchema = std::make_unique<ObjectSchema>();
+    targetBranchSchema->addField(payloadId, { targetPayloadSchemaId });
+    registry.schemas[targetBranchSchemaId] = std::move(targetBranchSchema);
+
+    auto targetPayloadSchema = std::make_unique<ObjectSchema>();
+    targetPayloadSchema->addField(targetId);
+    registry.schemas[targetPayloadSchemaId] = std::move(targetPayloadSchema);
+
+    auto noiseBranchSchema = std::make_unique<ObjectSchema>();
+    noiseBranchSchema->addField(noiseId);
+    registry.schemas[noiseBranchSchemaId] = std::move(noiseBranchSchema);
+
+    auto rootObjectSchema = std::make_unique<ObjectSchema>();
+    rootObjectSchema->addField(branchIds.front(), { targetBranchSchemaId });
+    for (auto branchIndex = std::size_t{1}; branchIndex < branchCount; ++branchIndex)
+        rootObjectSchema->addField(branchIds[branchIndex], { noiseBranchSchemaId });
+    registry.schemas[rootObjectSchemaId] = std::move(rootObjectSchema);
+
+    auto arraySchema = std::make_unique<ArraySchema>();
+    arraySchema->addElementSchemas({ rootObjectSchemaId });
+    registry.schemas[arraySchemaId] = std::move(arraySchema);
+    registry.finalize();
+
+    auto root = model->newArray(objectCount);
+    for (auto objectIndex = std::size_t{0}; objectIndex < objectCount; ++objectIndex) {
+        auto obj = model->newObject(branchCount, true);
+
+        auto targetBranch = model->newObject(1, true);
+        auto targetPayload = model->newObject(1, true);
+        targetPayload->addField("target", int64_t(1));
+        REQUIRE(targetPayload->setSchema(targetPayloadSchemaId));
+        targetBranch->addField("payload", targetPayload);
+        REQUIRE(targetBranch->setSchema(targetBranchSchemaId));
+        obj->addField(branchNames.front(), targetBranch);
+
+        for (auto branchIndex = std::size_t{1}; branchIndex < branchCount; ++branchIndex) {
+            auto noiseBranch = model->newObject(1, true);
+            noiseBranch->addField("noise", static_cast<int64_t>(objectIndex + branchIndex));
+            REQUIRE(noiseBranch->setSchema(noiseBranchSchemaId));
+            obj->addField(branchNames[branchIndex], noiseBranch);
+        }
+
+        REQUIRE(obj->setSchema(rootObjectSchemaId));
+        root->append(obj);
+    }
+
+    REQUIRE(root->setSchema(arraySchemaId));
+    model->addRoot(root);
+
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto modelRoot = model->root(0);
+    REQUIRE(modelRoot);
+
+    auto targetAst = compile(env, "count(**.target == 1)", false, false);
+    REQUIRE(targetAst);
+
+    registry.enabled = false;
+    BENCHMARK("Query sparse wide field 'target' recursive without schema") {
+        auto res = eval(env, **targetAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(objectCount));
+        return count;
+    };
+
+    registry.enabled = true;
+    BENCHMARK("Query sparse wide field 'target' recursive with schema") {
+        auto res = eval(env, **targetAst, **modelRoot, nullptr);
+        REQUIRE(res);
+        REQUIRE(res->size() == 1);
+
+        auto count = res->front().template as<ValueType::Int>();
+        REQUIRE(count == int64_t(objectCount));
         return count;
     };
 }

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -391,6 +391,52 @@ TEST_CASE("WildcardFieldExpr non-recursive queries ignore partial root schemas",
     REQUIRE((*result)[0].toString() == "123");
 }
 
+TEST_CASE("WildcardFieldExpr schema plan cache follows schema mutations", "[model.schema]")
+{
+    auto jsonModel = R"json(
+    {
+      "target": 123
+    }
+    )json";
+    auto model = json::parse(jsonModel).value();
+    auto registry = SchemaRegistry{};
+    auto strings = model->strings();
+    auto targetId = strings->get("target");
+    auto otherId = strings->emplace("other").value();
+
+    const auto rootSchemaId = SchemaId{1};
+    auto rootSchema = std::make_unique<ObjectSchema>();
+    auto* rootSchemaPtr = rootSchema.get();
+    rootSchema->addField(otherId);
+    registry.schemas[rootSchemaId] = std::move(rootSchema);
+    registry.finalize();
+
+    auto root = model->root(0);
+    REQUIRE(root);
+    auto rootObj = model->resolve<Object>(*root.value());
+    REQUIRE(rootObj);
+    REQUIRE(rootObj->setSchema(rootSchemaId));
+
+    Environment env(strings);
+    env.querySchemaCallback = registry.asFunction();
+
+    auto ast = compile(env, "**.target", false, false);
+    REQUIRE(ast);
+
+    auto beforeSchemaUpdate = eval(env, **ast, **root, nullptr);
+    REQUIRE(beforeSchemaUpdate);
+    REQUIRE(beforeSchemaUpdate->size() == 1);
+    REQUIRE((*beforeSchemaUpdate)[0].isa(ValueType::Null));
+
+    rootSchemaPtr->addField(targetId);
+    registry.finalize();
+
+    auto afterSchemaUpdate = eval(env, **ast, **root, nullptr);
+    REQUIRE(afterSchemaUpdate);
+    REQUIRE(afterSchemaUpdate->size() == 1);
+    REQUIRE((*afterSchemaUpdate)[0].toString() == "123");
+}
+
 TEST_CASE("Schema query performance", "[perf.schema]") {
     if (RUNNING_ON_VALGRIND) { // NOLINT
         SKIP("Skipping benchmarks when running under valgrind");

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -57,6 +57,7 @@ TEST_CASE("Path", "[ast.path]") {
 TEST_CASE("Wildcard", "[ast.wildcard]") {
     REQUIRE_AST("*", "*");
     REQUIRE_AST("**", "**");
+    REQUIRE_AST("*.a", "*.a");
     REQUIRE_AST("**.a", "**.a"); /* Optimization rewrites this from (. ** a) to **.a */
     REQUIRE_AST("**.a.b.c", "(. (. **.a b) c)");
     REQUIRE_AST("a.**.b", "(. a **.b)");

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -57,9 +57,10 @@ TEST_CASE("Path", "[ast.path]") {
 TEST_CASE("Wildcard", "[ast.wildcard]") {
     REQUIRE_AST("*", "*");
     REQUIRE_AST("**", "**");
-    REQUIRE_AST("**.a", "(. ** a)");
-    REQUIRE_AST("a.**.b", "(. (. a **) b)");
-    REQUIRE_AST("a.**.b.**.c", "(. (. (. (. a **) b) **) c)");
+    REQUIRE_AST("**.a", "**.a"); /* Optimization rewrites this from (. ** a) to **.a */
+    REQUIRE_AST("**.a.b.c", "(. (. **.a b) c)");
+    REQUIRE_AST("a.**.b", "(. a **.b)");
+    REQUIRE_AST("a.**.b.**.c", "(. (. a **.b) **.c)");
 
     REQUIRE_AST("* == *", "(== * *)");     /* Do not optimize away */
     REQUIRE_AST("** == **", "(== ** **)"); /* Do not optimize away */
@@ -425,6 +426,7 @@ TEST_CASE("Path Wildcard", "[yaml.path-wildcard]") {
     REQUIRE_RESULT("sub.*", R"(sub a|sub b|{"a":"sub sub a","b":"sub sub b"})");
     REQUIRE_RESULT("sub.**", R"({"a":"sub a","b":"sub b","sub":{"a":"sub sub a","b":"sub sub b"}}|sub a|sub b|)"
                              R"({"a":"sub sub a","b":"sub sub b"}|sub sub a|sub sub b)");
+    REQUIRE_RESULT("**.a", "1|sub a|sub sub a");
     REQUIRE_RESULT("(sub.*.{typeof _ != 'model'} + sub.*.{typeof _ != 'model'})._", "sub asub a|sub asub b|sub bsub a|sub bsub b"); /* . filters null */
     REQUIRE_RESULT("sub.*.{typeof _ != 'model'} + sub.*.{typeof _ != 'model'}", "sub asub a|sub asub b|sub bsub a|sub bsub b"); /* {_} filters null */
     REQUIRE_RESULT("count(*)", "12");
@@ -754,10 +756,33 @@ TEST_CASE("Visit AST", "[visit.ast]")
 
             visitedFieldName = expr.name_;
         }
+
+        auto visit(const WildcardFieldExpr& expr) -> void override
+        {
+            ExprVisitor::visit(expr);
+
+            visitedFieldName = expr.name_;
+        }
     };
 
     Visitor visitor;
     (*ast)->expr().accept(visitor);
 
     REQUIRE(visitor.visitedFieldName == "field");
+}
+
+TEST_CASE("AST expr ids are reenumerated after rewrites", "[ast.expr-id]")
+{
+    auto ast = Compile("**.field = 123", false);
+
+    std::vector<Expr::ExprId> ids;
+    const auto collectIds = [&](const auto& self, const Expr& expr) -> void {
+        ids.emplace_back(expr.id());
+        for (auto i = 0u; i < expr.numChildren(); ++i)
+            self(self, *expr.childAt(i));
+    };
+
+    collectIds(collectIds, ast->expr());
+
+    REQUIRE(ids == std::vector<Expr::ExprId>{0, 1, 2});
 }

--- a/test/simfil.cpp
+++ b/test/simfil.cpp
@@ -772,6 +772,50 @@ TEST_CASE("Visit AST", "[visit.ast]")
     REQUIRE(visitor.visitedFieldName == "field");
 }
 
+TEST_CASE("Visitors traverse unary children once", "[visit.ast]")
+{
+    UnaryExpr<OperatorNot> expr(std::make_unique<FieldExpr>("field"));
+
+    struct Visitor : ExprVisitor
+    {
+        int fieldVisits = 0;
+
+        using ExprVisitor::visit;
+
+        auto visit(const FieldExpr& expr) -> void override
+        {
+            ExprVisitor::visit(expr);
+            ++fieldVisits;
+        }
+    };
+
+    Visitor visitor;
+    expr.accept(visitor);
+
+    REQUIRE(visitor.fieldVisits == 1);
+}
+
+TEST_CASE("Parsed token locations are preserved", "[ast.source-location]")
+{
+    Environment env(Environment::WithNewStringCache);
+
+    auto fieldAst = compile(env, "field", false, false);
+    REQUIRE(fieldAst);
+
+    const auto* fieldExpr = dynamic_cast<const FieldExpr*>(&(*fieldAst)->expr());
+    REQUIRE(fieldExpr);
+    REQUIRE(fieldExpr->sourceLocation().offset == 0);
+    REQUIRE(fieldExpr->sourceLocation().size == 5);
+
+    auto binaryAst = compile(env, "field + 1", false, false);
+    REQUIRE(binaryAst);
+
+    const auto* binaryExpr = dynamic_cast<const BinaryExpr<OperatorAdd>*>(&(*binaryAst)->expr());
+    REQUIRE(binaryExpr);
+    REQUIRE(binaryExpr->sourceLocation().offset == 6);
+    REQUIRE(binaryExpr->sourceLocation().size == 1);
+}
+
 TEST_CASE("AST expr ids are reenumerated after rewrites", "[ast.expr-id]")
 {
     auto ast = Compile("**.field = 123", false);

--- a/test/value.cpp
+++ b/test/value.cpp
@@ -1,9 +1,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 #include <cstdint>
+#include <iterator>
+#include <sstream>
 
 #include "simfil/value.h"
 #include "simfil/model/model.h"
+#include "simfil/model/schema.h"
 #include "simfil/token.h"
 #include "simfil/transient.h"
 


### PR DESCRIPTION
# Changes
- Two new lists `bottomUpRewriteRules` and `topDownRewriteRules` holding expression rewrite functions are applied bottom-up and top-down to the AST during- and post compilation
- A new `WildcardFieldExpr` replaces `PathExpr(WildcardExpr, FieldExpr)` and implements candidate pruning by querying the node's schema
- Some small expression rewrites for redundant expressions (`**._ → **`, `_._ → _`, …)
- Expression IDs are now assigned post compilation
- Model object- and array-ids now point to an opaque `SchemaId` (`sizeof(SchemaId) == sizeof(StringId)`)
- Simfil provides no schema registry but expects the API user to provide a `SchemaId -> const Schema*` callback to the `Environment`
- Added a generic traversal API to `Expr` in addition to the `ExprVisitor` API

# Future Plans
- Add a basic JSONSchema registry (follow-up PR)
- Add more flexible AST rewrites to support pruning in non-trivial queries

Naive test gives $\approx \frac{1}{3}%$ speedup.