### PR TITLE
Add enum symbols to schema metadata

### DIFF
--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -89,6 +89,17 @@ public:
     virtual auto nestedFields() const & -> std::span<const StringId> = 0;
 
     /**
+     * Return field names directly available on this schema node.
+     *
+     * Completion uses this to suggest fields valid at the current node without
+     * also suggesting fields that only occur deeper in the schema graph.
+     */
+    virtual auto directFields() const & -> std::span<const StringId>
+    {
+        return nestedFields();
+    }
+
+    /**
      * @return All nested enum-like string symbols.
      */
     virtual auto nestedEnumSymbols() const & -> std::span<const StringId>
@@ -297,6 +308,7 @@ public:
         summary.field = field;
         summary.schemas.insert(summary.schemas.end(), schemas.begin(), schemas.end());
         fields_.push_back(std::move(summary));
+        directFields_.push_back(field);
         state_ = State::Dirty;
         ++revision_;
     }
@@ -318,6 +330,11 @@ public:
     auto nestedFields() const & -> std::span<const StringId> override
     {
         return {flatFields_.cbegin(), flatFields_.cend()};
+    }
+
+    auto directFields() const & -> std::span<const StringId> override
+    {
+        return {directFields_.cbegin(), directFields_.cend()};
     }
 
     auto nestedEnumSymbols() const & -> std::span<const StringId> override
@@ -359,6 +376,7 @@ private:
 
     sfl::small_vector<FieldSummary, 4> fields_;
 
+    std::vector<StringId> directFields_;
     std::vector<StringId> flatFields_; // Ordered!
     std::vector<StringId> flatEnumSymbols_; // Ordered!
     std::uint64_t revision_ = 0;

--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -135,58 +135,71 @@ protected:
     }
 
     /**
-     * Append fields reachable through a schema id, using a finalized child
-     * cache when possible and falling back to raw graph traversal for cycles.
+     * Append reachable values through a schema id, using finalized child
+     * caches when possible and falling back to raw graph traversal for cycles.
+     */
+    template <class CachedValuesFn, class CollectValuesFn>
+    static auto appendSchemaValues(SchemaId schemaId,
+                                   const std::function<Schema*(SchemaId)>& queryFn,
+                                   SchemaIdStack& visited,
+                                   std::vector<StringId>& values,
+                                   CachedValuesFn&& cachedValues,
+                                   CollectValuesFn&& collectValues) -> void
+    {
+        if (schemaId == NoSchemaId || std::ranges::find(visited, schemaId) != visited.end())
+            return;
+
+        auto* schema = queryFn(schemaId);
+        if (!schema)
+            return;
+
+        visited.push_back(schemaId);
+
+        if (schema->finalize(queryFn) == State::Clean) {
+            auto childValues = std::invoke(cachedValues, *schema);
+            values.insert(values.end(), childValues.begin(), childValues.end());
+            return;
+        }
+
+        std::invoke(collectValues, *schema, queryFn, visited, values);
+    }
+
+    /**
+     * Append fields reachable through a schema id.
      */
     static auto appendSchemaFields(SchemaId schemaId,
                                    const std::function<Schema*(SchemaId)>& queryFn,
                                    SchemaIdStack& visited,
                                    std::vector<StringId>& fields) -> void
     {
-        if (schemaId == NoSchemaId || std::ranges::find(visited, schemaId) != visited.end())
-            return;
-
-        auto* schema = queryFn(schemaId);
-        if (!schema)
-            return;
-
-        visited.push_back(schemaId);
-
-        if (schema->finalize(queryFn) == State::Clean) {
-            auto childFields = schema->nestedFields();
-            fields.insert(fields.end(), childFields.begin(), childFields.end());
-            return;
-        }
-
-        schema->collectNestedFields(queryFn, visited, fields);
+        appendSchemaValues(
+            schemaId,
+            queryFn,
+            visited,
+            fields,
+            [](const Schema& schema) { return schema.nestedFields(); },
+            [](const Schema& schema, const auto& query, auto& visitedSchemas, auto& values) {
+                schema.collectNestedFields(query, visitedSchemas, values);
+            });
     }
 
     /**
-     * Append enum-like string symbols reachable through a schema id, using a
-     * finalized child cache when possible and falling back to raw graph
-     * traversal for cycles.
+     * Append enum-like string symbols reachable through a schema id.
      */
     static auto appendSchemaEnumSymbols(SchemaId schemaId,
                                         const std::function<Schema*(SchemaId)>& queryFn,
                                         SchemaIdStack& visited,
                                         std::vector<StringId>& symbols) -> void
     {
-        if (schemaId == NoSchemaId || std::ranges::find(visited, schemaId) != visited.end())
-            return;
-
-        auto* schema = queryFn(schemaId);
-        if (!schema)
-            return;
-
-        visited.push_back(schemaId);
-
-        if (schema->finalize(queryFn) == State::Clean) {
-            auto childSymbols = schema->nestedEnumSymbols();
-            symbols.insert(symbols.end(), childSymbols.begin(), childSymbols.end());
-            return;
-        }
-
-        schema->collectNestedEnumSymbols(queryFn, visited, symbols);
+        appendSchemaValues(
+            schemaId,
+            queryFn,
+            visited,
+            symbols,
+            [](const Schema& schema) { return schema.nestedEnumSymbols(); },
+            [](const Schema& schema, const auto& query, auto& visitedSchemas, auto& values) {
+                schema.collectNestedEnumSymbols(query, visitedSchemas, values);
+            });
     }
 
     /**
@@ -200,24 +213,29 @@ protected:
     }
 
     /**
-     * Shared finalization implementation for concrete schema classes.
+     * Shared finalization implementation for schemas that cache descendant
+     * fields and enum-like string symbols.
      */
-    template <class CollectFn>
-    static auto finalizeFields(State& state,
-                               std::vector<StringId>& flatFields,
-                               const std::function<Schema*(SchemaId)>& queryFn,
-                               CollectFn&& collect) -> State
+    static auto finalizeReachableMetadata(State& state,
+                                          std::vector<StringId>& flatFields,
+                                          std::vector<StringId>& flatEnumSymbols,
+                                          const std::function<Schema*(SchemaId)>& queryFn,
+                                          const Schema& schema) -> State
     {
         if (state == State::Clean || state == State::Finalizing)
             return state;
 
         state = State::Finalizing;
         flatFields.clear();
+        flatEnumSymbols.clear();
 
-        SchemaIdStack visited;
-        collect(queryFn, visited, flatFields);
-
+        SchemaIdStack visitedFields;
+        schema.collectNestedFields(queryFn, visitedFields, flatFields);
         sortUnique(flatFields);
+
+        SchemaIdStack visitedEnumSymbols;
+        schema.collectNestedEnumSymbols(queryFn, visitedEnumSymbols, flatEnumSymbols);
+        sortUnique(flatEnumSymbols);
 
         state = State::Clean;
         return State::Clean;
@@ -289,23 +307,7 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        if (state_ == State::Clean || state_ == State::Finalizing)
-            return state_;
-
-        state_ = State::Finalizing;
-        flatFields_.clear();
-        flatEnumSymbols_.clear();
-
-        SchemaIdStack visitedFields;
-        collectNestedFields(lookup, visitedFields, flatFields_);
-        sortUnique(flatFields_);
-
-        SchemaIdStack visitedEnumSymbols;
-        collectNestedEnumSymbols(lookup, visitedEnumSymbols, flatEnumSymbols_);
-        sortUnique(flatEnumSymbols_);
-
-        state_ = State::Clean;
-        return State::Clean;
+        return finalizeReachableMetadata(state_, flatFields_, flatEnumSymbols_, lookup, *this);
     }
 
     auto fields() const & -> std::span<const FieldSummary>
@@ -487,23 +489,7 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        if (state_ == State::Clean || state_ == State::Finalizing)
-            return state_;
-
-        state_ = State::Finalizing;
-        flatFields_.clear();
-        flatEnumSymbols_.clear();
-
-        SchemaIdStack visitedFields;
-        collectNestedFields(lookup, visitedFields, flatFields_);
-        sortUnique(flatFields_);
-
-        SchemaIdStack visitedEnumSymbols;
-        collectNestedEnumSymbols(lookup, visitedEnumSymbols, flatEnumSymbols_);
-        sortUnique(flatEnumSymbols_);
-
-        state_ = State::Clean;
-        return State::Clean;
+        return finalizeReachableMetadata(state_, flatFields_, flatEnumSymbols_, lookup, *this);
     }
 
     auto nestedFields() const & -> std::span<const StringId> override

--- a/include/simfil/model/schema.h
+++ b/include/simfil/model/schema.h
@@ -43,6 +43,7 @@ public:
     enum class Kind {
         Object,
         Array,
+        Value,
     };
 
     /** Finalization state */
@@ -66,6 +67,15 @@ public:
     virtual auto canHaveField(StringId fieldId) const -> bool = 0;
 
     /**
+     * Returns true if this schema or any of the schemas it refers to
+     * can possibly contain the given enum-like string symbol.
+     */
+    virtual auto canHaveEnumSymbol(StringId symbolId) const -> bool
+    {
+        return false;
+    }
+
+    /**
      * Finalize this schema and all schemas it refers to.
      */
     virtual auto finalize(const std::function<Schema*(SchemaId)>& queryFn) -> State
@@ -77,6 +87,14 @@ public:
      * @return All nested field names.
      */
     virtual auto nestedFields() const & -> std::span<const StringId> = 0;
+
+    /**
+     * @return All nested enum-like string symbols.
+     */
+    virtual auto nestedEnumSymbols() const & -> std::span<const StringId>
+    {
+        return {};
+    }
 
     /**
      * Return true once `canHaveField` is backed by finalized field caches.
@@ -107,6 +125,16 @@ protected:
                                      std::vector<StringId>& fields) const -> void = 0;
 
     /**
+     * Append all enum-like string symbols reachable from this schema without
+     * relying on cached finalization state.
+     */
+    virtual auto collectNestedEnumSymbols(const std::function<Schema*(SchemaId)>& queryFn,
+                                          SchemaIdStack& visited,
+                                          std::vector<StringId>& symbols) const -> void
+    {
+    }
+
+    /**
      * Append fields reachable through a schema id, using a finalized child
      * cache when possible and falling back to raw graph traversal for cycles.
      */
@@ -134,6 +162,44 @@ protected:
     }
 
     /**
+     * Append enum-like string symbols reachable through a schema id, using a
+     * finalized child cache when possible and falling back to raw graph
+     * traversal for cycles.
+     */
+    static auto appendSchemaEnumSymbols(SchemaId schemaId,
+                                        const std::function<Schema*(SchemaId)>& queryFn,
+                                        SchemaIdStack& visited,
+                                        std::vector<StringId>& symbols) -> void
+    {
+        if (schemaId == NoSchemaId || std::ranges::find(visited, schemaId) != visited.end())
+            return;
+
+        auto* schema = queryFn(schemaId);
+        if (!schema)
+            return;
+
+        visited.push_back(schemaId);
+
+        if (schema->finalize(queryFn) == State::Clean) {
+            auto childSymbols = schema->nestedEnumSymbols();
+            symbols.insert(symbols.end(), childSymbols.begin(), childSymbols.end());
+            return;
+        }
+
+        schema->collectNestedEnumSymbols(queryFn, visited, symbols);
+    }
+
+    /**
+     * Sort ids and remove duplicates.
+     */
+    static auto sortUnique(std::vector<StringId>& values) -> void
+    {
+        std::ranges::sort(values);
+        auto duplicates = std::ranges::unique(values);
+        values.erase(duplicates.begin(), duplicates.end());
+    }
+
+    /**
      * Shared finalization implementation for concrete schema classes.
      */
     template <class CollectFn>
@@ -151,9 +217,7 @@ protected:
         SchemaIdStack visited;
         collect(queryFn, visited, flatFields);
 
-        std::ranges::sort(flatFields);
-        auto duplicates = std::ranges::unique(flatFields);
-        flatFields.erase(duplicates.begin(), duplicates.end());
+        sortUnique(flatFields);
 
         state = State::Clean;
         return State::Clean;
@@ -201,6 +265,11 @@ public:
         return containsField(state_, flatFields_, field);
     }
 
+    auto canHaveEnumSymbol(StringId symbol) const -> bool override
+    {
+        return containsField(state_, flatEnumSymbols_, symbol);
+    }
+
     /**
      * Add a direct field and optional child schemas reachable through it.
      */
@@ -220,11 +289,23 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        return finalizeFields(state_, flatFields_, lookup, [this](const auto& queryFn,
-                                                                  auto& visited,
-                                                                  auto& fields) {
-            collectNestedFields(queryFn, visited, fields);
-        });
+        if (state_ == State::Clean || state_ == State::Finalizing)
+            return state_;
+
+        state_ = State::Finalizing;
+        flatFields_.clear();
+        flatEnumSymbols_.clear();
+
+        SchemaIdStack visitedFields;
+        collectNestedFields(lookup, visitedFields, flatFields_);
+        sortUnique(flatFields_);
+
+        SchemaIdStack visitedEnumSymbols;
+        collectNestedEnumSymbols(lookup, visitedEnumSymbols, flatEnumSymbols_);
+        sortUnique(flatEnumSymbols_);
+
+        state_ = State::Clean;
+        return State::Clean;
     }
 
     auto fields() const & -> std::span<const FieldSummary>
@@ -235,6 +316,11 @@ public:
     auto nestedFields() const & -> std::span<const StringId> override
     {
         return {flatFields_.cbegin(), flatFields_.cend()};
+    }
+
+    auto nestedEnumSymbols() const & -> std::span<const StringId> override
+    {
+        return {flatEnumSymbols_.cbegin(), flatEnumSymbols_.cend()};
     }
 
     auto finalized() const -> bool override
@@ -259,9 +345,104 @@ private:
         }
     }
 
+    auto collectNestedEnumSymbols(const std::function<Schema*(SchemaId)>& lookup,
+                                  SchemaIdStack& visited,
+                                  std::vector<StringId>& symbols) const -> void override
+    {
+        for (const auto& field : fields_) {
+            for (const auto& fieldSchemaId : field.schemas)
+                appendSchemaEnumSymbols(fieldSchemaId, lookup, visited, symbols);
+        }
+    }
+
     sfl::small_vector<FieldSummary, 4> fields_;
 
     std::vector<StringId> flatFields_; // Ordered!
+    std::vector<StringId> flatEnumSymbols_; // Ordered!
+    std::uint64_t revision_ = 0;
+    State state_ = State::Dirty;
+};
+
+/**
+ * Schema for scalar value nodes.
+ *
+ * Stores optional enum-like string symbols for schema-aware completion and
+ * parsing. Value schemas never contribute nested fields.
+ */
+class ValueSchema : public Schema
+{
+public:
+    auto kind() const -> Kind override
+    {
+        return Kind::Value;
+    }
+
+    auto canHaveField(StringId) const -> bool override
+    {
+        return false;
+    }
+
+    auto canHaveEnumSymbol(StringId symbol) const -> bool override
+    {
+        return containsField(state_, enumSymbols_, symbol);
+    }
+
+    /**
+     * Add an enum-like string symbol accepted by this value schema.
+     */
+    auto addEnumSymbol(StringId symbol) -> void
+    {
+        enumSymbols_.push_back(symbol);
+        state_ = State::Dirty;
+        ++revision_;
+    }
+
+    auto finalize(const std::function<Schema*(SchemaId)>&) -> State override
+    {
+        if (state_ == State::Clean || state_ == State::Finalizing)
+            return state_;
+
+        state_ = State::Finalizing;
+        sortUnique(enumSymbols_);
+        state_ = State::Clean;
+        return State::Clean;
+    }
+
+    auto nestedFields() const & -> std::span<const StringId> override
+    {
+        return {};
+    }
+
+    auto nestedEnumSymbols() const & -> std::span<const StringId> override
+    {
+        return {enumSymbols_.cbegin(), enumSymbols_.cend()};
+    }
+
+    auto finalized() const -> bool override
+    {
+        return state_ == State::Clean;
+    }
+
+    auto revision() const -> std::uint64_t override
+    {
+        return revision_;
+    }
+
+private:
+    auto collectNestedFields(const std::function<Schema*(SchemaId)>&,
+                             SchemaIdStack&,
+                             std::vector<StringId>&) const -> void override
+    {
+    }
+
+    auto collectNestedEnumSymbols(const std::function<Schema*(SchemaId)>&,
+                                  SchemaIdStack&,
+                                  std::vector<StringId>& symbols) const -> void override
+    {
+        symbols.insert(symbols.end(), enumSymbols_.begin(), enumSymbols_.end());
+    }
+
+    std::vector<StringId> enumSymbols_; // Ordered after finalize().
     std::uint64_t revision_ = 0;
     State state_ = State::Dirty;
 };
@@ -285,6 +466,11 @@ public:
         return containsField(state_, flatFields_, field);
     }
 
+    auto canHaveEnumSymbol(StringId symbol) const -> bool override
+    {
+        return containsField(state_, flatEnumSymbols_, symbol);
+    }
+
     /**
      * Add possible schemas for elements contained in the array.
      */
@@ -301,16 +487,33 @@ public:
      */
     auto finalize(const std::function<Schema*(SchemaId)>& lookup) -> State override
     {
-        return finalizeFields(state_, flatFields_, lookup, [this](const auto& queryFn,
-                                                                  auto& visited,
-                                                                  auto& fields) {
-            collectNestedFields(queryFn, visited, fields);
-        });
+        if (state_ == State::Clean || state_ == State::Finalizing)
+            return state_;
+
+        state_ = State::Finalizing;
+        flatFields_.clear();
+        flatEnumSymbols_.clear();
+
+        SchemaIdStack visitedFields;
+        collectNestedFields(lookup, visitedFields, flatFields_);
+        sortUnique(flatFields_);
+
+        SchemaIdStack visitedEnumSymbols;
+        collectNestedEnumSymbols(lookup, visitedEnumSymbols, flatEnumSymbols_);
+        sortUnique(flatEnumSymbols_);
+
+        state_ = State::Clean;
+        return State::Clean;
     }
 
     auto nestedFields() const & -> std::span<const StringId> override
     {
         return {flatFields_.cbegin(), flatFields_.cend()};
+    }
+
+    auto nestedEnumSymbols() const & -> std::span<const StringId> override
+    {
+        return {flatEnumSymbols_.cbegin(), flatEnumSymbols_.cend()};
     }
 
     auto finalized() const -> bool override
@@ -337,8 +540,17 @@ private:
             appendSchemaFields(schemaId, lookup, visited, fields);
     }
 
+    auto collectNestedEnumSymbols(const std::function<Schema*(SchemaId)>& lookup,
+                                  SchemaIdStack& visited,
+                                  std::vector<StringId>& symbols) const -> void override
+    {
+        for (const auto& schemaId : schemas_)
+            appendSchemaEnumSymbols(schemaId, lookup, visited, symbols);
+    }
+
     sfl::small_vector<SchemaId, 1> schemas_;
     std::vector<StringId> flatFields_; // Ordered!
+    std::vector<StringId> flatEnumSymbols_; // Ordered!
     std::uint64_t revision_ = 0;
     State state_ = State::Dirty;
 };

--- a/src/completion.cpp
+++ b/src/completion.cpp
@@ -1,6 +1,7 @@
 #include "completion.h"
 
 #include "expressions.h"
+#include "simfil/model/schema.h"
 #include "simfil/model/string-pool.h"
 #include "simfil/result.h"
 #include "simfil/simfil.h"
@@ -78,6 +79,125 @@ auto escapeKey(std::string_view str)
     return escaped;
 }
 
+/// Return whether a string can be represented as an unquoted SIMFIL symbol.
+auto isSymbolLiteralWord(std::string_view str)
+{
+    if (str.empty())
+        return false;
+
+    auto first = static_cast<unsigned char>(str.front());
+    if (!(std::isalpha(first) != 0 || str.front() == '_'))
+        return false;
+
+    auto uppercaseLetters = 0;
+    return std::ranges::all_of(str, [&uppercaseLetters](auto c) {
+        auto uc = static_cast<unsigned char>(c);
+        if (std::isupper(uc) != 0) {
+            ++uppercaseLetters;
+            return true;
+        }
+        return c == '_' || std::isdigit(uc) != 0;
+    }) && uppercaseLetters > 0;
+}
+
+/// Escape a string value as a SIMFIL string literal completion.
+auto escapeStringLiteral(std::string_view str)
+{
+    std::string escaped = "\"";
+    escaped.reserve(str.size() + 2);
+
+    for (auto c : str) {
+        if (c == '"' || c == '\\')
+            escaped.push_back('\\');
+        escaped.push_back(c);
+    }
+
+    escaped.push_back('"');
+    return escaped;
+}
+
+/// Return the text that should be inserted for an enum-like string symbol.
+auto enumSymbolCompletionText(std::string_view str)
+{
+    if (isSymbolLiteralWord(str))
+        return std::string{str};
+    return escapeStringLiteral(str);
+}
+
+/// Add one field completion candidate if it matches the current prefix.
+auto completeFieldName(
+    std::string_view key,
+    std::string_view prefix,
+    bool caseSensitive,
+    simfil::Completion& comp,
+    simfil::SourceLocation loc) -> simfil::Result
+{
+    if (comp.size() >= comp.limit)
+        return simfil::Result::Stop;
+
+    if (!startsWith(key, prefix, caseSensitive))
+        return simfil::Result::Continue;
+
+    if (needsEscaping(key))
+        comp.add(escapeKey(key), loc, simfil::CompletionCandidate::Type::FIELD);
+    else
+        comp.add(std::string{key}, loc, simfil::CompletionCandidate::Type::FIELD);
+
+    return simfil::Result::Continue;
+}
+
+/// Complete fields listed by the node schema but not necessarily present in the model.
+auto completeSchemaFields(
+    const simfil::Context& ctx,
+    const simfil::ModelNode& node,
+    std::string_view prefix,
+    simfil::Completion& comp,
+    simfil::SourceLocation loc) -> simfil::Result
+{
+    const auto* schema = ctx.env->querySchema(node.schema());
+    if (!schema)
+        return simfil::Result::Continue;
+
+    const auto caseSensitive = comp.options.smartCase && containsUppercaseCharacter(prefix);
+    for (auto fieldId : schema->directFields()) {
+        auto fieldName = ctx.env->strings()->resolve(fieldId);
+        if (!fieldName || fieldName->empty())
+            continue;
+
+        if (auto r = completeFieldName(*fieldName, prefix, caseSensitive, comp, loc); r != simfil::Result::Continue)
+            return r;
+    }
+
+    return simfil::Result::Continue;
+}
+
+/// Complete enum-like string symbols reachable from the node schema.
+auto completeSchemaEnumSymbols(
+    const simfil::Context& ctx,
+    const simfil::ModelNode& node,
+    std::string_view prefix,
+    simfil::Completion& comp,
+    simfil::SourceLocation loc) -> simfil::Result
+{
+    const auto* schema = ctx.env->querySchema(node.schema());
+    if (!schema)
+        return simfil::Result::Continue;
+
+    const auto caseSensitive = comp.options.smartCase && containsUppercaseCharacter(prefix);
+    for (auto symbolId : schema->nestedEnumSymbols()) {
+        if (comp.size() >= comp.limit)
+            return simfil::Result::Stop;
+
+        auto symbol = ctx.env->strings()->resolve(symbolId);
+        if (!symbol || symbol->empty() || !startsWith(*symbol, prefix, caseSensitive))
+            continue;
+
+        comp.add(enumSymbolCompletionText(*symbol), loc, simfil::CompletionCandidate::Type::CONSTANT);
+    }
+
+    return simfil::Result::Continue;
+}
+
 /// Complete a function name staritng with `prefix` at `loc`.
 auto completeFunctions(const simfil::Context& ctx, std::string_view prefix, simfil::Completion& comp, simfil::SourceLocation loc) -> simfil::Result
 {
@@ -94,7 +214,12 @@ auto completeFunctions(const simfil::Context& ctx, std::string_view prefix, simf
 }
 
 /// Complete a single WORD starting with `prefix` at `loc`.
-auto completeWords(const simfil::Context& ctx, std::string_view prefix, simfil::Completion& comp, simfil::SourceLocation loc) -> simfil::Result
+auto completeWords(
+    const simfil::Context& ctx,
+    std::string_view prefix,
+    simfil::Completion& comp,
+    simfil::SourceLocation loc,
+    const simfil::ModelNode* node = nullptr) -> simfil::Result
 {
     using simfil::Result;
 
@@ -115,6 +240,11 @@ auto completeWords(const simfil::Context& ctx, std::string_view prefix, simfil::
         if (isWORD && str.size() >= prefix.size() && startsWith(str, prefix, caseSensitive)) {
             comp.add(str, loc, simfil::CompletionCandidate::Type::CONSTANT);
         }
+    }
+
+    if (node) {
+        if (auto r = completeSchemaEnumSymbols(ctx, *node, prefix, comp, loc); r != Result::Continue)
+            return r;
     }
 
     return Result::Continue;
@@ -151,12 +281,8 @@ auto CompletionFieldOrWordExpr::ieval(Context ctx, const Value& val, const Resul
 
     const auto caseSensitive = comp_->options.smartCase && containsUppercaseCharacter(prefix_);
 
-    // First we try to complete fields
+    // First we try to complete fields already present in the model.
     for (StringId id : node->fieldNames()) {
-        if (comp_->size() >= comp_->limit) {
-            return Result::Stop;
-        }
-
         if (id == StringPool::Empty)
             continue;
 
@@ -165,18 +291,16 @@ auto CompletionFieldOrWordExpr::ieval(Context ctx, const Value& val, const Resul
             continue;
         const auto& key = *keyPtr;
 
-        if (startsWith(key, prefix_, caseSensitive)) {
-            if (needsEscaping(key)) {
-                comp_->add(escapeKey(key), sourceLocation(), CompletionCandidate::Type::FIELD);
-            } else {
-                comp_->add(std::string{key}, sourceLocation(), CompletionCandidate::Type::FIELD);
-            }
-        }
+        if (auto r = completeFieldName(key, prefix_, caseSensitive, *comp_, sourceLocation()); r != Result::Continue)
+            return r;
     }
+
+    if (auto r = completeSchemaFields(ctx, *node, prefix_, *comp_, sourceLocation()); r != Result::Continue)
+        return r;
 
     // If not in a path, we try to complete words and functions
     if (!inPath_) {
-        if (auto r = completeWords(ctx, prefix_, *comp_, sourceLocation()); r != Result::Continue)
+        if (auto r = completeWords(ctx, prefix_, *comp_, sourceLocation(), node); r != Result::Continue)
             return r;
 
         if (auto r = completeFunctions(ctx, prefix_, *comp_, sourceLocation()); r != Result::Continue)
@@ -356,7 +480,8 @@ auto CompletionWordExpr::ieval(Context ctx, const Value& val, const ResultFn& re
     if (ctx.phase == Context::Phase::Compilation)
         return res(ctx, Value::undef());
 
-    if (auto r = completeWords(ctx, prefix_, *comp_, sourceLocation()); r != Result::Continue)
+    auto node = val.node();
+    if (auto r = completeWords(ctx, prefix_, *comp_, sourceLocation(), node); r != Result::Continue)
         return r;
 
     return res(ctx, Value::undef());

--- a/test/completion.cpp
+++ b/test/completion.cpp
@@ -1,10 +1,12 @@
 #include "src/completion.h"
 #include <algorithm>
+#include <map>
 #include <string_view>
 #include <optional>
 
 #include "common.hpp"
 #include "simfil/environment.h"
+#include "simfil/model/schema.h"
 #include "src/expected.h"
 
 const auto model = R"json(
@@ -50,6 +52,67 @@ auto EXPECT_COMPLETION(std::string_view query, std::optional<size_t> point, std:
     if (count > 0) {
         REQUIRE(comp.size() == count);
     }
+}
+
+auto CompleteSchemaQuery(std::string_view query, std::optional<size_t> point = {})
+{
+    auto parsed = simfil::json::parse(R"json({"present": 1})json");
+    REQUIRE(parsed);
+
+    auto model = std::move(*parsed);
+    auto strings = model->strings();
+    auto schemaOnlyField = strings->emplace("schemaOnlyField").value();
+    auto specialField = strings->emplace("schema field").value();
+    auto enumCarrier = strings->emplace("Carrier").value();
+    auto enumFast = strings->emplace("FAST_MODE").value();
+
+    auto valueSchema = std::make_unique<ValueSchema>();
+    valueSchema->addEnumSymbol(enumCarrier);
+    valueSchema->addEnumSymbol(enumFast);
+
+    auto objectSchema = std::make_unique<ObjectSchema>();
+    objectSchema->addField(schemaOnlyField, {SchemaId{2}});
+    objectSchema->addField(specialField);
+
+    auto registry = std::make_shared<std::map<SchemaId, std::unique_ptr<Schema>>>();
+    (*registry)[SchemaId{1}] = std::move(objectSchema);
+    (*registry)[SchemaId{2}] = std::move(valueSchema);
+
+    auto lookup = [registry](SchemaId schemaId) -> Schema* {
+        if (auto it = registry->find(schemaId); it != registry->end())
+            return it->second.get();
+        return nullptr;
+    };
+    for (auto const& [_, schema] : *registry)
+        schema->finalize(lookup);
+
+    auto root = model->root(0);
+    REQUIRE(root);
+    auto rootObj = model->resolve<Object>(**root);
+    REQUIRE(rootObj);
+    REQUIRE(rootObj->setSchema(SchemaId{1}));
+
+    Environment env(strings);
+    env.querySchemaCallback = [registry](SchemaId schemaId) -> const Schema* {
+        if (auto it = registry->find(schemaId); it != registry->end())
+            return it->second.get();
+        return nullptr;
+    };
+
+    CompletionOptions opts;
+    opts.showWildcardHints = false;
+    return complete(env, query, point.value_or(query.size()), **root, opts).value();
+}
+
+auto EXPECT_SCHEMA_COMPLETION(std::string_view query, std::string_view what, Type type)
+{
+    auto found = false;
+    for (const auto& item : CompleteSchemaQuery(query)) {
+        INFO("  Item: " << item.text);
+        if (item.text == what && item.type == type)
+            found = true;
+    }
+    REQUIRE(found);
 }
 
 TEST_CASE("CompleteField", "[completion.field.incompleteQuery]") {
@@ -153,4 +216,14 @@ TEST_CASE("Sort Completion", "[completion.sorted]") {
     REQUIRE(std::is_sorted(comp.begin(), comp.end(), [](const auto& l, const auto& r) {
         return l.text < r.text;
     }));
+}
+
+TEST_CASE("Complete schema fields", "[completion.schema-field]") {
+    EXPECT_SCHEMA_COMPLETION("schema", "schemaOnlyField", Type::FIELD);
+    EXPECT_SCHEMA_COMPLETION("schema", "[\"schema field\"]", Type::FIELD);
+}
+
+TEST_CASE("Complete schema enum symbols", "[completion.schema-enum]") {
+    EXPECT_SCHEMA_COMPLETION("Car", "\"Carrier\"", Type::CONSTANT);
+    EXPECT_SCHEMA_COMPLETION("FAST", "FAST_MODE", Type::CONSTANT);
 }

--- a/test/schema.cpp
+++ b/test/schema.cpp
@@ -131,6 +131,9 @@ TEST_CASE("Object schema finalization", "[model.schema]") {
     const auto link = strings->emplace("link").value();
     const auto back = strings->emplace("back").value();
     const auto missing = strings->emplace("missing").value();
+    const auto enumA = strings->emplace("ENUM_A").value();
+    const auto enumB = strings->emplace("ENUM_B").value();
+    const auto missingEnum = strings->emplace("MISSING_ENUM").value();
 
     SECTION("dirty schemas are conservative") {
         ObjectSchema schema;
@@ -213,6 +216,56 @@ TEST_CASE("Object schema finalization", "[model.schema]") {
         REQUIRE(arraySchema.canHaveField(a));
         REQUIRE(arraySchema.canHaveField(b));
         REQUIRE_FALSE(arraySchema.canHaveField(c));
+    }
+
+    SECTION("value schemas finalize enum symbols") {
+        ValueSchema schema;
+        schema.addEnumSymbol(enumB);
+        schema.addEnumSymbol(enumA);
+        schema.addEnumSymbol(enumA);
+
+        // Dirty value schemas are conservative until finalized.
+        REQUIRE(schema.canHaveEnumSymbol(missingEnum));
+
+        schema.finalize([](SchemaId) { return nullptr; });
+        REQUIRE(schema.canHaveEnumSymbol(enumA));
+        REQUIRE(schema.canHaveEnumSymbol(enumB));
+        REQUIRE_FALSE(schema.canHaveEnumSymbol(missingEnum));
+        REQUIRE(schema.nestedEnumSymbols().size() == 2);
+    }
+
+    SECTION("object and array schemas collect reachable enum symbols") {
+        ObjectSchema objectSchema;
+        objectSchema.addField(a, {SchemaId{1}});
+
+        ArraySchema arraySchema;
+        arraySchema.addElementSchemas({SchemaId{2}});
+
+        ValueSchema enumSchema;
+        enumSchema.addEnumSymbol(enumA);
+        enumSchema.addEnumSymbol(enumB);
+
+        auto lookup = [&](SchemaId schemaId) -> Schema* {
+            switch (schemaId) {
+            case SchemaId{1}:
+                return &enumSchema;
+            case SchemaId{2}:
+                return &objectSchema;
+            default:
+                return nullptr;
+            }
+        };
+
+        objectSchema.finalize(lookup);
+        arraySchema.finalize(lookup);
+
+        REQUIRE(objectSchema.canHaveEnumSymbol(enumA));
+        REQUIRE(objectSchema.canHaveEnumSymbol(enumB));
+        REQUIRE_FALSE(objectSchema.canHaveEnumSymbol(missingEnum));
+
+        REQUIRE(arraySchema.canHaveEnumSymbol(enumA));
+        REQUIRE(arraySchema.canHaveEnumSymbol(enumB));
+        REQUIRE_FALSE(arraySchema.canHaveEnumSymbol(missingEnum));
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Schema::Kind::Value` and `ValueSchema` for scalar schema branches
- add enum-symbol membership and nested-symbol collection APIs
- propagate enum symbols through object and array schema finalization

## Tests
- `cmake --build build-enum -j$(nproc)`
- `ctest --test-dir build-enum --output-on-failure`